### PR TITLE
Allow YAML blocks to end with periods

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -520,7 +520,9 @@ validate_front_matter <- function(front_matter) {
 partition_yaml_front_matter <- function(input_lines) {
 
   validate_front_matter <- function(delimiters) {
-    if (length(delimiters) >= 2 && (delimiters[2] - delimiters[1] > 1)) {
+    if (length(delimiters) >= 2 &&
+        (delimiters[2] - delimiters[1] > 1) &&
+        grepl("^---\\s*$", input_lines[delimiters[1]])) {
       # verify that it's truly front matter (not preceded by other content)
       if (delimiters[1] == 1)
         TRUE
@@ -532,7 +534,7 @@ partition_yaml_front_matter <- function(input_lines) {
   }
 
   # is there yaml front matter?
-  delimiters <- grep("^---\\s*$", input_lines)
+  delimiters <- grep("^(---|\\.\\.\\.)\\s*$", input_lines)
   if (validate_front_matter(delimiters)) {
 
     front_matter <- input_lines[(delimiters[1]):(delimiters[2])]


### PR DESCRIPTION
YAML blocks can end with `...` when closing ([Ref](http://www.yaml.org/spec/1.2/spec.html#id2760395)).  While Jekyll ends blocks with `---`, pandoc prefers `...`.  This change allow header blocks to end with either.  This means that rmarkdown will parse markdown files generated by pandoc (via `pandoc -t markdown -s`, which retains header metadata), and pandoc will parse *.Rmd files and retain their metadata.