### PR TITLE
Ignore "." and ".." dirs when discovering resources

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -78,6 +78,7 @@ find_external_resources <- function(input_file,
   discover_single_resource <- function(path, explicit, web) {
     if (is.character(path) && 
         length(path) == 1 && 
+        path != "." && path != ".." && 
         file.exists(file.path(input_dir, path))) {
       discovered_resources <<- rbind(discovered_resources, data.frame(
         path = path, 

--- a/tests/testthat/resources/period.Rmd
+++ b/tests/testthat/resources/period.Rmd
@@ -1,0 +1,10 @@
+---
+output: html_document
+---
+
+<a href=".">this dir</a>
+
+```{r}
+'.', '..'
+```
+

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -71,3 +71,9 @@ test_that("PDF-specific resources are discovered", {
 })
 
 
+test_that("bare relative directory references are ignored", {
+  skip_on_cran()
+  
+  resources <- find_external_resources("resources/period.Rmd")
+  expect_equal(nrow(resources), 0)
+})


### PR DESCRIPTION
As part of resource discovery, we look for strings in R code and test to see if they correspond to actual objects on disk. If they do, we include them in the resource bundle. This is designed to catch filenames passed as arguments to R functions, e.g.:

    read.csv("data/pop.csv", ...)

This change causes the strings "." and ".." to be omitted from the discovered resource set -- though they are indeed strings that correspond to objects on disk, they aren't likely to be resource references and shouldn't be emitted as dependencies. 