### PR TITLE
associate cache dir with the output format as well

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -198,7 +198,7 @@ render <- function(input,
     # use filename based figure and cache directories
     figures_dir <- paste(files_dir, "/figure-", pandoc_to, "/", sep = "")
     knitr::opts_chunk$set(fig.path=figures_dir)
-    cache_dir <- paste(knitr_cache_dir(input), '-', pandoc_to, "/", sep="")
+    cache_dir <-knitr_cache_dir(input, pandoc_to)
     knitr::opts_chunk$set(cache.path=cache_dir)
 
     # merge user options and hooks

--- a/R/util.R
+++ b/R/util.R
@@ -92,8 +92,8 @@ knitr_files_dir <- function(file) {
   paste(tools::file_path_sans_ext(file), "_files", sep = "")
 }
 
-knitr_cache_dir <- function(file) {
-  paste(tools::file_path_sans_ext(file), "_cache", sep = "")
+knitr_cache_dir <- function(file, pandoc_to) {
+  paste(tools::file_path_sans_ext(file), "_cache/", pandoc_to, "/", sep = "")
 }
 
 


### PR DESCRIPTION
I think the cache dir should be associated with a specific output format just like the figure dir, otherwise the cache can be frequently invalidated when switching between different output formats because each output format has its own set of chunk options.

I put `output_format$pandoc$to` in `pandoc_to` since there are multiple instances of it. If you do not like it, I can remove it and make this PR a one-liner change.
