### PR TITLE
Allow .R files in find_external_resources (for single-file Shiny)

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -57,7 +57,7 @@ find_external_resources <- function(input_file,
                                     encoding = getOption("encoding")) {
   # ensure we're working with valid input
   ext <- tolower(tools::file_ext(input_file))
-  if (!(ext %in% c("md", "rmd", "html", "htm"))) {
+  if (!(ext %in% c("md", "rmd", "html", "htm", "r"))) {
     stop("Resource discovery is only supported for R Markdown files or HTML ",
          "files.")
   }
@@ -132,6 +132,8 @@ find_external_resources <- function(input_file,
         web = TRUE,
         stringsAsFactors = FALSE))
     }
+  } else if (ext == "r") {
+    discover_r_resources(input_file, discover_single_resource)
   }
   
   # clean row names (they're not meaningful)

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -123,3 +123,18 @@ test_that("resource_files use cases all work", {
   expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
   expect_equal(resources, expected)
 })
+
+test_that("dependencies can be discovered on .R files directly", {
+  skip_on_cran()
+  
+  resources <- find_external_resources("resources/readcsv-source.R")
+  expected <- data.frame(
+    path = c("empty.csv", "readcsv.R"),
+    explicit = c(FALSE, FALSE),
+    web      = c(FALSE, FALSE),
+    stringsAsFactors = FALSE)
+  
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
+  expect_equal(resources, expected)
+})


### PR DESCRIPTION
This change permits `find_external_resources` to be invoked on .R files directly.

Formerly .R files could be analyzed for dependencies if e.g. `source()` was invoked on them in an R Markdown document; this change just exposes that codepath at the top level, with the goal of making it easy for the IDE to discover the dependencies of single-file Shiny applications.