### PR TITLE
Fix path issues with self-contained documents

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -141,7 +141,7 @@ html_document_base <- function(smart = TRUE,
         dir.create(dirname(dest), recursive = TRUE)
       
       # copy and remember to clean up this file later
-      file.copy(file.path(source_dir), dest)
+      file.copy(file.path(source_dir, res$path), dest)
       intermediates <<- c(intermediates, dest)
     })
     

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -110,6 +110,44 @@ html_document_base <- function(smart = TRUE,
 
     args
   }
+  
+  intermediates_generator <- function(original_input, encoding, 
+                                      intermediates_dir) {
+    intermediates <- c()
+    
+    # we only need to generate resources into the intermediates folder if we're 
+    # rendering a self-contained document (so pandoc needs access to the
+    # resources during render) and the document's being rendered in an
+    # intermediate folder (so those resources will not be alongside the input
+    # document)
+    if (!self_contained || missing(intermediates_dir) || 
+        is.null(intermediates_dir) || intermediates_dir == ".")
+    {
+      return(intermediates)
+    }
+    
+    # extract all the resources used by the input file; note that this actually 
+    # runs another (non-knitting) render, and that recursion is avoided because 
+    # we explicitly render with self-contained = FALSE while discovering
+    # resources
+    resources <- find_external_resources(original_input, encoding)
+    dest_dir <- normalizePath(intermediates_dir)
+    source_dir <- dirname(normalizePath(original_input))
+    by(resources, seq_len(nrow(resources)), function(res) {
+      # compute the new path to this file in the intermediates folder, and 
+      # create the hosting folder if it doesn't exist
+      dest <- file.path(dest_dir, res$path)
+      if (!file.exists(dirname(dest))) 
+        dir.create(dirname(dest), recursive = TRUE)
+      
+      # copy and remember to clean up this file later
+      file.copy(file.path(source_dir), dest)
+      intermediates <<- c(intermediates, dest)
+    })
+    
+    # return the list of files we generated
+    intermediates
+  }
 
   post_processor <- function(metadata, input_file, output_file, clean, verbose) {
     # if there are no preserved chunks to restore and no resource to copy then no
@@ -239,6 +277,7 @@ html_document_base <- function(smart = TRUE,
     keep_md = FALSE,
     clean_supporting = FALSE,
     pre_processor = pre_processor,
+    intermediates_generator = intermediates_generator,
     post_processor = post_processor
   )
 }

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -131,8 +131,8 @@ html_document_base <- function(smart = TRUE,
     # we explicitly render with self-contained = FALSE while discovering
     # resources
     resources <- find_external_resources(original_input, encoding)
-    dest_dir <- normalizePath(intermediates_dir)
-    source_dir <- dirname(normalizePath(original_input))
+    dest_dir <- normalizePath(intermediates_dir, winslash = "/")
+    source_dir <- dirname(normalizePath(original_input, winslash = "/"))
     by(resources, seq_len(nrow(resources)), function(res) {
       # compute the new path to this file in the intermediates folder, and 
       # create the hosting folder if it doesn't exist

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -14,7 +14,13 @@
 #'   \code{\link{render_supporting_files}}
 #' @param pre_processor An optional pre-processor function that receives the
 #'   \code{metadata}, \code{input_file}, \code{runtime}, \code{knit_meta},
-#'   and \code{files_dir} and can return additional arguments to pass to pandoc.
+#'   \code{files_dir}, and \code{output_dir} and can return additional arguments 
+#'   to pass to pandoc.
+#' @param intermediates_generator An optional function that receives the 
+#'   original \code{input_file}, its \code{encoding}, and the intermediates
+#'   directory (i.e. the \code{intermediates_dir} argument to
+#'   \code{\link{render}}). The function should generate and return the names of
+#'   any intermediate files required to render the \code{input_file}.
 #' @param post_processor An optional post-processor function that receives the
 #'   \code{metadata}, \code{input_file}, \code{output_file}, \code{clean},
 #'   and \code{verbose} parmaeters, and can return an alternative
@@ -38,6 +44,7 @@ output_format <- function(knitr,
                           keep_md = FALSE,
                           clean_supporting = TRUE,
                           pre_processor = NULL,
+                          intermediates_generator = NULL,
                           post_processor = NULL,
                           base_format = NULL) {
   format <- structure(list(knitr = knitr,
@@ -45,6 +52,7 @@ output_format <- function(knitr,
                  keep_md = keep_md,
                  clean_supporting = clean_supporting && !keep_md,
                  pre_processor = pre_processor,
+                 intermediates_generator = intermediates_generator,
                  post_processor = post_processor),
             class = "rmarkdown_output_format")
 
@@ -92,7 +100,7 @@ merge_post_processors <- function (base, overlay) {
 }
 
 # merges two output formats
-merge_output_formats <- function (base, overlay)  {
+merge_output_formats <- function(base, overlay)  {
   structure(list(
     knitr = merge_lists(base$knitr, overlay$knitr),
     pandoc = pandoc_options(
@@ -105,6 +113,9 @@ merge_output_formats <- function (base, overlay)  {
       merge_scalar(base$clean_supporting, overlay$clean_supporting),
     pre_processor =
       merge_function_outputs(base$pre_processor, overlay$pre_processor, c),
+    intermediates_generator = 
+      merge_function_outputs(base$intermediates_generator, 
+                             overlay$intermediates_generator, c),
     post_processor =
       merge_post_processors(base$post_processor, overlay$post_processor)
   ), class = "rmarkdown_output_format")

--- a/R/render.R
+++ b/R/render.R
@@ -81,9 +81,17 @@ render <- function(input,
       file.path(intermediates_dir, file)
   }
   
+  # resolve output directory before we change the working directory in 
+  # preparation for rendering the document
+  if (!is.null(output_dir)) {
+    if (!dir_exists(output_dir))
+      dir.create(output_dir, recursive = TRUE)
+    output_dir <- normalizePath(output_dir, winslash = "/")
+  }
+  
   # remember the name of the original input document (we overwrite 'input' once
   # we've knitted)
-  original_input <- input
+  original_input <- normalizePath(input, winslash = "/")
 
   # if the input file has shell characters in its name then make a copy that
   # doesn't have shell characters
@@ -172,8 +180,6 @@ render <- function(input,
 
   # if an output_dir was specified then concatenate it with the output file
   if (!is.null(output_dir)) {
-    if (!dir_exists(output_dir))
-      dir.create(output_dir)
     output_file <- file.path(output_dir, basename(output_file))
   }
   output_dir <- dirname(output_file)
@@ -424,8 +430,9 @@ render <- function(input,
                                                 clean,
                                                 !quiet)
 
-  if (!quiet)
-    message("\nOutput created: ", output_file)
+  if (!quiet) {
+    message("\nOutput created: ", relative_to(oldwd, output_file))
+  }
 
   perf_timer_stop("post-processor")
 

--- a/R/render.R
+++ b/R/render.R
@@ -399,6 +399,15 @@ render <- function(input,
                  run_citeproc,
                  output_format$pandoc$args,
                  !quiet)
+  
+  # pandoc writes the output alongside the input, so if we rendered from an 
+  # intermediate directory, move the output file
+  if (!is.null(intermediates_dir)) {
+    intermediate_output <- file.path(intermediates_dir, basename(output_file))
+    if (file.exists(intermediate_output)) {
+      file.rename(intermediate_output, output_file)
+    }
+  }
 
   perf_timer_stop("pandoc")
 

--- a/R/render.R
+++ b/R/render.R
@@ -69,8 +69,11 @@ render <- function(input,
   on.exit(if (clean) unlink(intermediates, recursive = TRUE), add = TRUE)
 
   # ensure we have a directory to store intermediates
-  if (!is.null(intermediates_dir) && !dir_exists(intermediates_dir))
-    dir.create(intermediates_dir)
+  if (!is.null(intermediates_dir)) {
+    if (!dir_exists(intermediates_dir))
+      dir.create(intermediates_dir, recursive = TRUE)
+    intermediates_dir <- normalizePath(intermediates_dir, winslash = "/")
+  } 
   intermediates_loc <- function(file) {
     if (is.null(intermediates_dir))
       file

--- a/R/render.R
+++ b/R/render.R
@@ -77,6 +77,10 @@ render <- function(input,
     else
       file.path(intermediates_dir, file)
   }
+  
+  # remember the name of the original input document (we overwrite 'input' once
+  # we've knitted)
+  original_input <- input
 
   # if the input file has shell characters in its name then make a copy that
   # doesn't have shell characters
@@ -354,6 +358,14 @@ render <- function(input,
                                               files_dir,
                                               output_dir)
     output_format$pandoc$args <- c(output_format$pandoc$args, extra_args)
+  }
+  
+  # call any intermediate files generator
+  if (!is.null(output_format$intermediates_generator)) {
+    intermediates <- c(intermediates, 
+                       output_format$intermediates_generator(original_input, 
+                                                             encoding, 
+                                                             intermediates_dir))
   }
 
   perf_timer_stop("pre-processor")

--- a/man/output_format.Rd
+++ b/man/output_format.Rd
@@ -5,7 +5,8 @@
 \title{Define an R Markdown output format}
 \usage{
 output_format(knitr, pandoc, keep_md = FALSE, clean_supporting = TRUE,
-  pre_processor = NULL, post_processor = NULL, base_format = NULL)
+  pre_processor = NULL, intermediates_generator = NULL,
+  post_processor = NULL, base_format = NULL)
 }
 \arguments{
 \item{knitr}{Knitr options for an output format (see
@@ -23,7 +24,14 @@ if this is \code{TRUE} then \code{clean_supporting} will always be
 
 \item{pre_processor}{An optional pre-processor function that receives the
 \code{metadata}, \code{input_file}, \code{runtime}, \code{knit_meta},
-and \code{files_dir} and can return additional arguments to pass to pandoc.}
+\code{files_dir}, and \code{output_dir} and can return additional arguments
+to pass to pandoc.}
+
+\item{intermediates_generator}{An optional function that receives the
+original \code{input_file}, its \code{encoding}, and the intermediates
+directory (i.e. the \code{intermediates_dir} argument to
+\code{\link{render}}). The function should generate and return the names of
+any intermediate files required to render the \code{input_file}.}
 
 \item{post_processor}{An optional post-processor function that receives the
 \code{metadata}, \code{input_file}, \code{output_file}, \code{clean},


### PR DESCRIPTION
This change fixes #429 by copying a document's supporting resources to the intermediates folder prior to invoking Pandoc, when the following are both true:

- The document is self-contained.
- The intermediates folder has been explicitly specified.

It also fixes #286, and by extension #130, by resolving `intermediates_dir` and `output_dir` before changing the working directory. 

There are two possible breaking changes here:

- `output_format` now has a new argument (`intermediates_generator`), which I've placed in the arg list between pre- and post-processors. I think this is the most logical place for it since that's when it runs, but if there's any existing third-party usage of `output_format` that uses positional args and supplies pre- and post-processors, it will break. If we think this might be the case I'll move the new arg to the end.

- `intermediates_dir` and `output_dir` are now resolved against the current working directory when calling `::render`, not the directory in which the input file resides. Obviously several people think the old behavior was a bug (and it is counter-intuitive) but it's possible that third-party code somewhere relies on it. 