### PR TITLE
Do not transform forward slashes to backslashes on Windows when self_contained=FALSE

### DIFF
--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -109,11 +109,13 @@ slidy_presentation <- function(incremental = FALSE,
 
     # slidy
     slidy_path <- rmarkdown_system_file("rmd/slidy/Slidy2")
-    if (!self_contained)
-      slidy_path <- normalized_relative_to(
+    slidy_path <- if (self_contained) {
+      pandoc_path_arg(slidy_path)
+    } else {
+      normalized_relative_to(
         output_dir, render_supporting_files(slidy_path, lib_dir))
-    args <- c(args, "--variable", paste("slidy-url=",
-                                        pandoc_path_arg(slidy_path), sep=""))
+    }
+    args <- c(args, "--variable", paste("slidy-url=", slidy_path, sep=""))
 
     # highlight
     args <- c(args, pandoc_highlight_args(highlight, default = "pygments"))


### PR DESCRIPTION
Otherwise URLs like foo_files\Slidy2/styles/slidy.css may not work in certain web browsers (such as Firefox) when the HTML output is published to a web server.

This fixes the problem reported in the email to Tareef titled "Regarding reproducible R Markdown on Windows issue" earlier today. I have tested it on Windows.