### PR TITLE
use the public API in knitr to generate figure filenames in tufte_handout()

### DIFF
--- a/R/tufte_handout.R
+++ b/R/tufte_handout.R
@@ -57,7 +57,7 @@ tufte_handout <- function(fig_width = 4,
                       paste("\\caption{", options$fig.cap, "}\n", sep = ""))
     
     # determine path to plot
-    file <- paste0(options$fig.path, options$label)
+    file <- knitr::fig_path(options = options)
     
     # determine figure type
     if (isTRUE(options$fig.margin)) 


### PR DESCRIPTION
There are a few subtle issues in generating the figure filenames, and it is not safe to paste fig.path with label as the filename. Possible issues are:
- more than one figure in one code chunk;
- special characters in fig.path or label (such as spaces) which may fail LaTeX;

This will fix the second problem reported in #269.
