### PR TITLE
Fix Windows path handling bugs in some RMarkdown paths

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -139,7 +139,8 @@ html_document_base <- function(smart = TRUE,
           file.copy(in_file, target_res_file)
 
           # replace the reference in the document
-          res_src <- sub(src, relative_to(output_dir, target_res_file), res_src)
+          res_src <- sub(src, normalized_relative_to(
+            output_dir, target_res_file), res_src)
         }
         res_src
       }

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -385,12 +385,8 @@ pandoc_mathjax_args <- function(mathjax,
       mathjax_path <- render_supporting_files(mathjax_path,
                                               files_dir,
                                               "mathjax-local")
-      mathjax <- paste(relative_to(
-                       normalizePath(
-                         output_dir, winslash = "/", mustWork = FALSE),
-                       normalizePath(
-                         mathjax_path, winslash = "/", mustWork = FALSE)), 
-                       "/", mathjax_config(), sep = "")
+      mathjax <- paste(normalized_relative_to(output_dir, mathjax_path), "/",
+                       mathjax_config(), sep = "")
     }
 
     if (identical(template, "default")) {
@@ -467,8 +463,10 @@ pandoc_html_highlight_args <- function(highlight,
       if (self_contained)
         highlight_path <- pandoc_path_arg(highlight_path)
       else
-        highlight_path <- relative_to(output_dir,
+      {
+        highlight_path <- normalized_relative_to(output_dir,
           render_supporting_files(highlight_path, files_dir))
+      }
       args <- c(args, "--no-highlight")
       args <- c(args,
                 "--variable", paste("highlightjs=", highlight_path, sep=""))

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -385,8 +385,12 @@ pandoc_mathjax_args <- function(mathjax,
       mathjax_path <- render_supporting_files(mathjax_path,
                                               files_dir,
                                               "mathjax-local")
-      mathjax <- paste(relative_to(output_dir, mathjax_path), "/",
-                       mathjax_config(), sep = "")
+      mathjax <- paste(relative_to(
+                       normalizePath(
+                         output_dir, winslash = "/", mustWork = FALSE),
+                       normalizePath(
+                         mathjax_path, winslash = "/", mustWork = FALSE)), 
+                       "/", mathjax_config(), sep = "")
     }
 
     if (identical(template, "default")) {

--- a/R/relative_to.R
+++ b/R/relative_to.R
@@ -28,3 +28,10 @@ relative_to <- function(dir, file) {
   
   file
 }
+
+# A variant of relative_to that normalizes its inputs.
+normalized_relative_to <- function(dir, file) {
+  relative_to(
+    normalizePath(dir, winslash = "/", mustWork = FALSE),
+    normalizePath(file, winslash = "/", mustWork = FALSE))
+}


### PR DESCRIPTION
`relative_to` can return incorrect results on Windows when its input paths differ in path separator style (e.g. `C:\Users\bob\file.txt` is not considered relative to `C:/Users/bob/`), which can result in downstream problems; for instance, a full path appearing in the output when a relative path is desired. 

This change introduces a `normalized_relative_to` variant that normalizes the path before comparing them, and uses the normalized version in instances where paths that differ in separator style are possible arguments.