### PR TITLE
move dependencies to a temporary folder on Windows (fixes #228)

### DIFF
--- a/R/html_extras.R
+++ b/R/html_extras.R
@@ -25,7 +25,12 @@ pandoc_html_extras_args <- function(extras, self_contained, lib_dir,
   # dependencies
   dependencies <- extras$dependencies
   if (length(dependencies) > 0) {
-    if (self_contained)
+    # On Windows, pandoc (after 1.13) doesn't parse paths of the form 
+    # D:\foo\bar when fetching content to build self-contained documents, so
+    # this content must be copied to the temporary lib_dir in order to 
+    # guarantee that it can be represented in the document with a relative
+    # path. 
+    if (self_contained && !is_windows()) 
       file <- as_tmpfile(html_dependencies_as_string(dependencies, NULL, NULL))
     else
       file <- as_tmpfile(html_dependencies_as_string(dependencies, lib_dir,

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -86,7 +86,7 @@ ioslides_presentation <- function(logo = NULL,
 
     # ioslides
     ioslides_path <- rmarkdown_system_file("rmd/ioslides/ioslides-13.5.1")
-    if (!self_contained)
+    if (!self_contained || is_windows())
       ioslides_path <- relative_to(output_dir,
         render_supporting_files(ioslides_path, lib_dir))
     else

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -403,7 +403,7 @@ pandoc_html_highlight_args <- function(highlight,
     highlight <- match.arg(highlight, html_highlighters())
     if (highlight %in% c("default", "textmate")) {
       highlight_path <- rmarkdown_system_file("rmd/h/highlight")
-      if (self_contained)
+      if (self_contained && !is_windows())
         highlight_path <- pandoc_path_arg(highlight_path)
       else
         highlight_path <- relative_to(output_dir,

--- a/R/revealjs_presentation.R
+++ b/R/revealjs_presentation.R
@@ -138,7 +138,7 @@ revealjs_presentation <- function(incremental = FALSE,
 
     # reveal.js
     revealjs_path <- rmarkdown_system_file("rmd/revealjs/reveal.js-2.6.1")
-    if (!self_contained)
+    if (!self_contained || is_windows())
       revealjs_path <- relative_to(
         output_dir, render_supporting_files(revealjs_path, lib_dir))
     args <- c(args, "--variable", paste("revealjs-url=",

--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -104,7 +104,7 @@ slidy_presentation <- function(incremental = FALSE,
 
     # slidy
     slidy_path <- rmarkdown_system_file("rmd/slidy/Slidy2")
-    if (!self_contained)
+    if (!self_contained || is_windows())
       slidy_path <- relative_to(
         output_dir, render_supporting_files(slidy_path, lib_dir))
     args <- c(args, "--variable", paste("slidy-url=",


### PR DESCRIPTION
When building a self-contained document, Pandoc fetches the content of HTML dependencies so that they may be inlined; that is, `<script src="foo.js">` is replaced with `<script src="data:...">`.

In pandoc 1.13 and later, Windows absolute paths beginning with a volume name are no longer supported when fetching content; that is, `<script src="\Users\bob\foo.js">` is permissible but `<script src="C:\Users\bob\foo.js">` is not.

Because it's possible for a document to reference dependencies from multiple volumes and there's no format the Pandoc dependency inliner accepts on Windows (as far as I can tell) for a path to another volume, this change works around the problem by making a temporary copy of the dependencies on Windows, so that the path can be relative. It's effectively what's already done when rendering a non self-contained document, but cleaned up with other intermediates when self-contained.
