### PR TITLE
ioslides: special key capture handling for selectize

### DIFF
--- a/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
+++ b/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
@@ -172,10 +172,10 @@ SlideDeck.prototype.onBodyKeyDown_ = function(e) {
   // when just the select control is showing -- for selectize we refrain from
   // handling keys only when the text input is active or when the up or down
   // arrow key is pressed (which is used to open the list from the keyboard)
-  var parentClassList = e.target.parentNode.classList;
-  if (parentClassList.contains('selectize-input')) {
-    if (parentClassList.contains('input-active') ||  // text input is active
-       (e.keyCode == 38) || (e.keyCode == 40))       // up or down arrow
+  var parentNode = e.target.parentNode || e.target; // handle no parent
+  if (parentNode.classList.contains('selectize-input')) {
+    if (parentNode.classList.contains('input-active') ||  // text input is active
+       (e.keyCode == 38) || (e.keyCode == 40))            // up or down arrow
       return;
   } else if (/^(input|textarea)$/i.test(e.target.nodeName) ||
       e.target.isContentEditable) {


### PR DESCRIPTION
ioslides already has code to not handle keys if an input or text area is active. However, selectize inputs require special handling because they retain focus within an offscreen textbox even when just the select control is showing.  For selectize we refrain from handling keys only when the text input is active or when the up or down arrow key is pressed (which is used to open the list from the keyboard)
