### PR TITLE
Implement resource discovery for raw HTML documents

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -58,7 +58,8 @@ find_external_resources <- function(input_file,
   # ensure we're working with valid input
   ext <- tolower(tools::file_ext(input_file))
   if (!(ext %in% c("rmd", "html"))) {
-    stop("Resource discovery is only supported for R Markdown files.")
+    stop("Resource discovery is only supported for R Markdown files or HTML ",
+         "files.")
   }
   if (!file.exists(input_file)) {
     stop("The input file file '", input_file, "' does not exist.")
@@ -163,7 +164,7 @@ discover_rmd_resources <- function(rmd_file, encoding,
   # source
   md_file <- tempfile(fileext = ".md")
   output_dir <- dirname(md_file)
-  rmd_content <- read_lines_utf8(input_file, encoding)
+  rmd_content <- read_lines_utf8(rmd_file, encoding)
   writeLines(rmd_content, md_file, useBytes = TRUE)
   
   # create a vector of temporary files; anything in here will be cleaned up on

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -163,6 +163,7 @@ discover_rmd_resources <- function(rmd_file, encoding,
   # create a UTF-8 encoded Markdown file to serve as the resource discovery 
   # source
   md_file <- tempfile(fileext = ".md")
+  input_dir <- dirname(normalizePath(rmd_file, winslash = "/"))
   output_dir <- dirname(md_file)
   rmd_content <- read_lines_utf8(rmd_file, encoding)
   writeLines(rmd_content, md_file, useBytes = TRUE)

--- a/man/find_external_resources.Rd
+++ b/man/find_external_resources.Rd
@@ -4,12 +4,12 @@
 \alias{find_external_resources}
 \title{Find External Resource References}
 \usage{
-find_external_resources(rmd_file, encoding = getOption("encoding"))
+find_external_resources(input_file, encoding = getOption("encoding"))
 }
 \arguments{
-\item{rmd_file}{path to the R Markdown document to process}
+\item{input_file}{path to the R Markdown document or HTML file to process}
 
-\item{encoding}{the encoding of the R Markdown document}
+\item{encoding}{the encoding of the document}
 }
 \value{
 A data frame with the following columns:
@@ -22,19 +22,21 @@ A data frame with the following columns:
   }
 }
 \description{
-Given an R Markdown document, attempt to determine the set of additional
-files needed in order to render and display the document.
+Given an R Markdown document or HTML file, attempt to determine the set of
+additional files needed in order to render and display the document.
 }
 \details{
 This routine applies heuristics in order to scan a document for
   possible resource references.
 
-  It looks for references to files implicitly referenced in Markdown (e.g.
-  \code{![alt](img.png)}), in the document's YAML header, in raw HTML chunks,
-  and as quoted strings in R code chunks (e.g. \code{read.csv("data.csv")}).
+  In R Markdown documents, it looks for references to files implicitly
+  referenced in Markdown (e.g. \code{![alt](img.png)}), in the document's
+  YAML header, in raw HTML chunks, and as quoted strings in R code chunks
+  (e.g. \code{read.csv("data.csv")}).
 
-  Resources specified explicitly in the document's YAML header are also
-  returned. To specify resources in YAML, use the \code{resource_files} key:
+  Resources specified explicitly in the YAML header for R Markdown documents
+  are also returned. To specify resources in YAML, use the
+  \code{resource_files} key:
 
   \preformatted{---
 title: My Document
@@ -54,7 +56,11 @@ resource_files:
     this case.
   }
 
-  Only resources that exist on disk and are contained in the document's
-  directory (or a child thereof) are returned.
+  In HTML files (and raw HTML chunks in R Markdown documents), this routine
+  searches for resources specified in common tag attributes, such as
+  \code{<img src="...">}, \code{<link href="...">}, etc.
+
+  In all cases, only resources that exist on disk and are contained in the
+  document's directory (or a child thereof) are returned.
 }
 


### PR DESCRIPTION
This change implements extends `find_external_resources` to discover resources in raw HTML files as well as source R Markdown documents, for use when collecting a list of static content that needs to be bundled with a rendered document.

Resource discovery in raw HTML was already implemented (as part of R Markdown resource discovery, the document is rendered to HTML); this just extends it in the following ways:

- `find_external_resources` may now be invoked with `.html` files in addition to `.Rmd` files, and the appropriate set of resource detection heuristics will be invoked
- If there's a `_files` directory alongside the `.html` file with a matching name, its contents are presumed  to be resources that need to be deployed along with the file, in addition to any resources automatically discovered inside the file itself
- A small performance optimization has been added to speed resource discovery in self-contained HTML files (since we don't know a priori whether we're operating on one or not)