### PR TITLE
Update version information

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 0.3.12
+Version: 0.3.13
 Date: 2014-09-08
 Author: JJ Allaire, Jonathan McPherson, Yihui Xie, Hadley Wickham, Joe Cheng,
     Jeff Allen
@@ -18,7 +18,7 @@ Imports:
     htmltools (>= 0.2.4),
     caTools
 Suggests:
-    shiny (>= 0.10.1),
+    shiny (>= 0.10.2.9004),
     testthat,
     digest
 SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,5 @@
+rmarkdown 0.3.13
+--------------------------------------------------------------------------------
+
+* Switched from the Bootstrap 2 web framework to Bootstrap 3. This is designed
+  to work with Shiny >= 0.10.2.9004, which has made the same switch.


### PR DESCRIPTION
This increases the suggested Shiny version to 0.10.2.9004 (which has Bootstrap 3), adds a NEWS entry, and also increments the rmarkdown version to 0.3.13.
