### PR TITLE
Avoid pandoc-citeproc only when --bibliography is provided

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -72,8 +72,12 @@ pandoc_convert <- function(input,
     args <- c(args, "--output", output)
 
   # citeproc filter if requested
-  if (citeproc)
+  if (citeproc) {
     args <- c(args, "--filter", pandoc_citeproc())
+    # --natbib/--biblatex conflicts with '--filter pandoc-citeproc'
+    i <- na.omit(match(c("--natbib", "--biblatex"), options))
+    if (length(i)) options <- options[-i]
+  }
 
   # set pandoc stack size
   stack_size <- getOption("pandoc.stack.size", default = "512m")

--- a/R/render.R
+++ b/R/render.R
@@ -376,7 +376,9 @@ render <- function(input,
   
   perf_timer_start("pandoc")
 
-  if (grepl('[.](pdf|tex)$', output_file)) {
+  # compile Rmd to tex when we need to generate --bibliography
+  if (grepl('[.](pdf|tex)$', output_file) &&
+      ('--bibliography' %in% output_format$pandoc$args)) {
     texfile <- file_with_ext(output_file, "tex")
     pandoc_convert(utf8_input,
                    pandoc_to,


### PR DESCRIPTION
There are two ways of writing references, i.e. use the `references` field, or `bibliography`. I forgot to consider the former case, in which the only way to process references is pandoc-citeproc.