### PR TITLE
support for parameters declared in yaml

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 0.5.3.2
+Version: 0.5.3.3
 Date: 2014-09-08
 Author: JJ Allaire, Jonathan McPherson, Yihui Xie, Hadley Wickham, Joe Cheng,
     Jeff Allen

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 rmarkdown 0.6 (under development)
 --------------------------------------------------------------------------------
 
+* Support for parameterized reports. Parameter names and default values are 
+  defined in YAML and can be specified via the 'params' argument to the
+  render function
+
 * 'md_extensions' option to enable/disable markdown extensions for input files
 
 * Automatically discover and include dependent resources (e.g. images, css, etc.)
@@ -9,6 +13,7 @@ rmarkdown 0.6 (under development)
 * Use VignetteEncoding directive in html_vignette format
 
 * Various improvements to tufte_handout format
+
 
 rmarkdown 0.5.1
 --------------------------------------------------------------------------------

--- a/R/render.R
+++ b/R/render.R
@@ -274,7 +274,7 @@ render <- function(input,
       params <- merge_lists(default_params, params)
      
       # make the params available in the knit environment
-      if (!exists("params", envir = envir)) {
+      if (!exists("params", envir = envir, inherits = FALSE)) {
         assign("params", params, envir = envir)
         on.exit(remove("params", envir = envir), add = TRUE)
       } else {

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -44,6 +44,10 @@ render(input, output_format = NULL, output_file = NULL, output_dir = NULL,
 
   \item{clean}{\code{TRUE} to clean intermediate files created
   during rendering.}
+  
+  \item{params}{List of named parameters that override custom params
+  specified within the YAML front-matter (e.g. specifying a dataset to
+  read or a date range to confine output to).}
 
   \item{envir}{The environment in which the code chunks are
   to be evaluated during knitting (can use


### PR DESCRIPTION
rmarkdown::render with no explicit params passed will use the default values specified in the yaml.

To create a parameterized function for a report you'd e.g. do this:

```r
my_report <- function(start, end) {
  rmarkdown::render("my_report.Rmd", params = list(
    start = start,
    end = end
  ))
}
```

This requires a pending PR in knitr: https://github.com/yihui/knitr/pull/997