### PR TITLE
wrap long lines of output in html_vignette CSS template

### DIFF
--- a/inst/rmarkdown/templates/html_vignette/resources/vignette.css
+++ b/inst/rmarkdown/templates/html_vignette/resources/vignette.css
@@ -112,9 +112,9 @@ pre, code {
   background-color: #f7f7f7;
   border-radius: 3px;
   color: #333;
+  white-space: pre-wrap;    /* Wrap long lines */
 }
 pre {
-  white-space: pre-wrap;    /* Wrap long lines */
   border-radius: 3px;
   margin: 5px 0px 10px 0px;
   padding: 10px;


### PR DESCRIPTION
I moved the line that takes care of wrapping long lines to also include `code` such that long output fit in the gray box. 
This behavior is more consistent with what the default html template uses (but it breaks words with `word-break: break-all; word-wrap: break-word;`)

Before:
![before](https://cloud.githubusercontent.com/assets/5502922/12429404/10cd6edc-beb8-11e5-8886-2b7f6bb2047f.png)

After:
![after](https://cloud.githubusercontent.com/assets/5502922/12429409/162fde6e-beb8-11e5-82e8-0d29d02b4a29.png)
