### PR TITLE
Extra dependencies in html_document()

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -58,8 +58,8 @@
 #'   default definition or R Markdown. See the \code{\link{rmarkdown_format}}
 #'   for additional details.
 #' @param pandoc_args Additional command line options to pass to pandoc
-#' @param ... Additional function arguments to pass to the base R Markdown HTML
-#'   output formatter
+#' @param extra_dependencies,... Additional function arguments to pass to the
+#'   base R Markdown HTML output formatter \code{\link{html_document_base}}
 #'
 #' @return R Markdown output format to pass to \code{\link{render}}
 #'
@@ -145,10 +145,8 @@ html_document <- function(toc = FALSE,
                           lib_dir = NULL,
                           md_extensions = NULL,
                           pandoc_args = NULL,
+                          extra_dependencies = NULL,
                           ...) {
-
-  # placeholder for any extra dependencies
-  extra_dependencies <- NULL
 
   # build pandoc args
   args <- c("--standalone")

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -9,6 +9,7 @@
 #' @param copy_resources Copy resources
 #' @param extra_dependencies Extra dependencies
 #' @param bootstrap_compatible Bootstrap compatible
+#' @param ... Ignored
 #'
 #' @return HTML base output format.
 #'

--- a/R/html_fragment.R
+++ b/R/html_fragment.R
@@ -16,6 +16,7 @@
 #' format.
 #'
 #' @inheritParams html_document
+#' @param ... Additional arguments passed to \code{\link{html_document}}
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @export
 html_fragment <- function(number_sections = FALSE,

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -18,6 +18,7 @@
 #' documentation} for additional details on using the \code{html_vignette} format.
 #'
 #' @inheritParams html_document
+#' @param ... Additional arguments passed to \code{\link{html_document}}
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @export
 html_vignette <- function(fig_width = 3,

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -10,7 +10,8 @@ html_document(toc = FALSE, toc_depth = 3, toc_float = FALSE,
   smart = TRUE, self_contained = TRUE, theme = "default",
   highlight = "default", mathjax = "default", template = "default",
   css = NULL, includes = NULL, keep_md = FALSE, lib_dir = NULL,
-  md_extensions = NULL, pandoc_args = NULL, ...)
+  md_extensions = NULL, pandoc_args = NULL, extra_dependencies = NULL,
+  ...)
 }
 \arguments{
 \item{toc}{\code{TRUE} to include a table of contents in the output}
@@ -90,8 +91,8 @@ for additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 
-\item{...}{Additional function arguments to pass to the base R Markdown HTML
-output formatter}
+\item{extra_dependencies, ...}{Additional function arguments to pass to the
+base R Markdown HTML output formatter \code{\link{html_document_base}}}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -52,8 +52,7 @@ section below for more details).}
 
 \item{bootstrap_compatible}{Bootstrap compatible}
 
-\item{...}{Additional function arguments to pass to the base R Markdown HTML
-output formatter}
+\item{...}{Ignored}
 }
 \value{
 HTML base output format.

--- a/man/html_fragment.Rd
+++ b/man/html_fragment.Rd
@@ -43,8 +43,7 @@ for additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 
-\item{...}{Additional function arguments to pass to the base R Markdown HTML
-output formatter}
+\item{...}{Additional arguments passed to \code{\link{html_document}}}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -16,8 +16,7 @@ html_vignette(fig_width = 3, fig_height = 3, dev = "png", css = NULL,
 
 \item{css}{One or more css files to include}
 
-\item{...}{Additional function arguments to pass to the base R Markdown HTML
-output formatter}
+\item{...}{Additional arguments passed to \code{\link{html_document}}}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -84,8 +84,8 @@ for additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 
-\item{...}{Additional function arguments to pass to the base R Markdown HTML
-output formatter}
+\item{...}{Additional function arguments to pass to the
+base R Markdown HTML output formatter \code{\link{html_document_base}}}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}


### PR DESCRIPTION
This is to fix rstudio/tufte#7. `tufte::tufte_html()` added a dependency to `html_document_base()`. This worked before #600 because `html_document()` did not use an explicit `extra_dependencies` argument when calling `html_document_base()`. Now it uses this argument to add tocify dependencies, so the tufte dependencies can no longer be passed to `html_document_base()` via `...` of `html_document()`.