### PR TITLE
always emit a named list

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -175,6 +175,13 @@ params_configurable <- function(param) {
   length(param$value) <= 1 && !is.null(params_get_control(param))
 }
 
+# Returns a new empty named list.
+params_namedList <- function() {
+  empty <- list()
+  names(empty) <- character()
+  empty
+}
+
 #' Run a shiny application asking for parameter configuration for the given document.
 #'
 #' @param file Path to the R Markdown document with configurable parameters.
@@ -217,10 +224,10 @@ knit_params_ask <- function(file = NULL,
     ## version.
   }
 
-  ## If we happen to not have any knit_params, just return an empty list and
-  ## don't fire up the Shiny app.
+  ## If we happen to not have any knit_params, just return an empty named list
+  ## and don't fire up the Shiny app.
   if (length(knit_params) == 0) {
-    return(list())
+    return(params_namedList())
   }
   
   configurable <- Filter(params_configurable, knit_params)
@@ -229,7 +236,7 @@ knit_params_ask <- function(file = NULL,
   ## This set of published values is the raw set that came from the user.
   ## It does not include those values that cannot be configured or are
   ## left to use the default.
-  values <- list()
+  values <- params_namedList()
 
   server <- function(input, output) {
     param.ui <- function(param) {


### PR DESCRIPTION
Returning a named list, even when empty due to a lack of parameter customization, allows for consistent downstream serialization. If we instead returned `list()`, `jsonlite::toJSON` would serialize as `[]` and not `{}`; meaning a different JSON root data structure.

https://github.com/jeroenooms/jsonlite/blob/777c7215a0d77085065d70299132287cd1392fca/R/asJSON.list.R#L38

I am playing with consuming the output from `rmarkdown::knit_params_ask` and it felt like this change would allow more consistent downstream processing. It's possible that I will throw away `length(overrides)==0` output, but if it hangs around, at least it will always serialize as a JSON map.

Are there other/better ways of accomplishing this?