### PR TITLE
correctly detect existence of cache dir on windows

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -222,6 +222,10 @@ render <- function(input,
     cache_dir <-knitr_cache_dir(input, pandoc_to)
     knitr::opts_chunk$set(cache.path=cache_dir)
 
+    # strip the trailing slash from cache_dir so that file.exists
+    # check on it later works on windows
+    cache_dir <- gsub("/$", "", cache_dir)
+
     # merge user options and hooks
     if (!is.null(output_format$knitr)) {
       knitr::opts_knit$set(as.list(output_format$knitr$opts_knit))


### PR DESCRIPTION
We were not recognizing the existence of the cache_dir on windows because it ended in a trailing slash, and file.exists on windows requires no trailing slash. This resulted in our not properly recognizing that there was a cache directory and as a result removing the _files directory when we shouldn't (see bug https://github.com/rstudio/rmarkdown/issues/341) 