### PR TITLE
Treat a single quote as a shell character requiring escaping

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -210,7 +210,7 @@ base_dir <- function(x) {
 
 # Regular expression representing characters likely to be considered special by
 # the shell (require quoting/escaping)
-.shell_chars_regex <- '[ <>()|\\:&;#?*]'
+.shell_chars_regex <- '[ <>()|\\:&;#?*\']'
 
 # Find a program within the PATH. On OSX we need to explictly call
 # /usr/bin/which with a forwarded PATH since OSX Yosemite strips


### PR DESCRIPTION
This change fixes an issue wherein a source filename containing a single quote can cause render to fail; e.g.:

    rmarkdown::render("~/Jacob's Folly.Rmd")

This seemed like the most logical place to handle the issue since it's where we handle spaces, etc. that cause a similar issue, but wasn't sure if there were implications around other Pandoc path sensitivity issues to consider here. 