### PR TITLE
Always use the graphics package for PDF output (fixes #532)

### DIFF
--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -118,6 +118,9 @@ beamer_presentation <- function(toc = FALSE,
   # content includes
   args <- c(args, includes_to_pandoc_args(includes))
 
+  # make sure the graphics package is always loaded
+  if (identical(template, "default")) args <- c(args, "--variable", "graphics=yes")
+
   # custom args
   args <- c(args, pandoc_args)
 

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -141,6 +141,9 @@ pdf_document <- function(toc = FALSE,
   # content includes
   args <- c(args, includes_to_pandoc_args(includes))
 
+  # make sure the graphics package is always loaded
+  if (identical(template, "default")) args <- c(args, "--variable", "graphics=yes")
+
   # args args
   args <- c(args, pandoc_args)
 


### PR DESCRIPTION
Also fixes #325 and #303 

This PR means we always use `\usepackage{graphics}` in the default LaTeX/beamer template. I have seen this problem more than three times, so I guess we should just fix it instead of telling them over and over again to add `graphics: yes` to YAML.