### PR TITLE
Use container-fluid for HTML documents

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -65,7 +65,7 @@ $endfor$
 <body>
 
 $if(theme)$
-<div class="container">
+<div class="container-fluid">
 $endif$
 
 $for(include-before)$


### PR DESCRIPTION
Without this, as the browser is resized, the content width changes
as a step function instead of continuously.
