### PR TITLE
add template option to ioslides_presentation

### DIFF
--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -18,8 +18,8 @@ ioslides_presentation <- function(logo = NULL,
                                   keep_md = FALSE,
                                   lib_dir = NULL,
                                   md_extensions = NULL,
-                                  pandoc_args = NULL,
                                   template = NULL,
+                                  pandoc_args = NULL,
                                   ...) {
 
   # base pandoc options for all output

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -13,12 +13,12 @@ ioslides_presentation <- function(logo = NULL,
                                   smaller = FALSE,
                                   transition = "default",
                                   mathjax = "default",
+                                  template = NULL,
                                   css = NULL,
                                   includes = NULL,
                                   keep_md = FALSE,
                                   lib_dir = NULL,
                                   md_extensions = NULL,
-                                  template = NULL,
                                   pandoc_args = NULL,
                                   ...) {
 

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -19,6 +19,7 @@ ioslides_presentation <- function(logo = NULL,
                                   lib_dir = NULL,
                                   md_extensions = NULL,
                                   pandoc_args = NULL,
+                                  template = NULL,
                                   ...) {
 
   # base pandoc options for all output
@@ -49,9 +50,12 @@ ioslides_presentation <- function(logo = NULL,
   args <- c(args, includes_to_pandoc_args(includes))
 
   # template path and assets
-  args <- c(args,
-            "--template",
-            pandoc_path_arg(rmarkdown_system_file("rmd/ioslides/default.html")))
+  if (!is.null(template) && file.exists(template))
+    args <- c(args, "--template", template)
+  else
+    args <- c(args,
+              "--template",
+              pandoc_path_arg(rmarkdown_system_file("rmd/ioslides/default.html")))
 
   # pre-processor for arguments that may depend on the name of the
   # the input file (e.g. ones that need to copy supporting files)

--- a/man/ioslides_presentation.Rd
+++ b/man/ioslides_presentation.Rd
@@ -8,9 +8,9 @@
 ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   fig_height = 4.5, fig_retina = 2, fig_caption = TRUE,
   dev = "png", smart = TRUE, self_contained = TRUE, widescreen = FALSE,
-  smaller = FALSE, transition = "default", mathjax = "default", css = NULL,
-  includes = NULL, keep_md = FALSE, lib_dir = NULL, md_extensions = NULL,
-  template = NULL, pandoc_args = NULL, ...)
+  smaller = FALSE, transition = "default", mathjax = "default", template = NULL,
+  css = NULL, includes = NULL, keep_md = FALSE, lib_dir = NULL,
+  md_extensions = NULL, pandoc_args = NULL, ...)
 }
 \arguments{
   \item{logo}{Path to file that includes a logo for use in
@@ -68,6 +68,9 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   into the output directory). You can pass an alternate URL
   or pass \code{NULL} to exclude MathJax entirely.}
 
+  \item{template}{Path to a pandoc template to use instead of
+  the default bundled template.}
+
   \item{css}{One or more css files to include}
 
   \item{includes}{Named list of additional content to
@@ -85,9 +88,6 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   \item{md_extensions}{Markdown extensions to be added or
   removed from the default definition or R Markdown. See the
   \code{\link{rmarkdown_format}} for additional details.}
-
-  \item{template}{Path to a pandoc template to use instead of
-  the default bundled template.}
 
   \item{pandoc_args}{Additional command line options to
   pass to pandoc}
@@ -386,4 +386,3 @@ To create a PDF version of a presentation you can use Print to PDF
 from Google Chrome.
 
 }
-

--- a/man/ioslides_presentation.Rd
+++ b/man/ioslides_presentation.Rd
@@ -10,7 +10,7 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   dev = "png", smart = TRUE, self_contained = TRUE, widescreen = FALSE,
   smaller = FALSE, transition = "default", mathjax = "default", css = NULL,
   includes = NULL, keep_md = FALSE, lib_dir = NULL, md_extensions = NULL,
-  pandoc_args = NULL, ...)
+  template = NULL, pandoc_args = NULL, ...)
 }
 \arguments{
   \item{logo}{Path to file that includes a logo for use in
@@ -85,6 +85,9 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   \item{md_extensions}{Markdown extensions to be added or
   removed from the default definition or R Markdown. See the
   \code{\link{rmarkdown_format}} for additional details.}
+
+  \item{template}{Path to a pandoc template to use instead of
+  the default bundled template.}
 
   \item{pandoc_args}{Additional command line options to
   pass to pandoc}


### PR DESCRIPTION
This has come up before in #460 and FWIW this achieves the result. I recognise that the slides themselves are not affected as the [Lua code handles their generation](https://github.com/rstudio/rmarkdown/issues/460#issuecomment-156434820), but there are other aspects of the template that can be altered - in my case I'm interested in the title slide. 

It would be good to see the [documentation](http://rmarkdown.rstudio.com/ioslides_presentation_format.html#custom_templates) updated to make note of this.
