### PR TITLE
add ulem for strikeout and morefloats for complex layouts

### DIFF
--- a/inst/rmarkdown/templates/tufte_handout/resources/tufte-handout.tex
+++ b/inst/rmarkdown/templates/tufte_handout/resources/tufte-handout.tex
@@ -38,6 +38,12 @@ $endif$
 % lipsum
 \usepackage{lipsum}
 
+% strikeout
+\usepackage[normalem]{ulem}
+ 
+% morefloats
+\usepackage{morefloats}
+
 % title / author / date
 $if(title)$
 \title{$title$}


### PR DESCRIPTION
Pandoc markdown defines a ~~ syntax for strikouts, but the tufte-handout
template did not support it.  Adding [normalem]{ulem} supports strikeout
without adjusting other formatting, and should be supported by all standard
TeX distributions.

LaTeX by default supports only a limited number of floating elements.
The tufte-handout template uses multi-column layouts and makes liberal
use of floating elements to layout things like side-notes, graphics, and
equations.  If you have a large number of side-notes or equations on a
page, LaTeX cannot lay out the page, and will stop with an error.
Adding {morefloats} resolves this problem, allowing more complex pages.
It is a core package, and should be available with all main LaTeX
distributions.