### PR TITLE
Added support for user-level pandoc-citeproc calls

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -426,7 +426,9 @@ pandoc <- function() {
 # get the path to the pandoc-citeproc binary
 pandoc_citeproc <- function() {
   find_pandoc()
-  file.path(.pandoc$dir, "pandoc-citeproc")
+  citeproc_path = file.path(.pandoc$dir, "pandoc-citeproc")
+
+  if (file.exists(citeproc_path)) citeproc_path else "pandoc-citeproc"
 }
 
 # quote args if they need it


### PR DESCRIPTION
Currently, if pandoc-citeproc is installed in a different location than pandoc (e.g. installed via cabal), the incorrect path will be used.

Although the absolute path could be found in a similar manner to pandoc, this is probably sufficient in most cases.
