### PR TITLE
Adjust regex for locating quoted strings to skip ""

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -386,7 +386,7 @@ discover_r_resources <- function(r_file, discover_single_resource) {
   # find quoted strings in the code and attempt to ascertain whether they are
   # files on disk
   r_lines <- paste(r_lines, collapse = "\n")
-  quoted_strs <- Reduce(c, lapply(c("\"[^\"]+\"", "'[^']+'"), function(pat) {
+  quoted_strs <- Reduce(c, lapply(c("\"[^\"\n]*\"", "'[^'\n]*'"), function(pat) {
     matches <- unlist(regmatches(r_lines, gregexpr(pat, r_lines)))
     substr(matches, 2, nchar(matches) - 1)
   }))
@@ -394,7 +394,8 @@ discover_r_resources <- function(r_file, discover_single_resource) {
   # consider any quoted string containing a valid relative path to a file that 
   # exists on disk to be a reference
   for (quoted_str in quoted_strs) {
-    discover_single_resource(quoted_str, FALSE, is_web_file(quoted_str))
+    if (nchar(quoted_str) > 0)
+       discover_single_resource(quoted_str, FALSE, is_web_file(quoted_str))
   }
 }
 

--- a/tests/testthat/resources/quotes.Rmd
+++ b/tests/testthat/resources/quotes.Rmd
@@ -1,0 +1,14 @@
+
+Here is a filename outside an .R chunk: "empty.bib". It shouldn't be discovered.
+
+```{r}
+# this R code has a lot of strings that aren't filenames
+paste("Covariances should be a ", n, " by ", n, " matrix")
+syms <- paste("x", 1:n, sep = "")
+as.numeric(attr(eval(deriv(form, syms), envir = envir), "gradient"))
+
+# this R code has strings that are filenames
+read.csv("./empty.csv")
+read.csv('./empty.tsv')
+```
+

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -153,3 +153,18 @@ test_that("filenames with shell characters can use relative resource paths", {
   on.exit(unlink(output_file), add = TRUE)
   file.rename("resources/file exists.Rmd", "resources/file-exists.Rmd")
 })
+
+test_that("empty quoted strings don't confuse resource discovery", {
+  skip_on_cran()
+  
+  resources <- find_external_resources("resources/quotes.Rmd")
+  expected <- data.frame(
+    path = c("empty.csv", "empty.tsv"),
+    explicit = c(FALSE, FALSE),
+    web      = c(FALSE, FALSE),
+    stringsAsFactors = FALSE)
+  
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
+  expect_equal(resources, expected)
+})


### PR DESCRIPTION
This fixes a case discovered in the wild in which an empty string (i.e. `""`) can trip up the regex that looks for quoted strings in R code. It happens because the regex doesn't match `""` itself, but after finding that `""` isn't a match, begins looking for a match on the next character (the second quote). In some documents this may align with an opening quote elsewhere, which of course unbalances the quote matching.

The fix is to for the regex to consume, but ignore, empty strings in the document. 