### PR TITLE
Retain tex source in pdf conversion when keep_tex = TRUE

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -103,10 +103,7 @@ merge_post_processors <- function (base, overlay) {
 merge_output_formats <- function(base, overlay)  {
   structure(list(
     knitr = merge_lists(base$knitr, overlay$knitr),
-    pandoc = pandoc_options(
-      to = merge_scalar(base$pandoc$to, overlay$pandoc$to),
-      from = merge_scalar(base$pandoc$from, overlay$pandoc$from),
-      args = c(base$pandoc$args, overlay$pandoc$args)),
+    pandoc = merge_lists(base$pandoc, overlay$pandoc),
     keep_md =
       merge_scalar(base$keep_md, overlay$keep_md),
     clean_supporting =

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -103,7 +103,10 @@ merge_post_processors <- function (base, overlay) {
 merge_output_formats <- function(base, overlay)  {
   structure(list(
     knitr = merge_lists(base$knitr, overlay$knitr),
-    pandoc = merge_lists(base$pandoc, overlay$pandoc),
+    pandoc = pandoc_options(
+      to = merge_scalar(base$pandoc$to, overlay$pandoc$to),
+      from = merge_scalar(base$pandoc$from, overlay$pandoc$from),
+      args = c(base$pandoc$args, overlay$pandoc$args)),
     keep_md =
       merge_scalar(base$keep_md, overlay$keep_md),
     clean_supporting =

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -106,7 +106,10 @@ merge_output_formats <- function(base, overlay)  {
     pandoc = pandoc_options(
       to = merge_scalar(base$pandoc$to, overlay$pandoc$to),
       from = merge_scalar(base$pandoc$from, overlay$pandoc$from),
-      args = c(base$pandoc$args, overlay$pandoc$args)),
+      args = c(base$pandoc$args, overlay$pandoc$args),
+      keep_tex = merge_scalar(base$pandoc$keep_tex, overlay$pandoc$keep_tex),
+      latex_engine = merge_scalar(base$pandoc$latex_engine, overlay$pandoc$latex_engine),
+      ext = merge_scalar(base$pandoc$ext, overlay$pandoc$ext)),
     keep_md =
       merge_scalar(base$keep_md, overlay$keep_md),
     clean_supporting =

--- a/R/render.R
+++ b/R/render.R
@@ -391,8 +391,10 @@ render <- function(input,
   perf_timer_start("pandoc")
 
   # compile Rmd to tex when we need to generate --bibliography
-  if (grepl('[.](pdf|tex)$', output_file) &&
-      ('--bibliography' %in% output_format$pandoc$args)) {
+  # or when keep_tex is TRUE
+  if ( (grepl('[.](pdf|tex)$', output_file) &&
+        ('--bibliography' %in% output_format$pandoc$args)) ||
+       output_format$pandoc$keep_tex ) {
     texfile <- file_with_ext(output_file, "tex")
     pandoc_convert(utf8_input,
                    pandoc_to,


### PR DESCRIPTION
Includes the fix f8a1783 for running intermediate conversion to tex when `keep_tex = TRUE`, and 49ea937 to capture and merge all pandoc options when defining or extending formats.