### PR TITLE
Add support for discovering resources in PDF-producing R Markdown documents

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -279,6 +279,13 @@ discover_rmd_resources <- function(rmd_file, encoding,
     })
   }
   
+  # check for bibliography and csl files at the top level 
+  for (bibfile in c("bibliography", "csl")) {
+    if (!is.null(front_matter[[bibfile]])) {
+      discover_render_resource(front_matter[[bibfile]])  
+    }
+  }
+  
   # check for knitr child documents in R Markdown documents
   if (tolower(tools::file_ext(rmd_file)) == "rmd") {
     chunk_lines <- gregexpr(knitr::all_patterns$md$chunk.begin, rmd_content,

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -307,7 +307,19 @@ discover_rmd_resources <- function(rmd_file, encoding,
  
   # render "raw" markdown to HTML
   html_file <- tempfile(fileext = ".html")
+  
+  # check to see what format this document is going to render as; if it's a 
+  # format that produces HTML, let it render as-is, but if it isn't, render as
+  # html_document to pick up dependencies
+  output_format <- output_format_from_yaml_front_matter(rmd_content)
+  output_format_function <- eval(parse(text = output_format$name))
+  override_output_format <- if (output_format_function()$pandoc$to == "html")
+                              NULL
+                            else
+                              "html_document"
+
   render(input = md_file, output_file = html_file, 
+         output_format = override_output_format,
          output_options = list(self_contained = FALSE), quiet = TRUE,
          encoding = "UTF-8")
   

--- a/tests/testthat/resources/empty.csl
+++ b/tests/testthat/resources/empty.csl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
+  <info>
+  </info>
+  <citation>
+    <layout>
+    </layout>
+  </citation>
+</style>

--- a/tests/testthat/resources/pdf.Rmd
+++ b/tests/testthat/resources/pdf.Rmd
@@ -1,0 +1,8 @@
+---
+output: pdf_document
+bibliography: empty.bib
+csl: empty.csl
+---
+
+![empty](empty.png)
+

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -53,3 +53,21 @@ test_that("Vanilla Markdown resource discovery finds expected resources", {
   expect_equal(resources, expected)
 })
 
+
+test_that("PDF-specific resources are discovered", {
+  
+  skip_on_cran()
+  
+  resources <- find_external_resources("resources/pdf.Rmd")
+  expected <- data.frame(
+    path = c("empty.bib", "empty.csl", "empty.png"),
+    explicit = c(FALSE, FALSE, FALSE),
+    web      = c(FALSE, FALSE, TRUE ),
+    stringsAsFactors = FALSE)
+  
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
+  expect_equal(resources, expected)
+})
+
+


### PR DESCRIPTION
This change adds the minimal support needed to discover resources in R Markdown documents which produce PDF output by default:

1. When rendering from Markdown to HTML in preparation for resource discovery, the output format is forced to `html_document` if it's not already an HTML-producing format
2. The `bibliography` and `csl` entries in the YAML header are now included in the list of discovered dependencies (presuming they point to real files)
