### PR TITLE
Allow knitr options to be set in html_document_base

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -9,6 +9,8 @@
 #' @param copy_resources Copy resources
 #' @param extra_dependencies Extra dependencies
 #' @param bootstrap_compatible Bootstrap compatible
+#' @param knitr Knitr options for an output format (see
+#'   \code{\link{knitr_options}})
 #' @param ... Ignored
 #'
 #' @return HTML base output format.
@@ -25,6 +27,7 @@ html_document_base <- function(smart = TRUE,
                                copy_resources = FALSE,
                                extra_dependencies = NULL,
                                bootstrap_compatible = FALSE,
+                               knitr = NULL,
                                ...) {
 
   # default for dependency_resovler
@@ -159,7 +162,7 @@ html_document_base <- function(smart = TRUE,
   }
 
   output_format(
-    knitr = NULL,
+    knitr = knitr,
     pandoc = pandoc_options(to = "html", from = NULL, args = args),
     keep_md = FALSE,
     clean_supporting = FALSE,

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -8,7 +8,7 @@ html_document_base(smart = TRUE, theme = NULL, self_contained = TRUE,
   lib_dir = NULL, mathjax = "default", pandoc_args = NULL,
   template = "default", dependency_resolver = NULL,
   copy_resources = FALSE, extra_dependencies = NULL,
-  bootstrap_compatible = FALSE, ...)
+  bootstrap_compatible = FALSE, knitr = NULL, ...)
 }
 \arguments{
 \item{smart}{Produce typographically correct output, converting straight
@@ -51,6 +51,9 @@ more details).}
 \item{extra_dependencies}{Extra dependencies}
 
 \item{bootstrap_compatible}{Bootstrap compatible}
+
+\item{knitr}{Knitr options for an output format (see
+\code{\link{knitr_options}})}
 
 \item{...}{Ignored}
 }


### PR DESCRIPTION
This change allows knitr options to be used in html
documents while keeping the dependency-detection
machinery of html_document_base. It is useful for
producing custom templates where, for instance,
custom hooks may be used to wrap outputs in html
tags.