### PR TITLE
Replace file.exists() with file_test('-d')

### DIFF
--- a/R/draft.R
+++ b/R/draft.R
@@ -101,7 +101,7 @@ draft <- function(file,
     file <- tools::file_path_sans_ext(file)
 
     # create dir (new dir only)
-    if (file.exists(file))
+    if (dir_exists(file))
       stop("The directory '", file, "' already exists.")
     dir.create(file)
 
@@ -147,7 +147,7 @@ list_template_dirs <- function() {
 
     # check to see if the package includes a template folder
     template_folder <- system.file("rmarkdown", "templates", package = pkg)
-    if (file.exists(template_folder)) {
+    if (dir_exists(template_folder)) {
 
       # it does; list each template directory within the template folder
       template_dirs <- list.dirs(path = template_folder, recursive = FALSE)

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -64,7 +64,7 @@ ioslides_presentation <- function(logo = NULL,
     args <- c()
 
     # create the files dir if it doesn't exist
-    if (!file.exists(files_dir))
+    if (!dir_exists(files_dir))
       dir.create(files_dir)
 
     # logo

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -497,7 +497,7 @@ find_pandoc <- function() {
 
     # determine the versions of the sources
     versions <- lapply(sources, function(src) {
-      if (file.exists(src))
+      if (dir_exists(src))
         get_pandoc_version(src)
       else
         numeric_version("0")

--- a/R/render.R
+++ b/R/render.R
@@ -64,15 +64,10 @@ render <- function(input,
 
   # setup a cleanup function for intermediate files
   intermediates <- c()
-  on.exit(lapply(intermediates,
-                 function(f) {
-                   if (clean && file.exists(f))
-                     unlink(f, recursive = TRUE)
-                 }),
-          add = TRUE)
+  on.exit(if (clean) unlink(intermediates, recursive = TRUE), add = TRUE)
 
   # ensure we have a directory to store intermediates
-  if (!is.null(intermediates_dir) && !file.exists(intermediates_dir))
+  if (!is.null(intermediates_dir) && !dir_exists(intermediates_dir))
     dir.create(intermediates_dir)
   intermediates_loc <- function(file) {
     if (is.null(intermediates_dir))
@@ -168,7 +163,7 @@ render <- function(input,
 
   # if an output_dir was specified then concatenate it with the output file
   if (!is.null(output_dir)) {
-    if (!file.exists(output_dir))
+    if (!dir_exists(output_dir))
       dir.create(output_dir)
     output_file <- file.path(output_dir, basename(output_file))
   }
@@ -222,7 +217,7 @@ render <- function(input,
     cache_dir <-knitr_cache_dir(input, pandoc_to)
     knitr::opts_chunk$set(cache.path=cache_dir)
 
-    # strip the trailing slash from cache_dir so that file.exists
+    # strip the trailing slash from cache_dir so that file.exists() and unlink()
     # check on it later works on windows
     cache_dir <- gsub("/$", "", cache_dir)
 
@@ -293,7 +288,7 @@ render <- function(input,
 
   # clean the files_dir if we've either been asking to clean supporting files or
   # the knitr cache is active
-  if (output_format$clean_supporting && (is.null(cache_dir) || !file.exists(cache_dir)))
+  if (output_format$clean_supporting && (is.null(cache_dir) || !dir_exists(cache_dir)))
       intermediates <- c(intermediates, files_dir)
 
   # read the input text as UTF-8 then write it back out
@@ -394,7 +389,7 @@ render <- function(input,
 render_supporting_files <- function(from, files_dir, rename_to = NULL) {
 
   # auto-create directory for supporting files
-  if (!file.exists(files_dir))
+  if (!dir_exists(files_dir))
     dir.create(files_dir)
 
   # target directory is based on the dirname of the path or the rename_to
@@ -405,7 +400,7 @@ render_supporting_files <- function(from, files_dir, rename_to = NULL) {
                                      rename_to))
 
   # copy the directory if it hasn't already been copied
-  if (!file.exists(target_dir) && !file.exists(target_stage_dir)) {
+  if (!dir_exists(target_dir) && !dir_exists(target_stage_dir)) {
     file.copy(from = from,
               to = files_dir,
               recursive = TRUE)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -97,7 +97,7 @@ run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
   
   # form and test locations
   dir <- normalizePath(dir, winslash="/")
-  if (!file.exists(dir))
+  if (!dir_exists(dir))
     stop("The directory '", dir, "' does not exist")
 
   if (!is.null(file)) {
@@ -236,7 +236,7 @@ rmarkdown_shiny_server <- function(dir, file, encoding, auto_reload, render_args
       result_path <- shiny::maskReactiveContext(do.call(render, args))
 
       # ensure the resource folder exists, and map requests to it in Shiny
-      if (!file.exists(resource_folder))
+      if (!dir_exists(resource_folder))
         dir.create(resource_folder, recursive = TRUE)
       shiny::addResourcePath(basename(resource_folder), resource_folder)
 
@@ -404,7 +404,7 @@ file.path.ci <- function(dir, name) {
   default <- file.path(dir, name)
   if (file.exists(default))
     return(default)
-  if (!file.exists(dir))
+  if (!dir_exists(dir))
     return(default)
 
   matches <- list.files(dir, name, ignore.case=TRUE, full.names=TRUE,

--- a/R/util.R
+++ b/R/util.R
@@ -78,6 +78,10 @@ as_tmpfile <- function(str) {
   }
 }
 
+dir_exists <- function(x) {
+  file_test('-d', x)
+}
+
 file_with_ext <- function(file, ext) {
   paste(tools::file_path_sans_ext(file), ".", ext, sep = "")
 }


### PR DESCRIPTION
The former does not work on directories with trailing slashes on Windows, whereas the latter does, e.g. file.exists('foo/') is FALSE, and file_test('-d', 'foo') is TRUE if the directory foo exists

BTW, this will also make the error message in #346 clearer.