### PR TITLE
Respect the user's cache.path settings if present

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -215,8 +215,10 @@ render <- function(input,
     # use filename based figure and cache directories
     figures_dir <- paste(files_dir, "/figure-", pandoc_to, "/", sep = "")
     knitr::opts_chunk$set(fig.path=figures_dir)
-    cache_dir <-knitr_cache_dir(input, pandoc_to)
-    knitr::opts_chunk$set(cache.path=cache_dir)
+    if (is.null(knitr::opts_chunk$get('cache.path'))) {
+      knitr::opts_chunk$set(cache.path=knitr_cache_dir(input, pandoc_to))
+    }
+    cache_dir <- knitr::opts_chunk$get('cache.path')
 
     # merge user options and hooks
     if (!is.null(output_format$knitr)) {


### PR DESCRIPTION
This pull request changes the implementation of `render()` to check if a user has already configured the `cache.path` used by knitr. In case the user has done so, the value is left as it is. In other words, `knitr_cache_dir(...)` is not called.

I changed the implementation to make `rmarkdown` more suitable for batch processing. One of my requirements is to have a central cache directory that I can automatically clean up regularly to ensure it does not grow past a certain size. With cache directories all over the filesystem, this task is significantly more complicated.

I hope you accept the pull request as it does not change the behavior of `rmarkdown` but merely makes it aware of a user-defined settings.