### PR TITLE
use parent.frame() as the default environment for knitting shiny documents

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -83,6 +83,8 @@ run <- function(file = "index.Rmd", dir = dirname(file), auto_reload = TRUE,
       "UTF-8"
     else
       render_args$encoding
+  # default environmnet to compile Rmd
+  if (is.null(render_args$envir)) render_args$envir <- parent.frame()
 
   onStart <- function() {
     global_r <- file.path.ci(dir, "global.R")


### PR DESCRIPTION
otherwise the parent.frame() when knit() is really called is an environment inside rmarkdown_shiny_server(), which does not make much sense
