### PR TITLE
Numbered sections should begin at 1 not 0

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -144,7 +144,7 @@ html_document <- function(toc = FALSE,
 
   # numbered sections
   if (number_sections)
-    args <- c(args, "--number-sections")
+    args <- c(args, "--number-sections", "--number-offset=1")
 
   # additional css
   for (css_file in css)


### PR DESCRIPTION
Otherwise tables of contents look like

> * 0.1 First header
> * 0.2 Second header
> * ...