### PR TITLE
preserve the attributes of lists while marking characters as UTF-8

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -73,9 +73,11 @@ mark_utf8 <- function(x) {
     Encoding(x) <- 'UTF-8'
     return(x)
   }
-  if (is.list(x)) {
-    lapply(x, mark_utf8)
-  } else x
+  if (!is.list(x)) return(x)
+  attrs <- attributes(x)
+  res <- lapply(x, mark_utf8)
+  attributes(res) <- attrs
+  res
 }
 
 # TODO: remove this when fixed upstream https://github.com/viking/r-yaml/issues/6


### PR DESCRIPTION
e.g. this test will be broken if we don't preserve attributes: https://github.com/yihui/knitr/blob/master/tests/testit/test-params.R#L75 because `attr(, 'type')` of `params$file2` will be lost during `lapply()`

( :+1: kudos to the tests written by JJ :)