### PR TITLE
don't use regexp when replacing img_src

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -230,8 +230,8 @@ html_document_base <- function(smart = TRUE,
         in_file <- utils::URLdecode(src)
         if (length(in_file) && file.exists(in_file)) {
           img_src <- sub(
-            src, utils::URLencode(relative_to(output_dir, in_file)), img_src,
-            fixed = TRUE)
+            src, utils::URLencode(normalized_relative_to(output_dir, in_file)),
+            img_src, fixed = TRUE)
         }
         img_src
       }

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -230,7 +230,8 @@ html_document_base <- function(smart = TRUE,
         in_file <- utils::URLdecode(src)
         if (length(in_file) && file.exists(in_file)) {
           img_src <- sub(
-            src, utils::URLencode(relative_to(output_dir, in_file)), img_src)
+            src, utils::URLencode(relative_to(output_dir, in_file)), img_src,
+            fixed = TRUE)
         }
         img_src
       }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -22,6 +22,10 @@ rmarkdown 0.8.3 (unreleased)
 * Fix for the error "cannot change value of locked binding for 'metadata'" when
   one call of rmarkdown::render() is nested in another one (#248)
 
+* Fix for an issue causing image paths to be rendered incorrectly in Windows
+  when rendering an `html_document` with `self_contained: false` and a path is
+  passed in argument `output_dir`. (#551)
+
 rmarkdown 0.8.1
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
`image_relative()` was using `sub()` to fix an image `src` URL but forgot the `fixed = TRUE` parameter to force the use of simple fixed string substitution.

Instead, this causes regular expression substitution to be used, which leads to all sorts of weird bugs in Windows, which uses backslashes in paths.

One particular case of note is when your image path has a directory containing only numbers in its name, this will cause a failure due to `invalid regular expression: invalid backreference` or something of that sort.