### PR TITLE
Fixes #257: use regex to detect : at the end instead of substring(nchar())

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -495,7 +495,7 @@ parse_yaml_front_matter <- function(input_lines) {
 
 validate_front_matter <- function(front_matter) {
   front_matter <- trim_trailing_ws(front_matter)
-  if (identical(substring(front_matter, nchar(front_matter)), ":"))
+  if (grepl(":$", front_matter))
     stop("Invalid YAML front matter (ends with ':')", call. = FALSE)
 }
 


### PR DESCRIPTION
When YAML contains multibyte chars, nchar() does not work if `front_matter`'s encoding is unknown
