### PR TITLE
Bad UI element argument lists do not stop Shiny configuration app

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -291,8 +291,19 @@ knit_params_ask <- function(file = NULL,
       hasDefaultValue <- function(value) {
         identical(uidefault, value)
       }
-      
-      inputControl <- do.call(inputControlFn, arguments)
+
+      inputControl <- NULL
+      unsupported <- setdiff(names(arguments), inputControlFnFormals)
+      if (length(unsupported) > 0) {
+        inputControl <- shiny::div(class = "form-group",
+                                   tags$label(class="control-label",param$name), 
+                                   shiny::div(paste('Cannot customize the parameter "', param$name, '" ',
+                                                    'because the "', params_get_input(param), '" ',
+                                                    'Shiny control does not support: ', 
+                                                    paste(unsupported, collapse = ', '), sep = '')))
+      } else {
+        inputControl <- do.call(inputControlFn, arguments)
+      }
 
       showSelectControl <- NULL
       selectControl <- NULL


### PR DESCRIPTION
If a parameter block has keys that are incompatible with the input control (either inferred or explicitly chosen), note that in the UI instead of blindly running the UI builder.

![screen shot 2015-11-16 at 10 32 38 am](https://cloud.githubusercontent.com/assets/362187/11186098/1648fbfc-8c4e-11e5-8237-f4d3f0ed12ea.png)

This prevents the most likely cause for configuration app startup failures.