### PR TITLE
vectorize pandoc_path_arg(), not assuming path is a scalar

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -251,14 +251,13 @@ pandoc_path_arg <- function(path) {
   path <- path.expand(path)
 
   # remove redundant ./ prefix if present
-  if (identical(substring(path, 1, 2), "./")) {
-    path <- substring(path, 3, nchar(path))
-  }
+  path <- sub('^[.]/', '', path)
 
   if (is_windows()) {
-    if (grepl(' ', path, fixed=TRUE))
-      path <- utils::shortPathName(path)
-    path <- gsub("/", "\\\\", path)
+    i <- grep(' ', path)
+    if (length(i))
+      path[i] <- utils::shortPathName(path[i])
+    path <- gsub('/', '\\\\', path)
   }
 
   path


### PR DESCRIPTION
this fixes the warning under Windows reported by http://rmarkdown.rstudio.com/#comment-1447899447

I'm not entirely sure if you expect `pandoc_path_arg()` to accept scalars only. If that is the case, I guess we have a deeper problem, because `path` here can be a vector of length > 1.
