### PR TITLE
Look for dependencies recursively in .R files referenced in .Rmd files

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -80,6 +80,11 @@ find_external_resources <- function(input_file,
         length(path) == 1 && 
         path != "." && path != ".." && 
         file.exists(file.path(input_dir, path))) {
+      if (tolower(tools::file_ext(file.path(input_dir, path))) == "r") {
+        # if this is a .R script, look for resources it contains, too
+        discover_r_resources(file.path(input_dir, path), 
+                             discover_single_resource)
+      }
       discovered_resources <<- rbind(discovered_resources, data.frame(
         path = path, 
         explicit = explicit, 
@@ -359,24 +364,29 @@ discover_rmd_resources <- function(rmd_file, encoding,
     knitr::purl(md_file, output = r_file, quiet = TRUE, documentation = 0,
                 encoding = "UTF-8")
     temp_files <- c(temp_files, r_file)
-    r_lines <- readLines(r_file, warn = FALSE, encoding = "UTF-8") 
+    discover_r_resources(r_file, discover_single_resource)
+  }
+}
+
+discover_r_resources <- function(r_file, discover_single_resource) {
+  # read the lines from the R file 
+  r_lines <- readLines(r_file, warn = FALSE, encoding = "UTF-8") 
+  
+  # clean comments from the R code (simply; consider: # inside strings)
+  r_lines <- sub("#.*$", "", r_lines)
     
-    # clean comments from the R code (simply; consider: # inside strings)
-    r_lines <- sub("#.*$", "", r_lines)
-      
-    # find quoted strings in the code and attempt to ascertain whether they are
-    # files on disk
-    r_lines <- paste(r_lines, collapse = "\n")
-    quoted_strs <- Reduce(c, lapply(c("\"[^\"]+\"", "'[^']+'"), function(pat) {
-      matches <- unlist(regmatches(r_lines, gregexpr(pat, r_lines)))
-      substr(matches, 2, nchar(matches) - 1)
-    }))
-    
-    # consider any quoted string containing a valid relative path to a file that 
-    # exists on disk to be a reference
-    for (quoted_str in quoted_strs) {
-      discover_single_resource(quoted_str, FALSE, is_web_file(quoted_str))
-    }
+  # find quoted strings in the code and attempt to ascertain whether they are
+  # files on disk
+  r_lines <- paste(r_lines, collapse = "\n")
+  quoted_strs <- Reduce(c, lapply(c("\"[^\"]+\"", "'[^']+'"), function(pat) {
+    matches <- unlist(regmatches(r_lines, gregexpr(pat, r_lines)))
+    substr(matches, 2, nchar(matches) - 1)
+  }))
+  
+  # consider any quoted string containing a valid relative path to a file that 
+  # exists on disk to be a reference
+  for (quoted_str in quoted_strs) {
+    discover_single_resource(quoted_str, FALSE, is_web_file(quoted_str))
   }
 }
 

--- a/tests/testthat/resources/readcsv-source.R
+++ b/tests/testthat/resources/readcsv-source.R
@@ -1,0 +1,2 @@
+
+source("readcsv.R")

--- a/tests/testthat/resources/readcsv.R
+++ b/tests/testthat/resources/readcsv.R
@@ -1,0 +1,2 @@
+
+read.csv("empty.csv")

--- a/tests/testthat/resources/readcsv.Rmd
+++ b/tests/testthat/resources/readcsv.Rmd
@@ -1,0 +1,5 @@
+
+```{r}
+source("readcsv-source.R")
+```
+

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -77,3 +77,19 @@ test_that("bare relative directory references are ignored", {
   resources <- find_external_resources("resources/period.Rmd")
   expect_equal(nrow(resources), 0)
 })
+
+
+test_that("dependencies in .R files are recursively discovered", {
+  skip_on_cran()
+  
+  resources <- find_external_resources("resources/readcsv.Rmd")
+  expected <- data.frame(
+    path = c("empty.csv", "readcsv.R", "readcsv-source.R"),
+    explicit = c(FALSE, FALSE, FALSE),
+    web      = c(FALSE, FALSE, FALSE),
+    stringsAsFactors = FALSE)
+  
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
+  expect_equal(resources, expected)
+})


### PR DESCRIPTION
This fixes an issue reported a couple of weeks ago by @tareefk; in his case, he was sourcing a `.R` file from an `.Rmd` file, and found that dependencies in that `.R` file did not get picked up automatically. 

Works:

    ```{r}
    read.csv("foo.csv")
    ```

Doesn't work:

    ```{r}
    source("foo.R")
    ```

    # foo.R
    read.csv("foo.csv")
    
This change adds support for this scenario by scanning R files to see if they reference any resources before adding them to the resource list (recursively, so the R file may itself source other R files). 