### PR TITLE
Quote value of PATH environment variable on Darwin

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -182,10 +182,11 @@ base_dir <- function(x) {
 find_program <- function(program) {
   if (Sys.info()["sysname"] == "Darwin") {
     res <- suppressWarnings({
-      # Quote the path (so it can contain spaces, etc.) and escape any quotes in
-      # the path itself. 
-      system(paste("PATH=\"", gsub("\"", "\\\"", Sys.getenv("PATH"), fixed = TRUE), "\" ", 
-                   "/usr/bin/which ", program, sep=""),
+      # Quote the path (so it can contain spaces, etc.) and escape any quotes 
+      # and escapes in the path itself
+      sanitized_path <- gsub("\\", "\\\\", Sys.getenv("PATH"), fixed = TRUE)      
+      sanitized_path <- gsub("\"", "\\\"", sanitized_path, fixed = TRUE)
+      system(paste("PATH=\"", sanitized_path, "\" /usr/bin/which ", program, sep=""),
              intern = TRUE)
     })
     if (length(res) == 0)


### PR DESCRIPTION
On OS X, `find_program` will fail if `$PATH` contains unescaped spaces; this change addresses the issue by quoting the value of `$PATH` on the command line (and escaping any quotes in `$PATH` itself.)
