### PR TITLE
Only remove /websocket/ from path if it's present

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -127,7 +127,11 @@ run <- function(file = "index.Rmd", dir = dirname(file), auto_reload = TRUE,
 rmarkdown_shiny_server <- function(dir, encoding, auto_reload, render_args) {
   function(input, output, session) {
     path_info <- utils::URLdecode(session$request$PATH_INFO)
-    path_info <- substr(path_info, 1, nchar(path_info) - 11)
+    # strip /websocket/ from the end of the request path if present
+    if (identical(substr(path_info, nchar(path_info) - 10, nchar(path_info)),
+                  "/websocket/")) {
+      path_info <- substr(path_info, 1, nchar(path_info) - 11)
+    }
     if (!nzchar(path_info)) {
       path_info <- "index.Rmd"
     }


### PR DESCRIPTION
Today, when rmarkdown is serving a directory of Shiny content, it presumes that request URI will end with `/websocket/`. This is in fact the case in Shiny Server and Shiny run locally, but it is by no means guaranteed. This change allows us to use raw (i.e. `/websocket/`-free) request URIs if they're given from the server.

(This came up when debugging an issue on a server that wasn't using websocket URLs, and isn't urgent.)
