### PR TITLE
Support for multiple author in ioslides

### DIFF
--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -47,7 +47,12 @@ $endif$
       presenters: [
       $for(author)$
       {
-        name: '$author$'
+        name: $if(author.name)$ '$author.name$' $else$ '$author$' $endif$,
+        company: '$author.company$',
+        gplus: '$author.gplus$',
+        twitter: '$author.twitter$',
+        www: '$author.www$',
+        github: '$author.github$'
       },
       $endfor$
       ]


### PR DESCRIPTION
For ioslides, while the pandoc template has logic to loop through multiple authors, ioslides requires each author having an additional company field.

``` yaml
title: "Untitled"
author: 
  - "John Smith"
  - "Alice"
  - "Bob"
date: "Sunday, November 16, 2014"
output: ioslides_presentation
```

produce
![image](https://cloud.githubusercontent.com/assets/4317392/5064204/7f2c71f4-6dd1-11e4-8994-b1e005e72b3e.png)

With this patch, we can create slide with multiple authors as

``` yaml
title: "Untitled"
author: 
  - name: "John Smith"
    company: "ABC"
  - name: "Alice"
    company: "XYZ"
  - name: "Bob"
    company: "XYZ"
date: "Sunday, November 16, 2014"
output: ioslides_presentation
```

![image](https://cloud.githubusercontent.com/assets/4317392/5064215/c4fb4980-6dd1-11e4-8166-b9f24ac90a8f.png)

Single author is not affected. You can still use the old style to just give the name or optionally add company.

I have also include additional fields as laid out in their template:
https://code.google.com/p/io-2012-slides/source/browse/slide_config.js
These can be picked up by the optional thank you slide:
http://io-2012-slides.googlecode.com/git/template.html#21

Is there any documentation for including custom slides like this? Currently the slide class is applied on the article div rather than the slide div, which makes creating slide like this impossible(?)
http://io-2012-slides.googlecode.com/git/template.html#17
I feel like `----` is supposed to serve this 'create a slide from blank slate' purpose but don't think that's how it works currently.
