### PR TITLE
set.seed(100) for default_site

### DIFF
--- a/R/site.R
+++ b/R/site.R
@@ -157,11 +157,13 @@ default_site <- function(input, ...) {
     sapply(files, function(x) {
       # we suppress messages so that "Output created" isn't emitted
       # (which could result in RStudio previewing the wrong file)
-      suppressMessages(
+      suppressMessages({
+        set.seed(100) # for stable html output
         rmarkdown::render(x,
                           output_format = output_format,
                           envir = envir,
-                          quiet = quiet))
+                          quiet = quiet)
+      })
     })
   }
 


### PR DESCRIPTION
In the websites we've created with rmarkdown to date we've included set.seed(100) in the website Makefile to ensure that html output doesn't constantly churn based on the random number seed (this ends up creating much messier and hard to reason about diffs).

We also include that in our rmarkdown-webstie example: https://github.com/rstudio/rmarkdown-website/blob/master/Makefile#L9

Is there any reason we can think of not to do this here?