### PR TITLE
Make sure pandoc_version() is not NULL before testing it against version numbers

### DIFF
--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -136,6 +136,7 @@ beamer_presentation <- function(toc = FALSE,
 }
 
 patch_beamer_template <- function() {
+  if (!pandoc_available()) stop("Pandoc not found")
   if (pandoc_version() >= '1.15.2') return()  # no need to patch the template
   f <- tempfile(fileext = '.tex')
   command <- paste(quoted(pandoc()), "-D beamer >", quoted(f))

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -136,7 +136,7 @@ beamer_presentation <- function(toc = FALSE,
 }
 
 patch_beamer_template <- function() {
-  if (!pandoc_available()) stop("Pandoc not found")
+  pandoc_available(error = TRUE)
   if (pandoc_version() >= '1.15.2') return()  # no need to patch the template
   f <- tempfile(fileext = '.tex')
   command <- paste(quoted(pandoc()), "-D beamer >", quoted(f))

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -110,6 +110,8 @@ pandoc_convert <- function(input,
 #' of pandoc available.
 #'
 #' @param version Required version of pandoc
+#' @param error Whether to signal an error if pandoc with the required version
+#'   is not found
 #'
 #' @return \code{pandoc_available} returns a logical indicating whether the
 #'   required version of pandoc is available. \code{pandoc_version} returns a
@@ -117,9 +119,12 @@ pandoc_convert <- function(input,
 #'
 #' @details
 #'
-#' The system path as well as the version of pandoc shipped with RStudio (if
-#' running under RStudio) are scanned for pandoc and the highest version
-#' available is used.
+#' The system environment variable \samp{PATH} as well as the version of pandoc
+#' shipped with RStudio (its location is set via the environment variable
+#' \samp{RSTUDIO_PANDOC} by RStudio products like the RStudio IDE, RStudio
+#' Server, Shiny Server, and RStudio Connect, etc) are scanned for pandoc and
+#' the highest version available is used. Please do not modify the environment
+#' varaible \samp{RSTUDIO_PANDOC} unless you know what it means.
 #'
 #' @examples
 #' \dontrun{
@@ -132,19 +137,21 @@ pandoc_convert <- function(input,
 #'   cat("requried version of pandoc is available!\n")
 #' }
 #' @export
-pandoc_available <- function(version = NULL) {
+pandoc_available <- function(version = NULL, error = FALSE) {
 
   # ensure we've scanned for pandoc
   find_pandoc()
 
   # check availability
-  if (!is.null(.pandoc$dir))
-    if (!is.null(version))
-      .pandoc$version >= version
-  else
-    TRUE
-  else
-    FALSE
+  found <- !is.null(.pandoc$dir) && (is.null(version) || .pandoc$version >= version)
+
+  msg <- c(
+    "pandoc", if (!is.null(version)) c("version", version, "or higher"),
+    "is required and was not found (see the help page ?rmarkdown::pandoc_available)."
+  )
+  if (error && !found) stop(paste(msg, collapse = " "), call. = FALSE)
+
+  found
 }
 
 

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -109,6 +109,7 @@ pdf_document <- function(toc = FALSE,
   # template path and assets
   if (identical(template, "default")) {
 
+    if (!pandoc_available()) stop("Pandoc not found")
     # choose the right template
     version <- pandoc_version()
     if (version >= "1.17.0.2")

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -109,7 +109,7 @@ pdf_document <- function(toc = FALSE,
   # template path and assets
   if (identical(template, "default")) {
 
-    if (!pandoc_available()) stop("Pandoc not found")
+    pandoc_available(error = TRUE)
     # choose the right template
     version <- pandoc_version()
     if (version >= "1.17.0.2")

--- a/R/render.R
+++ b/R/render.R
@@ -67,10 +67,7 @@ render <- function(input,
 
   # check for required version of pandoc
   required_pandoc <- "1.12.3"
-  if (!pandoc_available(required_pandoc)) {
-    stop("pandoc version ", required_pandoc, " or higher ",
-         "is required and was not found.", call. = FALSE)
-  }
+  pandoc_available(required_pandoc, error = TRUE)
 
   # setup a cleanup function for intermediate files
   intermediates <- c()

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -3,6 +3,8 @@ rmarkdown 0.9.7 (unreleased)
 
 * `toc_float` no longer automatically sets `toc = TRUE`
 
+* Added an argument `error` to `pandoc_available()` to signal an error when (if
+  `error = TRUE`) pandoc with the required version is not found.
 
 rmarkdown 0.9.6
 --------------------------------------------------------------------------------

--- a/man/pandoc_available.Rd
+++ b/man/pandoc_available.Rd
@@ -5,12 +5,15 @@
 \alias{pandoc_version}
 \title{Check pandoc availabilty and version}
 \usage{
-pandoc_available(version = NULL)
+pandoc_available(version = NULL, error = FALSE)
 
 pandoc_version()
 }
 \arguments{
 \item{version}{Required version of pandoc}
+
+\item{error}{Whether to signal an error if pandoc with the required version
+is not found}
 }
 \value{
 \code{pandoc_available} returns a logical indicating whether the
@@ -23,9 +26,12 @@ checking for a specific version or greater). Determine the specific version
 of pandoc available.
 }
 \details{
-The system path as well as the version of pandoc shipped with RStudio (if
-running under RStudio) are scanned for pandoc and the highest version
-available is used.
+The system environment variable \samp{PATH} as well as the version of pandoc
+shipped with RStudio (its location is set via the environment variable
+\samp{RSTUDIO_PANDOC} by RStudio products like the RStudio IDE, RStudio
+Server, Shiny Server, and RStudio Connect, etc) are scanned for pandoc and
+the highest version available is used. Please do not modify the environment
+varaible \samp{RSTUDIO_PANDOC} unless you know what it means.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Otherwise users may get a confusing error message like

> Error in if (version >= "1.15.2") latex_template <- "default-1.15.2.tex" else if (version >=  : argument is of length zero

This was originally reported in shiny-discuss https://groups.google.com/d/msgid/shiny-discuss/63de59d4-b208-4cd3-a98e-3f48de927511%40googlegroups.com and turns out to be due to an incorrect manipulation of the RSTUDIO_PANDOC variable.