### PR TITLE
Discover and copy resources inside CSS files

### DIFF
--- a/R/html_parser.R
+++ b/R/html_parser.R
@@ -70,3 +70,19 @@ call_resource_attrs <- function(html, callback = NULL)  {
     }
   }
 }
+
+# as call_resource_attrs, but for CSS
+call_css_resource_attrs <- function(css, callback = NULL)  {
+  css_encoding <- Encoding(css)
+  Encoding(css) <- "bytes"
+
+  urls <- gregexpr("url\\s*\\(\\s*['\"]?([^'\")]+)['\"]?\\s*\\)", css,
+                   perl = TRUE, useBytes = TRUE, ignore.case = TRUE)[[1]]
+  for (pos in seq_along(urls)) {
+    urlstart <- attr(urls, "capture.start", exact = TRUE)[pos,1]
+    url <- substr(css, urlstart,  urlstart +
+                    attr(urls, "capture.length", exact = TRUE)[pos,1] - 1)
+    Encoding(url) <- css_encoding
+    callback("css", "url", url, urlstart)
+  }
+}

--- a/R/html_resource_copy.R
+++ b/R/html_resource_copy.R
@@ -1,0 +1,120 @@
+# Given an HTML string, a library directory, and an output directory, copies the
+# HTML's dependencies as appropriate and rewrites the HTML to refer to those
+# files. If CSS files are among the dependencies, performs the same operation
+# on each after copying.
+copy_html_resources <- function (html_str, lib_dir, output_dir) {
+  resource_locator <- function(input_str, resource_copier) {
+    call_resource_attrs(input_str, function(node, att, src, idx) {
+      # copy the resource if needed
+      res_src <- resource_copier(node, att, src, idx)
+      if (is.null(res_src) || nchar(res_src) < 1)
+        return(NULL)
+
+      # if the resource is a CSS file, perform a similar rewriting of its
+      # content in the library directory
+      res_path <- file.path(output_dir, res_src)
+      if (identical(tolower(tools::file_ext(res_path)), "css") &&
+          file.exists(res_path)) {
+        css_content <- paste(readLines(res_path), collapse = "\n")
+        css_content <- copy_resources(css_content, lib_dir, lib_dir,
+                                      call_css_resource_attrs)
+        writeLines(css_content, res_path)
+      }
+    })
+  }
+  copy_resources(html_str, lib_dir, output_dir, resource_locator)
+}
+
+copy_resources <- function (input_str, lib_dir, output_dir, resource_locator) {
+  # ensure the lib directory exists
+  dir.create(lib_dir, recursive = TRUE, showWarnings = FALSE)
+  relative_lib <- normalized_relative_to(output_dir, lib_dir)
+
+  res_replacements <- c()
+
+  resource_copier <- function(node, att, src, idx) {
+    in_file <- utils::URLdecode(src)
+
+    # only process the file if (a) it isn't already in the library, and (b)
+    # it exists on the local file system (this also excludes external
+    # resources such as "http://foo/bar.png")
+    if (length(in_file) &&
+        substr(src, 1, nchar(lib_dir) + 1) != file.path(relative_lib, "") &&
+        file.exists(in_file)) {
+
+      # check to see if it's already in the library (by absolute path)
+      res_src <- normalized_relative_to(lib_dir, in_file)
+      if (same_path(res_src, in_file)) {
+        # not inside the library, copy it there
+        target_dir <- if (dirname(in_file) == ".")
+          lib_dir
+        else
+          file.path(lib_dir, dirname(in_file))
+        dir.create(target_dir, recursive = TRUE, showWarnings = FALSE)
+        target_res_file <- file.path(target_dir, basename(in_file))
+
+        # copy the file to the library
+        if (!file.exists(target_res_file)) {
+          file.copy(in_file, target_res_file)
+        }
+
+        if (identical(lib_dir, output_dir))
+          res_src <- in_file
+        else
+          res_src <- file.path(relative_lib, src)
+      } else {
+        # inside the library, fix up the URL
+        res_src <- file.path(relative_lib, res_src)
+      }
+
+      # replace the reference in the document and adjust the offset
+      if (!identical(src, res_src)) {
+        res_replacements <<- c(res_replacements, list(list(
+          pos = idx,
+          len = nchar(src),
+          text = res_src)))
+      }
+
+      res_src
+    }
+  }
+
+  # parse the HTML and copy the resources found
+  resource_locator(input_str, resource_copier)
+
+  # rewrite the HTML to refer to the copied resources
+  if (length(res_replacements) > 0) {
+    ch_pos <- 1
+    output_str <- ""
+
+    # we do all replacements in bytes for performance reasons--mark the
+    # output with byte encoding temporarily
+    prev_encoding <- Encoding(input_str)
+    Encoding(input_str) <- "bytes"
+    Encoding(output_str) <- "bytes"
+
+    for (res_rep in seq_along(res_replacements)) {
+      rep <- res_replacements[[res_rep]]
+
+      # the text from the last replacement to the current one
+      before <- substr(input_str, ch_pos, rep$pos - 1)
+      ch_pos <- rep$pos + rep$len
+
+      # the text from the current replacement to the end of the output,
+      # if applicable
+      after <- if (res_rep == length(res_replacements))
+        substring(input_str, ch_pos)
+      else
+        ""
+
+      # compose the next segment of the output from the text between
+      # replacements and the current replacement text
+      output_str <- paste(output_str, before, rep$text, after,
+                          sep = "")
+    }
+    input_str <- output_str
+    Encoding(input_str) <- prev_encoding
+  }
+
+  input_str
+}

--- a/tests/testthat/resources/has-css.Rmd
+++ b/tests/testthat/resources/has-css.Rmd
@@ -1,0 +1,7 @@
+---
+output: 
+  html_document:
+    css: has-image.css
+---
+
+# Hello, world.

--- a/tests/testthat/resources/has-image.css
+++ b/tests/testthat/resources/has-image.css
@@ -1,0 +1,6 @@
+/* this css file refers to an image */
+body 
+{
+    background-image: url(empty.png)
+}
+

--- a/tests/testthat/test-htmlparse.R
+++ b/tests/testthat/test-htmlparse.R
@@ -60,3 +60,19 @@ test_that("common resource types are found in a simple document", {
     stringsAsFactors = FALSE))
   reset_accumulator()
 })
+
+test_that("resources referenced in CSS files are discovered", {
+  call_css_resource_attrs(paste(
+    "body {\n",
+    "  background-image: url('foo.png');\n",
+    "}\n",
+    "p {\n",
+    "  background-image: url(bar.png), url(\"baz.png\");\n",
+    "}\n)"), html_accumulator)
+  expect_equal(accumulated, data.frame(
+    tag = c("css", "css", "css"),
+    attribute = c("url", "url", "url"),
+    value = c("foo.png", "bar.png", "baz.png"),
+    stringsAsFactors = FALSE))
+  reset_accumulator()
+})

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -181,3 +181,18 @@ test_that("empty quoted strings don't confuse resource discovery", {
   expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
   expect_equal(resources, expected)
 })
+
+test_that("resources are discovered in CSS files", {
+  skip_on_cran()
+
+  resources <- find_external_resources("resources/has-css.Rmd")
+  expected <- data.frame(
+    path = c("empty.png", "has-image.css"),
+    explicit = c(FALSE, FALSE),
+    web      = c(TRUE, TRUE),
+    stringsAsFactors = FALSE)
+
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
+  expect_equal(resources, expected)
+})


### PR DESCRIPTION
This change fixes an issue brought to my attention at the Shiny developer conference, namely that resources referred to in CSS files (via e.g. `background-image: url(...)`, `@font-face`, etc.) don't always appear in Shiny interactive documents and presentations.

The problem is one of omission--we parsed the main HTML and made sure all of its dependencies were present, but that was it. This change adds parsing for any CSS files referenced from the main HTML file, with the following result:

- Resources referenced in CSS files are now copied alongside Shiny interactive documents prior to rendering.
- When publishing content, resources referenced in CSS files are discovered and automatically included in the set of content to publish.
