### PR TITLE
Fixes #248: make sure to unlock the binding `metadata` before updating its value

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -299,9 +299,13 @@ render <- function(input,
     # knit environment (unless it is already defined there in which case
     # we emit a warning)
     env <- environment(render)
+    metadata_this <- env$metadata
     do.call("unlockBinding", list("metadata", env))
     on.exit({
-      env$metadata <- list()
+      if (bindingIsLocked("metadata", env)) {
+        do.call("unlockBinding", list("metadata", env))
+      }
+      env$metadata <- metadata_this
       lockBinding("metadata", env)
     }, add = TRUE)
     env$metadata <- yaml_front_matter

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -19,6 +19,9 @@ rmarkdown 0.8.3 (unreleased)
   
 * Always use the graphics package for PDF output
 
+* Fix for the error "cannot change value of locked binding for 'metadata'" when
+  one call of rmarkdown::render() is nested in another one (#248)
+
 rmarkdown 0.8.1
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
I just ran into this issue myself, and the fix looks simple enough.