### PR TITLE
Add ability to set 'opts_hooks' in knitr_options()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Imports:
     tools,
     utils,
     grDevices,
-    knitr (>= 1.11),
+    knitr (>= 1.12),
     yaml (>= 2.1.5),
     htmltools (>= 0.2.4),
     caTools

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -145,6 +145,8 @@ merge_pandoc_options <- function(base, overlay) {
 #'   \code{\link[knitr:opts_chunk]{opts_chunk}})
 #' @param knit_hooks List of hooks for R code chunks, inline R code, and output
 #'   (see \code{\link[knitr:knit_hooks]{knit_hooks}})
+#' @param opts_hooks List of hooks for code chunk options
+#'   (see \code{\link[knitr:opts_hooks]{opts_hooks}})
 #' @param opts_template List of templates for chunk level knitr options (see
 #'   \code{\link[knitr:opts_template]{opts_template}})
 #'
@@ -157,10 +159,12 @@ merge_pandoc_options <- function(base, overlay) {
 knitr_options <- function(opts_knit = NULL,
                           opts_chunk = NULL,
                           knit_hooks = NULL,
+                          opts_hooks = NULL,
                           opts_template = NULL) {
   list(opts_knit = opts_knit,
        opts_chunk = opts_chunk,
        knit_hooks = knit_hooks,
+       opts_hooks = opts_hooks,
        opts_template = opts_template)
 }
 

--- a/R/render.R
+++ b/R/render.R
@@ -236,6 +236,8 @@ render <- function(input,
     on.exit(knitr::opts_chunk$restore(optc), add = TRUE)
     hooks <- knitr::knit_hooks$get()
     on.exit(knitr::knit_hooks$restore(hooks), add = TRUE)
+    ohooks <- knitr::opts_hooks$get()
+    on.exit(knitr::opts_hooks$restore(ohooks), add = TRUE)
     templates <- knitr::opts_template$get()
     on.exit(knitr::opts_template$restore(templates), add = TRUE)
 
@@ -277,6 +279,7 @@ render <- function(input,
       knitr::opts_chunk$set(as.list(output_format$knitr$opts_chunk))
       knitr::opts_template$set(as.list(output_format$knitr$opts_template))
       knitr::knit_hooks$set(as.list(output_format$knitr$knit_hooks))
+      knitr::opts_hooks$set(as.list(output_format$knitr$opts_hooks))
     }
 
     # presume that we're rendering as a static document unless specified

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,8 @@
 rmarkdown 0.9.6 (unreleased)
 --------------------------------------------------------------------------------
 
+* Ability to set `opts_hooks` in `knitr_options()` (#672)
+
 * Added `render_site` and related functions for rendering collections of
   documents within a directory as a website.
 

--- a/man/knitr_options.Rd
+++ b/man/knitr_options.Rd
@@ -5,7 +5,7 @@
 \title{Knitr options for an output format}
 \usage{
 knitr_options(opts_knit = NULL, opts_chunk = NULL, knit_hooks = NULL,
-  opts_template = NULL)
+  opts_hooks = NULL, opts_template = NULL)
 }
 \arguments{
 \item{opts_knit}{List of package level knitr options (see
@@ -16,6 +16,9 @@ knitr_options(opts_knit = NULL, opts_chunk = NULL, knit_hooks = NULL,
 
 \item{knit_hooks}{List of hooks for R code chunks, inline R code, and output
 (see \code{\link[knitr:knit_hooks]{knit_hooks}})}
+
+\item{opts_hooks}{List of hooks for code chunk options
+(see \code{\link[knitr:opts_hooks]{opts_hooks}})}
 
 \item{opts_template}{List of templates for chunk level knitr options (see
 \code{\link[knitr:opts_template]{opts_template}})}


### PR DESCRIPTION
Addresses issue https://github.com/rstudio/rmarkdown/issues/672.