### PR TITLE
YAML STRUCTURED AUTHOR SUPPORT IN HTML

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -82,10 +82,10 @@ $for(author)$
 $if(author.name)$
 <h4 class="author"><em>$author.name$</em></h4>
 $if(author.affiliation)$
-<address>
+<address class="author_afil">
 $author.affiliation$<br>$endif$
 $if(author.email)$
-<a href="mailto:#">$author.email$</a>
+<a class="author_email" href="mailto:#">$author.email$</a>
 </address>
 $endif$
 $else$


### PR DESCRIPTION
added support within the default HTML template for structured author
details (author.name, author.affiliation, author.email) in the YAML
metadata block. Idea was to match the example YAML metadata block on [pandoc
website](http://johnmacfarlane.net/pandoc//demo/example19/YAML-metadata-block.html).
