### PR TITLE
Do not inline bootstrap.min.css when not self-contained

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -10,7 +10,7 @@ html_dependency_jquery <- function()  {
 }
 
 # create an html dependency for our embedded bootstrap
-html_dependency_bootstrap <- function(theme) {
+html_dependency_bootstrap <- function(theme, self_contained) {
   
   # inline bootstrap theme b/c pandoc 1.14 base64 encoding 
   # somehow borks up reading bootstrap.min.css. it also borks
@@ -21,7 +21,7 @@ html_dependency_bootstrap <- function(theme) {
   #
   # see pandoc bug filed here: https://github.com/jgm/pandoc/issues/2224
   
-  if (pandoc_available("1.14")) {
+  if (self_contained && pandoc_available("1.14")) {
     theme_css <- rmarkdown_system_file(paste0("rmd/h/bootstrap-3.3.1/css/", 
                                               theme, ".min.css"))
     theme_style_tag <- paste(c('<style type="text/css">',

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -80,12 +80,12 @@ html_document_base <- function(smart = TRUE,
     format_deps <- append(format_deps, extra_dependencies)
     if (!is.null(theme)) {
       format_deps <- append(format_deps, list(html_dependency_jquery(),
-                                              html_dependency_bootstrap(theme)))
+                                              html_dependency_bootstrap(theme, self_contained)))
     }
     else if (isTRUE(bootstrap_compatible) && identical(runtime, "shiny")) {
       # If we can add bootstrap for Shiny, do it
       format_deps <- append(format_deps,
-                            list(html_dependency_bootstrap("bootstrap")))
+                            list(html_dependency_bootstrap("bootstrap", self_contained)))
     }
 
     extras <- html_extras_for_document(knit_meta, runtime, dependency_resolver,


### PR DESCRIPTION
There is no need to inline it when we don't want the output to be self-contained.

BTW, since the bug https://github.com/jgm/pandoc/issues/2224 seems to have been fixed, I'm wondering if we still need the workaround anyway.