### PR TITLE
Check for critical environment variables.

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -427,6 +427,14 @@ with_pandoc_safe_environment <- function(code) {
     Sys.unsetenv("LC_ALL")
     on.exit(Sys.setenv(LC_ALL = lc_all), add = TRUE)
   }
+  if (Sys.info()['sysname'] == "Linux" &&
+        is.na(Sys.getenv("HOME", unset = NA))) {
+    stop("The 'HOME' environment variable must be set before running Pandoc.")
+  }
+  if (Sys.info()['sysname'] == "Linux" &&
+        is.na(Sys.getenv("LANG", unset = NA))) {
+    stop("The 'LANG' environment variable must be set before running Pandoc.")
+  }
   force(code)
 }
 


### PR DESCRIPTION
Ensure that LANG and HOME are both set before running Pandoc, as their
absence can cause fatal errors as discussed in #31.

I was torn about whether we should fail or take a stab at setting a default LANG. To me, this behavior is the most reasonable.
