### PR TITLE
`setspace` latex metadata added

### DIFF
--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -56,6 +56,7 @@
 #'    \item{\code{geometry}}{Options for geometry class (e.g. margin=1in); may be repeated}
 #'    \item{\code{mainfont, sansfont, monofont, mathfont}}{Document fonts (works only with xelatex and lualatex, see the \code{latex_engine} option)}
 #'    \item{\code{linkcolor, urlcolor, citecolor}}{Color for internal, external, and citation links (red, green, magenta, cyan, blue, black)}
+#'    \item{\code{setspace}}{Options for line spacing (e.g. one­half­s­pac­ing, dou­blespac­ing)}
 #' }
 #'
 #' @examples
@@ -155,4 +156,3 @@ pdf_pre_processor <- function(metadata, input_file, runtime, knit_meta, files_di
 
   args
 }
-

--- a/inst/rmd/latex/default.tex
+++ b/inst/rmd/latex/default.tex
@@ -4,6 +4,10 @@
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{fixltx2e} % provides \textsubscript
+% Set line spacing
+$if(setspace)$
+\usepackage[$setspace$]{setspace}
+$endif$
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex

--- a/man/pdf_document.Rd
+++ b/man/pdf_document.Rd
@@ -86,6 +86,7 @@ Available metadata variables include:
    \item{\code{geometry}}{Options for geometry class (e.g. margin=1in); may be repeated}
    \item{\code{mainfont, sansfont, monofont, mathfont}}{Document fonts (works only with xelatex and lualatex, see the \code{latex_engine} option)}
    \item{\code{linkcolor, urlcolor, citecolor}}{Color for internal, external, and citation links (red, green, magenta, cyan, blue, black)}
+   \item{\code{setspace}}{Options for line spacing (e.g. one­half­s­pac­ing, dou­blespac­ing)}
 }
 }
 \examples{


### PR DESCRIPTION
Added the LaTeX metadata option `setspace` allowing users to set line spacing, e.g. `onehalfspacing`, `doublespacing`.
