### PR TITLE
Use absolute history reference instead of relative.

### DIFF
--- a/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
+++ b/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
@@ -702,11 +702,13 @@ SlideDeck.prototype.makeBuildLists_ = function () {
 SlideDeck.prototype.updateHash_ = function(dontPush) {
   if (!dontPush) {
     var slideNo = this.curSlide_ + 1;
+    // Add everything except the hash.
+    var loc = location.protocol+'//'+location.host+location.pathname+(location.search?location.search:"");
     var hash = '#' + slideNo;
     if (window.history.pushState) {
-      window.history.pushState(this.curSlide_, 'Slide ' + slideNo, hash);
+      window.history.pushState(this.curSlide_, 'Slide ' + slideNo, loc + hash);
     } else {
-      window.location.replace(hash);
+      window.location.replace(loc + hash);
     }
 
     // Record GA hit on this slide.


### PR DESCRIPTION
This is needed due to SSP's setting of a <base href> which was being used when ioslides went to use history.pushState(). This commit uses absolute URLs to ensure that the user-visible URL is not altered by the injected worker ID.
