### PR TITLE
Allow subtitles in both pdf and html output.

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -90,7 +90,7 @@ $if(title)$
 <div id="$idprefix$header">
 <h1 class="title">$title$</h1>
 $if(subtitle)$
-<h1 class="subtitle">$subtitle$</h1>
+<h3 class="subtitle"><em>$subtitle$</em></h3>
 $endif$
 $for(author)$
 $if(author.name)$

--- a/inst/rmd/latex/default.tex
+++ b/inst/rmd/latex/default.tex
@@ -138,6 +138,14 @@ $endif$
 
 %%% Change title format to be more compact
 \usepackage{titling}
+
+% Create subtitle command for use in maketitle
+\newcommand{\subtitle}[1]{
+  \posttitle{
+    \begin{center}\large#1\end{center}
+    }
+}
+
 \setlength{\droptitle}{-2em}
 $if(title)$
   \title{$title$}
@@ -147,6 +155,9 @@ $else$
   \title{}
   \pretitle{\vspace{\droptitle}}
   \posttitle{}
+$endif$
+$if(subtitle)$
+\subtitle{$subtitle$}
 $endif$
 $if(author)$
   \author{$for(author)$$author$$sep$ \\ $endfor$}
@@ -163,10 +174,6 @@ $if(date)$
 $else$
   \date{}
   \predate{}\postdate{}
-$endif$
-
-$if(subtitle)$
-\subtitle{$subtitle$}
 $endif$
 
 $for(header-includes)$


### PR DESCRIPTION
Following up on a previous pull request (#360) that I just closed. The previous request added the ability to include a subtitle in pdf output, but the html output had a subtitle that was not visually distinguishable from the title (both `<h1>`). This request also modifies default.html so that the subtitle is distinct from the title (`<h3>` and `<em>`). Those choices were my preference and I'd be happy to change.  Please let me know if I need to make any other changes to get this merged. Thanks!


