### PR TITLE
Fix after #569

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -103,13 +103,7 @@ merge_post_processors <- function (base, overlay) {
 merge_output_formats <- function(base, overlay)  {
   structure(list(
     knitr = merge_lists(base$knitr, overlay$knitr),
-    pandoc = pandoc_options(
-      to = merge_scalar(base$pandoc$to, overlay$pandoc$to),
-      from = merge_scalar(base$pandoc$from, overlay$pandoc$from),
-      args = c(base$pandoc$args, overlay$pandoc$args),
-      keep_tex = merge_scalar(base$pandoc$keep_tex, overlay$pandoc$keep_tex),
-      latex_engine = merge_scalar(base$pandoc$latex_engine, overlay$pandoc$latex_engine),
-      ext = merge_scalar(base$pandoc$ext, overlay$pandoc$ext)),
+    pandoc = merge_pandoc_options(base$pandoc, overlay$pandoc),
     keep_md =
       merge_scalar(base$keep_md, overlay$keep_md),
     clean_supporting =
@@ -122,6 +116,12 @@ merge_output_formats <- function(base, overlay)  {
     post_processor =
       merge_post_processors(base$post_processor, overlay$post_processor)
   ), class = "rmarkdown_output_format")
+}
+
+merge_pandoc_options <- function(base, overlay) {
+  res <- merge_lists(base, overlay, recursive = FALSE)
+  res$args <- c(base$args, overlay$args)
+  res
 }
 
 #' Knitr options for an output format

--- a/R/render.R
+++ b/R/render.R
@@ -395,10 +395,8 @@ render <- function(input,
   perf_timer_start("pandoc")
 
   # compile Rmd to tex when we need to generate --bibliography
-  # or when keep_tex is TRUE
-  if ( (grepl('[.](pdf|tex)$', output_file) &&
-        ('--bibliography' %in% output_format$pandoc$args)) ||
-       output_format$pandoc$keep_tex ) {
+  if (grepl('[.](pdf|tex)$', output_file) &&
+      ('--bibliography' %in% output_format$pandoc$args)) {
     texfile <- file_with_ext(output_file, "tex")
     pandoc_convert(utf8_input,
                    pandoc_to,

--- a/R/render.R
+++ b/R/render.R
@@ -394,17 +394,17 @@ render <- function(input,
   
   perf_timer_start("pandoc")
 
+  convert <- function(output, citeproc = FALSE) {
+    pandoc_convert(
+      utf8_input, pandoc_to, output_format$pandoc$from, output, citeproc,
+      output_format$pandoc$args, !quiet
+    )
+  }
+  texfile <- file_with_ext(output_file, "tex")
   # compile Rmd to tex when we need to generate --bibliography
   if (grepl('[.](pdf|tex)$', output_file) &&
       ('--bibliography' %in% output_format$pandoc$args)) {
-    texfile <- file_with_ext(output_file, "tex")
-    pandoc_convert(utf8_input,
-                   pandoc_to,
-                   output_format$pandoc$from,
-                   texfile,
-                   FALSE,
-                   output_format$pandoc$args,
-                   !quiet)
+    convert(texfile)
     # manually compile tex if PDF output is expected
     if (grepl('[.]pdf$', output_file)) {
       latexmk(texfile, output_format$pandoc$latex_engine)
@@ -415,13 +415,9 @@ render <- function(input,
       on.exit(unlink(texfile), add = TRUE)
   } else {
     # run the main conversion if the output file is not .tex
-    pandoc_convert(utf8_input,
-                   pandoc_to,
-                   output_format$pandoc$from,
-                   output_file,
-                   run_citeproc,
-                   output_format$pandoc$args,
-                   !quiet)
+    convert(output_file, run_citeproc)
+    # run conversion again to .tex if we want to keep the tex source
+    if (output_format$pandoc$keep_tex) convert(texfile, run_citeproc)
   }
   
   # pandoc writes the output alongside the input, so if we rendered from an 


### PR DESCRIPTION
- simplified e4cf95e772d5f70b421cc5a342cf003ce7ec7ddb a little bit;
- included a correct fix for the bug I introduced in #536 (when `keep_tex = TRUE` and there is no `bibliography`, the intermediate tex file is not really preserved)