### PR TITLE
fix #180: support cached ioslides presentations on Shiny Server

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -184,7 +184,7 @@ rmarkdown_shiny_server <- function(dir, encoding, auto_reload, render_args) {
                                output_file = output_dest,
                                output_dir = dirname(output_dest),
                                output_options = output_opts,
-                               intermediates_dir = tempdir(),
+                               intermediates_dir = dirname(output_dest),
                                runtime = "shiny"),
                           render_args)
       result_path <- shiny::maskReactiveContext(do.call(render, args))
@@ -290,7 +290,7 @@ rmd_cached_output <- function (input, encoding) {
     cacheable <- TRUE
     output_key <- digest::digest(paste(input, file.info(input)[4]),
                                  algo = "md5", serialize = FALSE)
-    output_dest <- paste(file.path(dirname(tempdir()), "rmarkdown",
+    output_dest <- paste(file.path(dirname(tempdir()), "rmarkdown", output_key,
                                    paste("rmd", output_key, sep = "_")),
                          "html", sep = ".")
 


### PR DESCRIPTION
This change fixes a bug that exists when rendering static IOSlides presentations via `rmarkdown::run`. 

The problem is that the `ioslides_presentation.lua` script is expected to be in the same directory as the destination file. This is the case when rendering uncached documents (`runtime = shiny`), but not the case when rendering cacheable documents: in that case the destination file is in `/tmp/rmarkdown`, but the intermediates are in `/tmp/[R session temp]`. 

The fix:
1. Use another directory level in the cache--so instead of putting all cached docs in `/tmp/rmarkdown`, put them in `/tmp/rmarkdown/[cache key].`"
2. Use the document's destination folder as its intermediates directory. This will still be `tempdir()` for uncacheable (Shiny) content, but for cached content the intermediates directory will now be alongside the destination file.
