### PR TITLE
Update vignette preamble to use VignetteEncoding

### DIFF
--- a/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd
@@ -6,7 +6,7 @@ output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Vignette Title}
   %\VignetteEngine{knitr::rmarkdown}
-  \usepackage[utf8]{inputenc}
+  %\VignetteEncoding{UTF-8}
 ---
 
 Vignettes are long form documentation commonly included in packages. Because they are part of the distribution of the package, they need to be as compact as possible. The `html_vignette` output type provides a custom style sheet (and tweaks some options) to ensure that the resulting html is as small as possible. The `html_vignette` format:


### PR DESCRIPTION
This uses the VignetteEncoding rather than `\usepackage[utf8]{inputenc}`.  The check logic was changed in commit https://github.com/wch/r-source/commit/b1648464ee4c5fe3aa227a6151a9f23a9e868b40.  The previous template also failed R CMD check with non-ASCII vignettes because of the prefixed `%` in the encoding line, the vignette lines should have been

```r
vignette: >
  %\VignetteIndexEntry{Vignette Title}
  %\VignetteEngine{knitr::rmarkdown}
  \usepackage[utf8]{inputenc}
```