### PR TITLE
when extensions = NULL, grepl() returns logical(0), hence if() fails

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -255,7 +255,7 @@ rmarkdown_format <- function(extensions = NULL) {
   # only add extensions if the user hasn't already specified
   # a manual override for them
   addExtension <- function(extension) {
-    if (!grepl(extension, extensions))
+    if (length(grep(extension, extensions)) == 0)
       format <<- c(format, paste0("+", extension))
   }
   


### PR DESCRIPTION
use `length(grep()) == 0` instead of `!grepl()` since the former considers both cases: 1) no match; 2) length zero arguments