### PR TITLE
Render Shiny docs in new environment (fixes #619)

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -231,7 +231,8 @@ rmarkdown_shiny_server <- function(dir, file, encoding, auto_reload, render_args
                                output_dir = dirname(output_dest),
                                output_options = output_opts,
                                intermediates_dir = dirname(output_dest),
-                               runtime = "shiny"),
+                               runtime = "shiny",
+                               envir = new.env()),
                           render_args)
       result_path <- shiny::maskReactiveContext(do.call(render, args))
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -52,6 +52,9 @@ rmarkdown 0.9.2.9001 (unreleased)
   add the extension .bib to bibliography files, e.g. it treats foo.bib as
   foo.bib.bib. (#623)
 
+* Render Shiny documents in a clean environment; fixes issue in which code in
+  Shiny documents could access internal R Markdown state
+
 rmarkdown 0.9.2
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This change fixes an issue in which statements in Shiny documents can have unintended consequences.

By default, `render()` executes chunks in the environment of its caller (i.e. the parent frame). In the case of Shiny documents, this parent frame is the Shiny document wrapper. This environment is relatively empty, but values from it could conceivably pollute the Shiny doc, and vice versa as observed in #619. 

The fix is to use a new (clean) environment when rendering Shiny documents. 