### PR TITLE
Export the current output format to knitr

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -192,6 +192,7 @@ render <- function(input,
     knitr::opts_knit$set(rmarkdown.pandoc.to = pandoc_to)
     knitr::opts_knit$set(rmarkdown.keep_md = output_format$keep_md)
     knitr::opts_knit$set(rmarkdown.version = 2)
+    knitr::opts_knit$set(rmarkdown.output = output_format)
 
     # trim whitespace from around source code
     if (packageVersion("knitr") < "1.5.23") {


### PR DESCRIPTION
This will allow for the knitr blocks to know the name of the output block.  This information can be used to adjust settings for different types of output.  An example of such a setting is the fig.align which currently does not produce figures in pdf documents if it is set.  Though the `rmarkdown.pandoc.to` field contains some information concerning this it is degenerate since multiple types of html documents will simply say 'html'.  By knowing the actual output format name (which includes extensions to the current rmarkdown package) the end user has some more flexibility.