### PR TITLE
quote paths that contain spaces or >

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -545,8 +545,11 @@ pandoc_citeproc <- function() {
 
 # quote args if they need it
 quoted <- function(args) {
-  spaces <- grepl('[ >]', args)
-  args[spaces] <- shQuote(args[spaces])
+  # some characters are legal in filenames but without quoting are likely to be
+  # interpreted by the shell (e.g. redirection, wildcard expansion, etc.) --
+  # wrap arguments containing these characters in quotes. 
+  shell_chars <- grepl(.shell_chars_regex, args)
+  args[shell_chars] <- shQuote(args[shell_chars])
   args
 }
 

--- a/R/render.R
+++ b/R/render.R
@@ -78,19 +78,20 @@ render <- function(input,
       file.path(intermediates_dir, file)
   }
 
-  # if the input file has spaces in it's name then make a copy
-  # that doesn't have spaces
-  if (grepl(' ', basename(input), fixed=TRUE)) {
-    input_no_spaces <- intermediates_loc(
-        file_name_without_spaces(basename(input)))
-    if (file.exists(input_no_spaces)) {
-      stop("The name of the input file cannot contain spaces (attempted to ",
-           "copy to a version without spaces '", input_no_spaces, "' ",
+  # if the input file has shell characters in its name then make a copy that
+  # doesn't have shell characters
+  if (grepl(.shell_chars_regex, basename(input))) {
+    input_no_shell_chars <- intermediates_loc(
+        file_name_without_shell_chars(basename(input)))
+    if (file.exists(input_no_shell_chars)) {
+      stop("The name of the input file cannot contain the special shell ",
+           "characters: ", .shell_chars_regex, " (attempted to copy to a ", 
+           "version without those characters '", input_no_shell_chars, "' ",
            "however that file already exists)", call. = FALSE)
     }
-    file.copy(input, input_no_spaces, overwrite = TRUE)
-    intermediates <- c(intermediates, input_no_spaces)
-    input <- input_no_spaces
+    file.copy(input, input_no_shell_chars, overwrite = TRUE)
+    intermediates <- c(intermediates, input_no_shell_chars)
+    input <- input_no_shell_chars
   }
 
   # execute within the input file's directory

--- a/R/util.R
+++ b/R/util.R
@@ -58,8 +58,8 @@ read_lines_utf8 <- function(file, encoding) {
     lines
 }
 
-file_name_without_spaces <- function(file) {
-  name <- gsub(' ', '_', basename(file), fixed = TRUE)
+file_name_without_shell_chars <- function(file) {
+  name <- gsub(.shell_chars_regex, '_', basename(file))
   dir <- dirname(file)
   if (nzchar(dir) && !identical(dir, "."))
     file.path(dir, name)
@@ -190,3 +190,8 @@ base_dir <- function(x) {
 
   base
 }
+
+# Regular expression representing characters likely to be considered special by
+# the shell (require quoting/escaping)
+.shell_chars_regex <- '[ <>()|\\:&;#?*]'
+


### PR DESCRIPTION
This change causes us to quote pandoc arguments that contains either a space or > character (rather than just quoting arguments with spaces). Note that the reason we don't quote every argument is so that the pandoc command is more readable within the R Markdown output window.
