### PR TITLE
Run highlight.js even when injected after load

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -34,6 +34,13 @@ $if(highlightjs)$
     background-color: white;
   }
 </style>
+<script type="text/javascript">
+if (window.hljs && document.readyState && document.readyState === "complete") {
+   window.setTimeout(function() {
+      hljs.initHighlighting();
+   }, 0);
+}
+</script>
 $endif$
 
 $if(highlighting-css)$


### PR DESCRIPTION
`highlight.js` highlights when the document load is complete, but in the Shiny document case the document's already loaded when the reactive doc's content is inserted into the DOM, so the load event doesn't fire. 

The fix is to check to see whether `highlight.js` is being injected when the document's initial load is already complete. When it is, we initialize highlighting immediately after control returns to script (after the code blocks below have been added to the DOM).  
