### PR TITLE
Fixes #555: `output_file` in render() can be a character vector when rendering multiple output formats

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -54,6 +54,10 @@ render <- function(input,
                        encoding = encoding)
       outputs <- c(outputs, output)
     }
+    if (length(output_file) > 1) {
+      file.rename(outputs, output_file)
+      outputs <- output_file
+    }
     return(invisible(outputs))
   }
 


### PR DESCRIPTION
e.g. 

```r
render(
  'foo.Rmd',
  c('html_document', 'pdf_document'),
  output_file = c('bar.html', 'bar.pdf')
)
```