### PR TITLE
Apply empty 3d transform to lists in multi-column layouts (for Safari)

### DIFF
--- a/inst/rmd/ioslides/ioslides-13.5.1/theme/css/default.css
+++ b/inst/rmd/ioslides/ioslides-13.5.1/theme/css/default.css
@@ -725,6 +725,11 @@ button:not(:disabled):active {
   column-count: 2;
 }
 
+/* workaround for Safari 8 render bug with lists in columns */
+.columns-2 ul, .columns-2 ol {
+  -webkit-transform: translate3d(0, 0, 0);
+}
+
 /* line 472, ../scss/default.scss */
 table.rmdtable {
   width: 100%;


### PR DESCRIPTION
This is a workaround for a bug in Safari that causes wildly incorrect painting and clipping in some cases when lists appear in CSS columns. The workaround forces Safari to send the content through the 3D transformation pipeline to get it painted correctly.
