### PR TITLE
Add simple caching for static docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Suggests:
     shiny (>= 0.9.1),
     caTools,
     httpuv (>= 1.2.2),
-    testthat
+    testthat,
+    digest
 SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc
 URL: http://rmarkdown.rstudio.com
 License: GPL-3


### PR DESCRIPTION
This change improves performance in the case where `rmarkdown::run` is viewing a folder that contains a mix of Shiny docs and non-Shiny docs. It adds a system-level cache for rendered non-Shiny docs, which persists across R sessions and allows these documents to be served immediately.
