### PR TITLE
f/ioslides background

### DIFF
--- a/R/base64.R
+++ b/R/base64.R
@@ -117,10 +117,14 @@ process_html_res <- function(html, reg, processor) {
 }
 
 process_images <- function(html, processor) {
-  process_html_res(
+  html <- process_html_res(
     html,
     "<\\s*[Ii][Mm][Gg]\\s+[Ss][Rr][Cc]\\s*=\\s*[\"']([^\"']+)[\"']",
     processor)
+  process_html_res(
+      html,
+      "<[^>]*style=\"[^\"]*url\\(([^\\)]+)\\)",
+      processor)
 }
 
 base64_encode_images <- function(html, encoder) {

--- a/tests/testthat/test-ioslides.R
+++ b/tests/testthat/test-ioslides.R
@@ -15,35 +15,60 @@ context("ioslides")
 
 }
 
+mock_markdown <- function(mdtext = NULL,  outputdir = NULL, ... ) {
+  # create input file
+  mdfile <- tempfile(pattern = "mock_XXXXX",
+                     tmpdir = outputdir,
+                     fileext = ".Rmd")
+  cat(mdtext, file = mdfile, sep = "\n", append = FALSE)
+
+  # output file name
+  outfile <- basename(
+    tempfile(pattern = "mock_XXXXX",
+             tmpdir = outputdir,
+             fileext = ".html"
+    )
+  )
+  # convert
+  output <- capture.output(
+    render(mdfile,
+           output_dir = outputdir,
+           output_file = outfile,
+           ioslides_presentation(...)
+    )
+  )
+
+  # read in output
+  html_file <- readLines(file.path(outputdir, outfile))
+
+  # return structure for testing properties of
+  invisible(structure(
+    list(
+      output = output,
+      html_file = html_file
+      ),
+    class = "mocked")
+    )
+}
+
 test_ioslides_presentation <- function() {
 
   skip_on_cran()
 
-  outputdir <-  tempfile()
+  outputdir <- tempfile()
   dir.create(outputdir)
   on.exit(unlink(outputdir), add = TRUE)
 
   # Generate mock md file
   mdtext <- .generate_markdown_for_test()
-  mdfile <- file.path(outputdir, "mock.Rmd")
-  cat(mdtext, file = mdfile, sep = "\n")
-
-  # test conversion
-  outfile <- "mock_default.html"
-  rout2 <- capture.output(
-    render(mdfile,
-           output_dir = outputdir,
-           output_file = outfile,
-           ioslides_presentation()
-    )
-  )
+  mock2 <- mock_markdown(mdtext = mdtext, outputdir = outputdir)
 
   # test argument passing to pandoc
-  expect_true(any(grepl("--slide-level 2", paste(rout2), fixed = TRUE)))
+  expect_true(any(grepl("--slide-level 2", paste(mock2$output), fixed = TRUE)))
 
   # test status of headers in resulting file
   # Header3 should not be a slide header
-  html_file <- readLines(file.path(outputdir, outfile))
+  html_file <- mock2$html_file
   header_lines <- c(
     any(grepl("<h2>Header1</h2>", html_file, fixed = TRUE)),
     any(grepl("<h2>Header2</h2>", html_file, fixed = TRUE)),
@@ -66,22 +91,16 @@ test_ioslides_presentation <- function() {
   )
   expect_false(any(header_classes))
 
-
+  mock3 <- mock_markdown(mdtext = mdtext, outputdir = outputdir, slide_level = 3)
   # Place the header 3 as title slide
-  rout3 <- capture.output(
-    render(mdfile,
-           output_dir = outputdir,
-           output_file = outfile,
-           ioslides_presentation(slide_level = 3)
-    )
-  )
+  rout3 <- mock3$output
 
   # test argument passing to pandoc
   expect_true(any(grepl("--slide-level 3", paste(rout3), fixed = TRUE)))
 
   # test status of headers in resulting file
   # Header3 should be a slide header
-  html_file <- readLines(file.path(outputdir, outfile))
+  html_file <- mock3$html_file
   header_lines <- c(
     any(grepl("<h2>Header1</h2>", html_file, fixed = TRUE)),
     any(grepl("<h2>Header2</h2>", html_file, fixed = TRUE)),
@@ -107,3 +126,60 @@ test_ioslides_presentation <- function() {
 }
 
 test_that("test_ioslides_presentation", test_ioslides_presentation())
+
+test_ioslides_presentation_css <- function() {
+
+  skip_on_cran()
+
+  outputdir <- tempfile()
+  dir.create(outputdir)
+  on.exit(unlink(outputdir), add = TRUE)
+
+  # Generate mock md file for data-background
+  mdtext <- c("# Slide One\n",
+              "## Slide Two {data-background=#CCC}\n",
+              "## Slide Three {data-background=img/test.png}\n",
+              "# Slide Four {data-background=#ABCDEF}\n"
+              )
+  mock <- mock_markdown(mdtext = mdtext, outputdir = outputdir, self_contained = FALSE)
+  html = mock$html_file
+
+  slide_lines <-
+    c(any(grepl('<slide[^>]*class="[^"]*\\bsegue\\b[^"]*".*<h2>Slide One</h2>', html, perl = TRUE))
+    ## separated to be order agnostic
+    , any(grepl('<slide[^>]*class="[^"]*\\bnobackground\\b[^"]*".*<h2>Slide Two</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*class="[^"]*\\bfill\\b[^"]*".*<h2>Slide Two</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*style="background-color: #CCC;".*<h2>Slide Two</h2>', html, perl = TRUE))
+
+    ## separated to be order agnostic - within values of attributes also (hence [^"]*)
+    , any(grepl('<slide[^>]*class="[^"]*\\bnobackground\\b[^"]*".*<h2>Slide Two</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*class="[^"]*\\bfill\\b[^"]*".*<h2>Slide Two</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*style="[^"]*background-image: url\\(img/test.png\\);[^"]*".*<h2>Slide Three</h2>', html))
+    , any(grepl('<slide[^>]*style="[^"]*background-size: 100% 100%;[^"]*".*<h2>Slide Three</h2>', html))
+
+    ## separated to be order agnostic
+    , any(grepl('<slide[^>]*class="[^"]*\\bsegue\\b[^"]*".*<h2>Slide Four</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*class="[^"]*\\bnobackground\\b[^"]*".*<h2>Slide Four</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*class="[^"]*\\bfill\\b[^"]*".*<h2>Slide Four</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*class="[^"]*\\blevel1\\b[^"]*".*<h2>Slide Four</h2>', html, perl = TRUE))
+    , any(grepl('<slide[^>]*style="background-color: #ABCDEF;".*<h2>Slide Four</h2>', html, perl = TRUE))
+
+  )
+  expect_true(all(slide_lines), info = "slide lines - style attribute")
+
+  # Generate mock md file for data-background
+  plot <- file.path(getwd(), 'resources', 'tinyplot.png')
+  mdtext <- c(paste0("## BG Slide {data-background=", plot, "}\n"))
+  mock <- mock_markdown(mdtext = mdtext, outputdir = outputdir, self_contained = TRUE)
+  html = mock$html_file
+
+  slide_lines <-
+    c(any(grepl('<slide[^>]*style="[^"]*background-image: url\\(data:image/png;base64,[^\\)]*);[^"]*".*<h2>BG Slide</h2>', html))
+      ## still separate
+    , any(grepl('<slide[^>]*style="[^"]*background-size: 100% 100%;[^"]*".*<h2>BG Slide</h2>', html))
+    )
+  expect_true(all(slide_lines), info = "slide lines - self contained image")
+}
+
+
+test_that("ioslides presentation is styled", test_ioslides_presentation_css())


### PR DESCRIPTION
## Change

Add more simple syntax for slide backgrounds and slide specific class.

Issues #195 and #230 are addressed, or partially so. The thank you slide is a little tricky as it breaks the mold somewhat.
## Usage

``` markdown
## Slide One {data-background="http://www.prolificbeing.com/wp-content/uploads/2015/02/Hello-World.png"}
## Another Slide | subtitle
Lorem ipsum dolor.
## Final content {slide-class="csstricks"}
`
slide > slide [data-slide-num="7"] {
  background-image: url("figures/xx.jpg");
}
`
## Thanks for listening {slide-class="thank-you-slide" class="flexbox vleft auto-fadein"}
```
## Testing

@alequartz's unit testing would be a really useful addition.
