### PR TITLE
add support for multimedia web fomats

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -206,6 +206,9 @@ is_web_file <- function(filename) {
     "jpeg",
     "jpg",
     "js",
-    "png")
+    "mp3",
+    "mp4",
+    "png",
+    "wav")
 }
 


### PR DESCRIPTION
This pull request simply adds `mp3`, `mp4`, and `wav` as valid web files when scanning for external resources.