### PR TITLE
--natbib does not work with the default beamer template

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -285,7 +285,10 @@ latexmk_emu <- function(file, engine) {
   on.exit(add = TRUE, {
     files2 <- file_with_same_base(file)
     files3 <- setdiff(files2, files1)
-    aux <- c('aux', 'log', 'bbl', 'blg', 'fls', 'out', 'lof', 'lot', 'idx', 'toc')
+    aux <- c(
+      'aux', 'log', 'bbl', 'blg', 'fls', 'out', 'lof', 'lot', 'idx', 'toc',
+      'nav', 'snm', 'vrb'
+    )
     if (keep_log) aux <- setdiff(aux, 'log')
     unlink(files3[tools::file_ext(files3) %in% aux])
   })


### PR DESCRIPTION
I discovered this issue yesterday and finally figured out the culprit: https://github.com/jgm/pandoc-templates/blob/de2e524e7df0a9d4159f2794deaa2e1847c87d46/default.beamer#L124-L140

I included the default beamer template and stripped off the problematic LaTeX commands (actually I don't see the difference with/without them).