### PR TITLE
Append extra_dependencies after all other dependencies

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -77,7 +77,6 @@ html_document_base <- function(smart = TRUE,
     # resolve and inject extras, including dependencies specified by the format
     # and dependencies specified by the user (via extra_dependencies)
     format_deps <- list()
-    format_deps <- append(format_deps, extra_dependencies)
     if (!is.null(theme)) {
       format_deps <- append(format_deps, list(html_dependency_jquery(),
                                               html_dependency_bootstrap(theme)))
@@ -87,6 +86,7 @@ html_document_base <- function(smart = TRUE,
       format_deps <- append(format_deps,
                             list(html_dependency_bootstrap("bootstrap")))
     }
+    format_deps <- append(format_deps, extra_dependencies)
 
     extras <- html_extras_for_document(knit_meta, runtime, dependency_resolver,
                                        format_deps)


### PR DESCRIPTION
Doing this allows extra_dependencies to be loaded last, this is
beneficial if a dependency depends on jquery for instance.

This also allows you to load both bootstrap 3 and bootstrap 2 in the same document.