### PR TITLE
Protocol relative URL for MathJax

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -242,7 +242,7 @@ html_highlighters <- function() {
 }
 
 default_mathjax <- function() {
-  paste("https://cdn.mathjax.org/mathjax/latest/",
+  paste("//cdn.mathjax.org/mathjax/latest/",
         mathjax_config(), sep="")
 }
 

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -135,7 +135,10 @@ $if(mathjax-url)$
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "$mathjax-url$";
+    var src = "$mathjax-url$";
+    if (location.protocol === 'file:' && src.substr(0, 2) === '//')
+      src = 'http:' + src;
+    script.src  = src;
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>


### PR DESCRIPTION
But when the protocol is `file:`, use the http link for the MathJax URL.

Sometimes web browsers do not allow https resources in http pages, and we may see errors like this when we hard-code https for the MathJax URL:

```
Failed to load resource: Error creating SSL context ()
```

This is reproducible in the RStudio viewer on Windows and Linux. An example is the vignette `knitr-intro` after 

``` r
devtools::install_github('yihui/knitr', build_vignettes = TRUE)
help(package = 'knitr')
```

The math expression is not rendered in the RStudio viewer.

@jjallaire If you think this change makes sense, I will make the same change in other templates. Or if you can "fix" the RStudio viewer, that will be perfect, too.
