### PR TITLE
Copy bibliographies and supporting intermediates for PDFs

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -113,40 +113,10 @@ html_document_base <- function(smart = TRUE,
   
   intermediates_generator <- function(original_input, encoding, 
                                       intermediates_dir) {
-    intermediates <- c()
-    
-    # we only need to generate resources into the intermediates folder if we're 
-    # rendering a self-contained document (so pandoc needs access to the
-    # resources during render) and the document's being rendered in an
-    # intermediate folder (so those resources will not be alongside the input
-    # document)
-    if (!self_contained || missing(intermediates_dir) || 
-        is.null(intermediates_dir) || intermediates_dir == ".")
-    {
-      return(intermediates)
-    }
-    
-    # extract all the resources used by the input file; note that this actually 
-    # runs another (non-knitting) render, and that recursion is avoided because 
-    # we explicitly render with self-contained = FALSE while discovering
-    # resources
-    resources <- find_external_resources(original_input, encoding)
-    dest_dir <- normalizePath(intermediates_dir, winslash = "/")
-    source_dir <- dirname(normalizePath(original_input, winslash = "/"))
-    by(resources, seq_len(nrow(resources)), function(res) {
-      # compute the new path to this file in the intermediates folder, and 
-      # create the hosting folder if it doesn't exist
-      dest <- file.path(dest_dir, res$path)
-      if (!file.exists(dirname(dest))) 
-        dir.create(dirname(dest), recursive = TRUE)
-      
-      # copy and remember to clean up this file later
-      file.copy(file.path(source_dir, res$path), dest)
-      intermediates <<- c(intermediates, dest)
-    })
-    
-    # return the list of files we generated
-    intermediates
+    # copy intermediates; skip web resources if not self contained (pandoc can
+    # create references to web resources without the file present)
+    return(copy_render_intermediates(original_input, encoding, 
+                                     intermediates_dir, !self_contained))
   }
 
   post_processor <- function(metadata, input_file, output_file, clean, verbose) {

--- a/R/render.R
+++ b/R/render.R
@@ -369,8 +369,9 @@ render <- function(input,
     output_format$pandoc$args <- c(output_format$pandoc$args, extra_args)
   }
   
-  # call any intermediate files generator
-  if (!is.null(output_format$intermediates_generator)) {
+  # call any intermediate files generator, if we have an intermediates directory
+  if (!is.null(intermediates_dir) &&
+      !is.null(output_format$intermediates_generator)) {
     intermediates <- c(intermediates, 
                        output_format$intermediates_generator(original_input, 
                                                              encoding, 
@@ -386,7 +387,7 @@ render <- function(input,
     output_format$pandoc$args <- c(output_format$pandoc$args,
       rbind("--bibliography", pandoc_path_arg(yaml_front_matter$bibliography)))
   }
-
+  
   perf_timer_start("pandoc")
 
   # run intermediate conversion if it's been specified


### PR DESCRIPTION
This change addresses a number of outstanding issues with `intermediates_dir`, in particular:

#290, #430: **When a document uses a bibliography, it doesn't work with `runtime: shiny`.**

The problem here is that `runtime: shiny` renders to an intermediate directory, but the bibliography isn't copied there. The fix is just to always do resource discovery when an intermediate directory is supplied; due to recent changes (i.e. https://github.com/rstudio/rmarkdown/commit/c100529a62fb967ab531cbc034839e4802427241) the bibliography (and any accompanying CSL files) are discovered and copied with other resources. 

#438: **When a PDF file references content in Markdown, it doesn't render with `intermediates_dir`**

It appears that PDFs haven't ever really worked with `intermediates_dir`, so this change addresses that:

1. The PDF's auto-discovered resources (including bibliography files and Markdown references) are copied to the intermediates folder (when one is supplied). 
2. The PDF's runtime-generated supporting files (i.e. figures) are copied to the intermediates folder (when one is supplied).

This is mostly done by re-using the intermediate generation logic we use for self-contained HTML documents, which have many of the same requirements.
