### PR TITLE
Make sure yaml::yaml.load() marks character output as UTF-8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ rmarkdown 0.6 (under development)
 
 * Fix issues related to use of non-ASCII characters in ioslides_presentation
 
+* Non-ASCII characters in the YAML data are not marked with the UTF-8 encoding
+  when they are read into R, so character strings in `rmarkdown::metadata` may
+  be displayed incorrectly (#420)
+
 * Various improvements to tufte_handout format
 
 

--- a/R/draft.R
+++ b/R/draft.R
@@ -85,7 +85,7 @@ draft <- function(file,
   if (!file.exists(template_yaml)) {
     stop("No template.yaml file found for template '", template, "'")
   }
-  template_meta <- yaml::yaml.load_file(template_yaml)
+  template_meta <- yaml_load_file_utf8(template_yaml)
   if (is.null(template_meta$name) || is.null(template_meta$description)) {
     stop("template.yaml must contain name and description fields")
   }

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -329,7 +329,7 @@ output_format_from_yaml_front_matter <- function(input_lines,
 
   # parse common _output.yaml if we have it
   if (file.exists("_output.yaml"))
-    common_output_format_yaml <- yaml::yaml.load_file("_output.yaml")
+    common_output_format_yaml <- yaml_load_file_utf8("_output.yaml")
   else
     common_output_format_yaml <- list()
 
@@ -447,7 +447,7 @@ enumerate_output_formats <- function(input, envir, encoding) {
   # read any _output.yaml
   output_yaml <- file.path(dirname(input), "_output.yaml")
   if (file.exists(output_yaml))
-    common_output_format_yaml <- yaml::yaml.load_file(output_yaml)
+    common_output_format_yaml <- yaml_load_file_utf8(output_yaml)
   else
     common_output_format_yaml <- list()
 
@@ -485,7 +485,7 @@ parse_yaml_front_matter <- function(input_lines) {
       front_matter <- front_matter[2:(length(front_matter)-1)]
       front_matter <- paste(front_matter, collapse="\n")
       validate_front_matter(front_matter)
-      parsed_yaml <- yaml::yaml.load(front_matter)
+      parsed_yaml <- yaml_load_utf8(front_matter)
       if (is.list(parsed_yaml))
         parsed_yaml
       else

--- a/R/render.R
+++ b/R/render.R
@@ -251,7 +251,7 @@ render <- function(input,
         stop("knitr >= 1.10 required to use rmarkdown params")
       
       # read the default parameters and extract them into a named list
-      knit_params <- knitr::knit_params(input_lines)
+      knit_params <- mark_utf8(knitr::knit_params(input_lines))
       default_params <- list()
       for (param in knit_params)
         default_params[[param$name]] <- param$value

--- a/R/render.R
+++ b/R/render.R
@@ -247,8 +247,8 @@ render <- function(input,
     if (!is.null(yaml_front_matter$params)) {
       
       # check for recent enough knitr
-      if (packageVersion("knitr") < "1.9.18")
-        stop("knitr >= 1.9.18 required to use rmarkdown params")
+      if (packageVersion("knitr") < "1.10")
+        stop("knitr >= 1.10 required to use rmarkdown params")
       
       # read the default parameters and extract them into a named list
       knit_params <- knitr::knit_params(input_lines)

--- a/R/util.R
+++ b/R/util.R
@@ -67,6 +67,26 @@ read_lines_utf8 <- function(file, encoding) {
     lines
 }
 
+# mark the encoding of character vectors as UTF-8
+mark_utf8 <- function(x) {
+  if (is.character(x)) {
+    Encoding(x) <- 'UTF-8'
+    return(x)
+  }
+  if (is.list(x)) {
+    lapply(x, mark_utf8)
+  } else x
+}
+
+# TODO: remove this when fixed upstream https://github.com/viking/r-yaml/issues/6
+yaml_load_utf8 <- function(...) {
+  mark_utf8(yaml::yaml.load(...))
+}
+
+yaml_load_file_utf8 <- function(...) {
+  mark_utf8(yaml::yaml.load_file(...))
+}
+
 file_name_without_shell_chars <- function(file) {
   name <- gsub(.shell_chars_regex, '_', basename(file))
   dir <- dirname(file)

--- a/R/util.R
+++ b/R/util.R
@@ -79,12 +79,12 @@ mark_utf8 <- function(x) {
 }
 
 # TODO: remove this when fixed upstream https://github.com/viking/r-yaml/issues/6
-yaml_load_utf8 <- function(...) {
-  mark_utf8(yaml::yaml.load(...))
+yaml_load_utf8 <- function(string, ...) {
+  mark_utf8(yaml::yaml.load(enc2utf8(string), ...))
 }
 
-yaml_load_file_utf8 <- function(...) {
-  mark_utf8(yaml::yaml.load_file(...))
+yaml_load_file_utf8 <- function(input, ...) {
+  yaml_load_utf8(readLines(input, encoding = 'UTF-8'), ...)
 }
 
 file_name_without_shell_chars <- function(file) {

--- a/R/util.R
+++ b/R/util.R
@@ -80,6 +80,7 @@ mark_utf8 <- function(x) {
 
 # TODO: remove this when fixed upstream https://github.com/viking/r-yaml/issues/6
 yaml_load_utf8 <- function(string, ...) {
+  string <- paste(string, collapse = '\n')
   mark_utf8(yaml::yaml.load(enc2utf8(string), ...))
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -64,7 +64,7 @@ read_lines_utf8 <- function(file, encoding) {
   if (!identical(encoding, "UTF-8"))
     iconv(lines, from = encoding, to = "UTF-8")
   else
-    lines
+    mark_utf8(lines)
 }
 
 # mark the encoding of character vectors as UTF-8


### PR DESCRIPTION
I used a function `mark_utf8()` to mark all character strings as UTF-8 recursively if `yaml.load()` returns a list.