### PR TITLE
Handles soft breaks. Resolve issue #661

### DIFF
--- a/inst/rmd/ioslides/ioslides_presentation.lua
+++ b/inst/rmd/ioslides/ioslides_presentation.lua
@@ -91,6 +91,10 @@ function LineBreak()
   return "<br/>"
 end
 
+function SoftBreak()
+  return " "
+end
+
 function Emph(s)
   return "<em>" .. s .. "</em>"
 end


### PR DESCRIPTION
Soft-breaks are added by pandoc when a new-line is found but no real
break is required, e.g. when wrapping long lines in lists.
If not handled they are rendered to empty strings, with the result of
merging the last word of a line with the first of the next one.