### PR TITLE
Write relative path to MathJax when mathjax = "local"

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -78,7 +78,8 @@ html_document_base <- function(smart = TRUE,
     args <- c(args, pandoc_mathjax_args(mathjax,
                                         template,
                                         self_contained,
-                                        lib_dir))
+                                        lib_dir,
+                                        output_dir))
 
     # The input file is converted to UTF-8 from its native encoding prior
     # to calling the preprocessor (see ::render)

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -345,7 +345,8 @@ validate_self_contained <- function(mathjax) {
 pandoc_mathjax_args <- function(mathjax,
                                 template,
                                 self_contained,
-                                files_dir) {
+                                files_dir,
+                                output_dir) {
   args <- c()
 
   if (!is.null(mathjax)) {
@@ -361,7 +362,8 @@ pandoc_mathjax_args <- function(mathjax,
       mathjax_path <- render_supporting_files(mathjax_path,
                                               files_dir,
                                               "mathjax-2.3.0")
-      mathjax <- paste(mathjax_path, "/", mathjax_config(), sep = "")
+      mathjax <- paste(relative_to(output_dir, mathjax_path), "/",
+                       mathjax_config(), sep = "")
     }
 
     if (identical(template, "default")) {


### PR DESCRIPTION
The `mathjax = local` argument currently writes an absolute path into the document. This change makes that path relative, so the document can be relocated, and/or served over HTTP successfully. 

This change, in combination with https://github.com/rstudio/rstudio/commit/33cc1d0e4cf487591ba54905f08a43e15f3b266e, serves the local (patched) version of Mathjax inside Shiny documents, so math content can be rendered without timeouts on Qt platforms. 
