### PR TITLE
Update licenses in NOTICE

### DIFF
--- a/inst/NOTICE
+++ b/inst/NOTICE
@@ -88,7 +88,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-tufte latex and OpenSans Web Font License
+tufte latex and Open Sans Web Font License
 ----------------------------------------------------------------------
 
                                  Apache License
@@ -323,8 +323,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-Lato, Lora, Telex, NewsCycle, Quicksand, Montserrat,
-and Raleway Bold Web Fonts
+Lato, News Cycle, Source Sans Pro, and Raleway Web Fonts
 ----------------------------------------------------------------------
 
 SIL OPEN FONT LICENSE


### PR DESCRIPTION
The licenses listed in NOTICE refer to some fonts that were removed in the move to Bootstrap 3.