### PR TITLE
Added subtitle command to default.tex to allow for subtitle in yaml header

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -90,7 +90,7 @@ $if(title)$
 <div id="$idprefix$header">
 <h1 class="title">$title$</h1>
 $if(subtitle)$
-<h1 class="subtitle">$subtitle$</h1>
+<h3 class="subtitle"><em>$subtitle$</em></h3>
 $endif$
 $for(author)$
 $if(author.name)$

--- a/inst/rmd/latex/default.tex
+++ b/inst/rmd/latex/default.tex
@@ -138,6 +138,14 @@ $endif$
 
 %%% Change title format to be more compact
 \usepackage{titling}
+
+% Create subtitle command for use in maketitle
+\newcommand{\subtitle}[1]{
+  \posttitle{
+    \begin{center}\large#1\end{center}
+    }
+}
+
 \setlength{\droptitle}{-2em}
 $if(title)$
   \title{$title$}
@@ -147,6 +155,9 @@ $else$
   \title{}
   \pretitle{\vspace{\droptitle}}
   \posttitle{}
+$endif$
+$if(subtitle)$
+\subtitle{$subtitle$}
 $endif$
 $if(author)$
   \author{$for(author)$$author$$sep$ \\ $endfor$}
@@ -163,10 +174,6 @@ $if(date)$
 $else$
   \date{}
   \predate{}\postdate{}
-$endif$
-
-$if(subtitle)$
-\subtitle{$subtitle$}
 $endif$
 
 $for(header-includes)$


### PR DESCRIPTION
I think it would be nice to include subtitles in the default pdf layout (and apparently [I'm not alone](http://stackoverflow.com/questions/26043807/multiple-authors-and-subtitles-in-rmarkdown-yaml)).

This may have been planned since `\subtitle` already existed in the default.tex template, but this command is not defined in the default `article` documentclass in latex. I added `\newcommand{subtitle}` to default.tex so that a subtitle will render. 

Example yaml header:

~~~
---
title: "Title"
subtitle: "Subtitle Here"
author: "John Stanton-Geddes"
date: "January 22, 2015"
output:
  pdf_document:
    keep_tex: yes
---
~~~

This is my first pull request so I apologize for any mistakes, and would be happy to close/open as an issue if there's a reason not to implement this. 

Thanks for the work on rmarkdown!