### PR TITLE
Improve resource extraction speed

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -185,6 +185,13 @@ html_document_base <- function(smart = TRUE,
       if (length(res_replacements) > 0) {
         ch_pos <- 1
         new_output_str <- ""
+        
+        # we do all replacements in bytes for performance reasons--mark the 
+        # output with byte encoding temporarily 
+        prev_encoding <- Encoding(output_str)
+        Encoding(output_str) <- "bytes"
+        Encoding(new_output_str) <- "bytes"
+        
         for (res_rep in seq_along(res_replacements)) {
           rep <- res_replacements[[res_rep]]
           
@@ -195,7 +202,7 @@ html_document_base <- function(smart = TRUE,
           # the text from the current replacement to the end of the output,
           # if applicable
           after <- if (res_rep == length(res_replacements))
-            substr(output_str, ch_pos, nchar(output_str))
+            substring(output_str, ch_pos)
           else 
             ""
           
@@ -205,6 +212,7 @@ html_document_base <- function(smart = TRUE,
                                   sep = "")
         }
         output_str <- new_output_str
+        Encoding(output_str) <- prev_encoding
       }
       
     } else if (!self_contained) {

--- a/R/html_parser.R
+++ b/R/html_parser.R
@@ -16,7 +16,7 @@ call_resource_attrs <- function(html, callback = NULL)  {
   # use the fastest defaults we can here--PCRE, bytes (RE and input both UTF-8)
   # as the HTML can be quite large
   tags <- gregexpr(
-    "<\\s*(img|link|object|script|audio|video|embed)\\s+([^>]+)>", html, 
+    "<\\s*(img|link|object|script|audio|video|embed|iframe)\\s+([^>]+)>", html, 
     perl = TRUE, useBytes = TRUE, ignore.case = TRUE)[[1]]
   
   for (pos in seq_along(tags)) {
@@ -35,7 +35,8 @@ call_resource_attrs <- function(html, callback = NULL)  {
                       script = "src",
                       audio  = "src",
                       video  = "src",
-                      embed  = "src")
+                      embed  = "src",
+                      iframe = "src")
     
     # extract the tags
     attrstart <- attr(tags, "capture.start", exact = TRUE)[pos,2]

--- a/R/html_parser.R
+++ b/R/html_parser.R
@@ -1,171 +1,59 @@
-# This file implements a simple HTML parser designed to locate tags and
-# attribute values in HTML emitted by pandoc. Herein, we process input HTML one 
-# character at a time and use a simple state machine to determine where to go 
-# go next.
-
-# Parse states--each is a list of rules which govern transitions to other
-# states. Any character that doesn't match one of the rules causes the parser
-# to stay in the state and store the character as content.
-.parse_states <- new.env(parent = emptyenv())
-
-assign("TEXT", list(
-  "<" = "NODE"), 
-  envir = .parse_states)
-
-assign("NODE", list(
-  "!" = "COMMENT", 
-  "alpha" = "TAG",
-  ">" = "TEXT"), 
-  envir = .parse_states)
-
-assign("COMMENT", list(
-  ">" = "TEXT"), 
-  envir = .parse_states)
-
-assign("TAG", list(
-  "white" = "ATTR_LIST",
-  ">" = "TEXT"), 
-  envir = .parse_states)
-
-assign("ATTR_LIST", list(
-  "alpha" = "ATTR",
-  ">" = "TEXT"), 
-  envir = .parse_states)
-
-assign("ATTR", list(
-  "white" = "ATTR_END",
-  "=" = "ATTR_VALUE"), 
-  envir = .parse_states)
-
-assign("ATTR_END", list(
-  "alpha" = "ATTR",
-  "=" = "ATTR_VALUE"), 
-  envir = .parse_states)
-
-assign("ATTR_VALUE", list(
-  "'" = "SINGLE_ATTR",
-  "\"" = "DOUBLE_ATTR",
-  "white" = "ATTR_VALUE",
-  "any" = "UNQUOTED_ATTR"), 
-  envir = .parse_states)
-
-assign("SINGLE_ATTR", list(
-  "'" = "ATTR_LIST"), 
-  envir = .parse_states)
-
-assign("DOUBLE_ATTR", list(
-  "\"" = "ATTR_LIST"),
-  envir = .parse_states)
-
-assign("UNQUOTED_ATTR", list(
-  "white" = "ATTR_LIST",
-  ">" = "TEXT"),
-  envir = .parse_states)
-
-# Extract HTML attribute values, invoking a callback on each. The callback 
-# receives the tag, attribute name, attribute value, and position in the string
-# where the value was found.
+# This function invokes a callback for each resource attribute discovered 
+# in its first argument. The parameters to the callback are:
+# 
+# 1) The tag discovered (e.g. "img")
+# 2) The resource attribute (e.g. "src")
+# 3) The attribute's value (e.g. "thumbnail.png")
+# 4) The position of the attribute value in the original string (in bytes)
 #
-# For instance, extracting values from:
-#
-#    <img class="bordered" src="foo.png">
-#
-# results in two callbacks:
-#    callback("img", "class", "bordered", ...)
-#    callback("img", "src", "foo.png", ...)
-#
-html_extract_values <- function(html, callback = NULL, show_parse = FALSE) {
+call_resource_attrs <- function(html, callback = NULL)  {
   
-  # collapse HTML if needed
-  if (length(html) > 1) {
-    html <- paste(html, collapse = "\n")
-  }
-  
-  # iterating over characters using substr is extremely slow; creating a vector 
-  # of individual characters dramatically improves speed since we can access 
-  # the characters directly
-  htmlchars <- unlist(strsplit(html, "", fixed = TRUE))
-  
-  # state information (rewritten as we go)
-  idx <- 1
-  end <- length(htmlchars)
-  state <- get("TEXT", envir = .parse_states)
-  contents_idx <- idx
-  cur_tag <- ""
-  cur_attr <- ""
-  current_state <- ""
-  consume <- FALSE
-  
-  # loop over the contents of the HTML string
-  while (idx <= end) {
-    # get the character to examine and set up state
-    ch <- htmlchars[[idx]]
+  # for performance reasons, we do all regexp matching on literal bytes, and 
+  # reapply encoding after extracting matches
+  html_encoding <- Encoding(html)
+  Encoding(html) <- "bytes"
     
-    # check each rule
-    for (rule_idx in seq_along(state)) {
-      
-      # extract the pattern to test against
-      pat <- names(state)[[rule_idx]]
-      
-      if (pat == "alpha") {
-        # alphabetic character
-        chRaw <- charToRaw(ch)
-        if ((chRaw >= charToRaw("a") && chRaw <= charToRaw("z")) ||
-            (chRaw >= charToRaw("A") && chRaw <= charToRaw("Z"))) {
-          new_state <- state[[rule_idx]]
-          break
-        }
-      } else if (pat == "white" && 
-                 (ch == " "  || ch == "\n" || ch == "\t" || ch == "\v")) {
-        # whitespace character
-        new_state <- state[[rule_idx]]
-        break
-      } else if (pat == "any") {
-        # any character
-        new_state <- state[[rule_idx]]
-        break
-      } else if (pat == ch) {
-        # specific character--consume it
-        new_state <- state[[rule_idx]]
-        consume <- TRUE
-        break
-      }
-    }
+  # use the fastest defaults we can here--PCRE, bytes (RE and input both UTF-8)
+  # as the HTML can be quite large
+  tags <- gregexpr(
+    "<\\s*(img|link|object|script|audio|video|embed)\\s+([^>]+)>", html, 
+    perl = TRUE, useBytes = TRUE, ignore.case = TRUE)[[1]]
+  
+  for (pos in seq_along(tags)) {
+    # extract the HTML tag in question
+    tagstart <- attr(tags, "capture.start", exact = TRUE)[pos,1]
+    tag <- substr(html, tagstart,  tagstart + 
+                    attr(tags, "capture.length", exact = TRUE)[pos,1] - 1)
+    Encoding(tag) <- html_encoding
+    tag <- tolower(tag)
     
-    # did we change states above?
-    if (current_state != new_state) {
-      if (current_state == "TAG")
-        cur_tag <- paste0(htmlchars[(contents_idx - 1):(idx - 1)], collapse = "")
-      else if (current_state == "ATTR")
-        cur_attr <- paste0(htmlchars[(contents_idx - 1):(idx - 1)], collapse = "")
-      else if (!is.null(callback) && 
-          (current_state == "DOUBLE_ATTR" || 
-           current_state == "SINGLE_ATTR" ||
-           current_state == "UNQUOTED_ATTR")) {
-        # if the attribute is unquoted then it's already begun
-        callback(cur_tag, cur_attr, 
-                 paste0(htmlchars[
-                        (if (current_state == "UNQUOTED_ATTR") 
-                          contents_idx - 1
-                        else
-                          contents_idx):(idx - 1)], collapse = ""), 
-                 if (current_state == "UNQUOTED_ATTR")
-                   contents_idx - 1 
-                 else
-                   contents_idx)    
-      }
-      if (show_parse) {
-        print(paste0(htmlchars[(contents_idx - 1):(idx - 1)], collapse = ""))
-        print(new_state)
-      }
-      current_state <- new_state
-      contents_idx <- idx + 1
-      state <- get(new_state, envir = .parse_states)
-      if (consume)
-        idx <- idx + 1
-      consume <- FALSE
-    } else {
-      idx <- idx + 1
+    # determine the attribute to look for based on the tag name
+    tagattr <- switch(tag,
+                      img    = "src",
+                      link   = "href",
+                      object = "data",
+                      script = "src",
+                      audio  = "src",
+                      video  = "src",
+                      embed  = "src")
+    
+    # extract the tags
+    attrstart <- attr(tags, "capture.start", exact = TRUE)[pos,2]
+    attrs <- substr(html, attrstart, attrstart + 
+                    attr(tags, "capture.length", exact = TRUE)[pos,2] - 1)
+    
+    # see if one of the attributes if the one we're looking for
+    attrmatch <- regexpr(paste0("\\s*", tagattr, 
+                                "\\s*=\\s*('[^']+'|\"[^\"]+\")"), 
+                         attrs, ignore.case = TRUE, perl = TRUE, 
+                         useBytes = TRUE)
+    if (attrmatch >= 0) {
+      matchstart <- attrstart + 
+        attr(attrmatch, "capture.start", exact = TRUE) - 1
+      resource <- substr(html, matchstart + 1, 
+        matchstart + attr(attrmatch, "capture.length", exact = TRUE) - 2)
+      Encoding(resource) <- html_encoding
+      callback(tag, tagattr, resource, matchstart + 1)
     }
   }
 }

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -151,7 +151,8 @@ find_external_resources <- function(rmd_file,
   }
  
   # parse the HTML and invoke our resource discovery callbacks
-  call_resource_attrs(readLines(html_file, warn = FALSE, encoding = "UTF-8"),
+  call_resource_attrs(paste(
+      readLines(html_file, warn = FALSE, encoding = "UTF-8"), collapse = "\n"),
     discover_resource)
   
   # purl the file to extract just the R code 

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -195,31 +195,6 @@ find_external_resources <- function(rmd_file,
   discovered_resources 
 }
 
-# given HTML input and a callback, invokes the callback on everything in the 
-# HTML that looks like it might point to a resource.
-call_resource_attrs <- function(html, callback) {
-  
-  attr_handler <- function(tag, attr_name, attr_value, attr_idx) {
-    if ((tag == "img"    && attr_name == "src")  ||
-        (tag == "link"   && attr_name == "href") ||
-        (tag == "object" && attr_name == "data") || 
-        (tag == "script" && attr_name == "src")  ||
-        (tag == "audio"  && attr_name == "src")  ||
-        (tag == "video"  && attr_name == "src")  ||
-        (tag == "embed"  && attr_name == "src"))
-    {
-      # value found, invoke callbcak
-      callback(tag, attr_name, attr_value, attr_idx)
-    }
-  }
-  
-  # parse the HTML and invoke handlers on all elements that look like they might
-  # refer to external resources
-  html_extract_values(html, attr_handler)
-  
-  invisible(NULL)
-}
-
 # given a filename, return true if the file appears to be a web file
 is_web_file <- function(filename) {
   tolower(tools::file_ext(filename)) %in% c(

--- a/tests/testthat/test-htmlparse.R
+++ b/tests/testthat/test-htmlparse.R
@@ -15,48 +15,33 @@ html_accumulator <- function(tag, att, val, idx) {
 }
 
 test_that("different attribute quoting styles are supported", {
-  html_extract_values(paste(
-    "<h1 align='center'></h1>",
-    "<h2 align=\"left\"></h2>",
-    "<h3 align=right></h3>"), html_accumulator)
+  call_resource_attrs(paste(
+    "<img src='123'/>",
+    "<img src=\"456\"/>"), html_accumulator)
   expect_equal(accumulated, data.frame(
-    tag = c("h1", "h2", "h3"),
-    attribute = c("align", "align", "align"),
-    value = c("center", "left", "right"),
+    tag = c("img", "img"),
+    attribute = c("src", "src"),
+    value = c("123", "456"),
     stringsAsFactors = FALSE))
   reset_accumulator()
 })
 
 test_that("irrelevant white space is ignored", {
-  html_extract_values(paste(
-    "<  input type =   \n",
-    "        \t 'text'\n",
+  call_resource_attrs(paste(
+    "<  img src =   \n",
+    "        \t '123'\n",
     "        \t value ='abc'  />",
-    "<button></button>"), html_accumulator)
+    "<link href=    '456'>"), html_accumulator)
   expect_equal(accumulated, data.frame(
-    tag = c("input", "input"),
-    attribute = c("type", "value"),
-    value = c("text", "abc"),
-    stringsAsFactors = FALSE))
-  reset_accumulator()
-})
-
-test_that("comments are ignored", {
-  html_extract_values(paste(
-    "<!--img src='foo.png'-->\n",
-    "<img src='bar.png'>\n",
-    "<!-- <img src='baz.png'> -->\n",
-    "<img src='quux.png'>\n"), html_accumulator)
-  expect_equal(accumulated, data.frame(
-    tag = c("img", "img"),
-    attribute = c("src", "src"),
-    value = c("bar.png", "quux.png"),
+    tag = c("img", "link"),
+    attribute = c("src", "href"),
+    value = c("123", "456"),
     stringsAsFactors = FALSE))
   reset_accumulator()
 })
 
 test_that("common resource types are found in a simple document", {
-  html_extract_values(paste(
+  call_resource_attrs(paste(
     "<!DOCTYPE html>\n",
     "<HTML>\n",
     "<HEAD>\n",
@@ -68,9 +53,9 @@ test_that("common resource types are found in a simple document", {
     "</BODY>\n",
     "</HTML>\n"), html_accumulator)
   expect_equal(accumulated, data.frame(
-    tag = c("SCRIPT", "LINK", "LINK", "IMG"),
-    attribute = c("SRC", "REL", "HREF", "SRC"),
-    value = c("foo.js", "stylesheet", "bar.css", "baz.png"),
+    tag = c("script", "link", "img"),
+    attribute = c("src", "href", "src"),
+    value = c("foo.js", "bar.css", "baz.png"),
     stringsAsFactors = FALSE))
   reset_accumulator()
 })

--- a/tests/testthat/test-htmlparse.R
+++ b/tests/testthat/test-htmlparse.R
@@ -50,12 +50,13 @@ test_that("common resource types are found in a simple document", {
     "</HEAD>\n",
     "<BODY>\n",
     "  <IMG SRC=\"baz.png\"/>\n",
+    "  <IFRAME SRC=\"quux.html\"/>\n",
     "</BODY>\n",
     "</HTML>\n"), html_accumulator)
   expect_equal(accumulated, data.frame(
-    tag = c("script", "link", "img"),
-    attribute = c("src", "href", "src"),
-    value = c("foo.js", "bar.css", "baz.png"),
+    tag = c("script", "link", "img", "iframe"),
+    attribute = c("src", "href", "src", "src"),
+    value = c("foo.js", "bar.css", "baz.png", "quux.html"),
     stringsAsFactors = FALSE))
   reset_accumulator()
 })


### PR DESCRIPTION
This change removes the DFA-like HTML parser used to extract resources for Shiny rendering and publishing. The performance of the DFA parser was good on Unix platforms, but it struggled on Windows platforms and no further opportunities for tuning were found. 

A regular expression-based system replaces the DFA parser. This system makes only a single pass over the input and operates on raw bytes. It's several times faster than the previous approach, at the expense of the correctness of some edge cases (e.g. commented-out HTML), but it otherwise maintains the same benefits of the DFA parser (compared to the code prior to the introduction of either):

- A wide variety of HTML tags and attributes are supported (`img`, `link`, `object`, `embed`, etc.)
- The placement, order, and case of attributes does not matter (`<img title="foo" SRC="bar" />` is acceptable)
- Whitespace for formatting is tolerated anywhere within the tag