### PR TITLE
ioslides_presentation Google analytics update ga.js to analytics.js

### DIFF
--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -19,6 +19,7 @@ ioslides_presentation <- function(logo = NULL,
                                   lib_dir = NULL,
                                   md_extensions = NULL,
                                   pandoc_args = NULL,
+                                  analytics = NULL,
                                   ...) {
 
   # base pandoc options for all output
@@ -52,6 +53,10 @@ ioslides_presentation <- function(logo = NULL,
   args <- c(args,
             "--template",
             pandoc_path_arg(rmarkdown_system_file("rmd/ioslides/default.html")))
+
+  # analytics
+  if(!is.null(analytics))
+    args <- c(args, '--variable', paste("analytics", analytics, sep = ':'))
 
   # pre-processor for arguments that may depend on the name of the
   # the input file (e.g. ones that need to copy supporting files)

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -13,12 +13,12 @@ ioslides_presentation <- function(logo = NULL,
                                   smaller = FALSE,
                                   transition = "default",
                                   mathjax = "default",
+                                  analytics = NULL,
                                   css = NULL,
                                   includes = NULL,
                                   keep_md = FALSE,
                                   lib_dir = NULL,
                                   md_extensions = NULL,
-                                  analytics = NULL,
                                   pandoc_args = NULL,
                                   ...) {
 
@@ -221,4 +221,3 @@ ioslides_presentation <- function(logo = NULL,
                                      pandoc_args = pandoc_args,
                                      bootstrap_compatible = TRUE, ...))
 }
-

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -18,8 +18,8 @@ ioslides_presentation <- function(logo = NULL,
                                   keep_md = FALSE,
                                   lib_dir = NULL,
                                   md_extensions = NULL,
-                                  pandoc_args = NULL,
                                   analytics = NULL,
+                                  pandoc_args = NULL,
                                   ...) {
 
   # base pandoc options for all output

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -38,6 +38,9 @@ $endif$
         usePrettify: true,
         enableSlideAreas: true,
         enableTouch: true,
+        $if(analytics)$
+        analytics: '$analytics$',
+        $endif$
         $if(logo)$
         favIcon: '$logo$',
         $endif$

--- a/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
+++ b/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
@@ -128,11 +128,11 @@ SlideDeck.prototype.addEventListeners_ = function() {
   //   'msTransition': 'MSTransitionEnd',
   //   'transition': 'transitionend'
   // };
-  // 
+  //
   // // Find the correct transitionEnd vendor prefix.
   // window.transEndEventName = transEndEventNames[
   //     Modernizr.prefixed('transition')];
-  // 
+  //
   // // When slides are done transitioning, kickoff loading iframes.
   // // Note: we're only looking at a single transition (on the slide). This
   // // doesn't include autobuilds the slides may have. Also, if the slide
@@ -582,7 +582,7 @@ SlideDeck.prototype.updateSlides_ = function(opt_dontPush) {
   this.triggerSlideEvent('slideenter', curSlide);
 
 // window.setTimeout(this.disableSlideFrames_.bind(this, curSlide - 2), 301);
-// 
+//
 // this.enableSlideFrames_(curSlide - 1); // Previous slide.
 // this.enableSlideFrames_(curSlide + 1); // Current slide.
 // this.enableSlideFrames_(curSlide + 2); // Next slide.
@@ -723,8 +723,10 @@ SlideDeck.prototype.updateHash_ = function(dontPush) {
     }
 
     // Record GA hit on this slide.
-    window['_gaq'] && window['_gaq'].push(['_trackPageview',
-                                          document.location.href]);
+    if(typeof window.ga === 'function') {
+      ga('set', 'page', hash)
+      ga('send', 'pageview');
+    }
   }
 };
 
@@ -770,15 +772,13 @@ SlideDeck.prototype.loadTheme_ = function(theme) {
  * @private
  */
 SlideDeck.prototype.loadAnalytics_ = function() {
-  var _gaq = window['_gaq'] || [];
-  _gaq.push(['_setAccount', this.config_.settings.analytics]);
-  _gaq.push(['_trackPageview']);
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+  ga('create', this.config_.settings.analytics, 'auto');
+  ga('send', 'pageview');
 };
 
 

--- a/man/ioslides_presentation.Rd
+++ b/man/ioslides_presentation.Rd
@@ -8,9 +8,9 @@
 ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   fig_height = 4.5, fig_retina = 2, fig_caption = TRUE,
   dev = "png", smart = TRUE, self_contained = TRUE, widescreen = FALSE,
-  smaller = FALSE, transition = "default", mathjax = "default", css = NULL,
-  includes = NULL, keep_md = FALSE, lib_dir = NULL, md_extensions = NULL,
-  analytics = NULL, pandoc_args = NULL, ...)
+  smaller = FALSE, transition = "default", mathjax = "default",
+  analytics = NULL,css = NULL, includes = NULL, keep_md = FALSE, lib_dir = NULL,
+  md_extensions = NULL, pandoc_args = NULL, ...)
 }
 \arguments{
   \item{logo}{Path to file that includes a logo for use in
@@ -68,6 +68,8 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   into the output directory). You can pass an alternate URL
   or pass \code{NULL} to exclude MathJax entirely.}
 
+  \item{analytics}{A Google analytics property ID}
+
   \item{css}{One or more css files to include}
 
   \item{includes}{Named list of additional content to
@@ -85,8 +87,6 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   \item{md_extensions}{Markdown extensions to be added or
   removed from the default definition or R Markdown. See the
   \code{\link{rmarkdown_format}} for additional details.}
-
-  \item{analytics}{A Google analytics property ID}
 
   \item{pandoc_args}{Additional command line options to
   pass to pandoc}
@@ -385,4 +385,3 @@ To create a PDF version of a presentation you can use Print to PDF
 from Google Chrome.
 
 }
-

--- a/man/ioslides_presentation.Rd
+++ b/man/ioslides_presentation.Rd
@@ -10,7 +10,7 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   dev = "png", smart = TRUE, self_contained = TRUE, widescreen = FALSE,
   smaller = FALSE, transition = "default", mathjax = "default", css = NULL,
   includes = NULL, keep_md = FALSE, lib_dir = NULL, md_extensions = NULL,
-  pandoc_args = NULL, ...)
+  analytics = NULL, pandoc_args = NULL, ...)
 }
 \arguments{
   \item{logo}{Path to file that includes a logo for use in
@@ -85,6 +85,8 @@ ioslides_presentation(logo = NULL, incremental = FALSE, fig_width = 7.5,
   \item{md_extensions}{Markdown extensions to be added or
   removed from the default definition or R Markdown. See the
   \code{\link{rmarkdown_format}} for additional details.}
+
+  \item{analytics}{A Google analytics property ID}
 
   \item{pandoc_args}{Additional command line options to
   pass to pandoc}


### PR DESCRIPTION
The Google analytics code is partially removed from the bundled version of ioslides, this PR updates and makes it functional.

Usage is via `analytics` option in `output.ioslides_presentation` as well as a `--variable` option in pandoc_args.

```yaml
output:
  ioslides_presentation:
    analytics: UA-XXXXXXXX-1
```

or

```yaml
output:
  ioslides_presentation:
    pandoc_args: [
      "--variable", "analytics:UA-XXXXXXXX-1"
    ]
```