### PR TITLE
Fix issues preventing resource discovery from working in notebooks

### DIFF
--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -7,6 +7,10 @@
 #'   outputs to use instead of those produced by evaluating the
 #'   underlying \R code). See \code{\link{html_notebook_output}} for
 #'   more details.
+#' @param self_contained Produce a standalone HTML file with no external
+#'   dependencies. Defaults to \code{TRUE}. In notebooks, setting this to
+#'   \code{FALSE} is not recommended, since the setting does not apply to
+#'   embedded notebook output such as plots and HTML widgets.
 #' @importFrom evaluate evaluate
 #' @export
 html_notebook <- function(toc = FALSE,

--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -28,6 +28,7 @@ html_notebook <- function(toc = FALSE,
                           md_extensions = NULL,
                           pandoc_args = NULL,
                           output_source = NULL,
+                          self_contained = TRUE,
                           ...)
 {
   # some global state that is captured in pre_knit
@@ -123,7 +124,7 @@ html_notebook <- function(toc = FALSE,
 
   # these arguments to html_document are fixed so we need to
   # flag them as invalid for users
-  fixed_args <- c("self_contained", "keep_md", "template", "lib_dir", "dev")
+  fixed_args <- c("keep_md", "template", "lib_dir", "dev")
   forwarded_args <- names(list(...))
   for (arg in forwarded_args) {
     if (arg %in% fixed_args)
@@ -149,10 +150,10 @@ html_notebook <- function(toc = FALSE,
                                includes = includes,
                                md_extensions = md_extensions,
                                pandoc_args = pandoc_args,
+                               self_contained = self_contained,
                                # options forced for notebooks
                                dev = "png",
                                code_download = TRUE,
-                               self_contained = TRUE,
                                keep_md = FALSE,
                                template = "default",
                                lib_dir = NULL,

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -362,10 +362,11 @@ discover_rmd_resources <- function(rmd_file, encoding,
                             else
                               "html_document"
 
-  render(input = md_file, output_file = html_file,
-         output_format = override_output_format,
-         output_options = list(self_contained = FALSE), quiet = TRUE,
-         encoding = "UTF-8")
+  html_file <- render(input = md_file, output_file = html_file,
+                      output_format = override_output_format,
+                      output_options = list(self_contained = FALSE),
+                      quiet = TRUE,
+                      encoding = "UTF-8")
 
   # clean up output file and its supporting files directory
   temp_files <- c(temp_files, html_file, knitr_files_dir(md_file))

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -10,7 +10,7 @@ html_notebook(toc = FALSE, toc_depth = 3, toc_float = FALSE,
   smart = TRUE, theme = "default", highlight = "textmate",
   mathjax = "default", extra_dependencies = NULL, css = NULL,
   includes = NULL, md_extensions = NULL, pandoc_args = NULL,
-  output_source = NULL, ...)
+  output_source = NULL, self_contained = TRUE, ...)
 }
 \arguments{
 \item{toc}{\code{TRUE} to include a table of contents in the output}
@@ -29,8 +29,8 @@ options that control the behavior of the floating table of contents. See the
 \item{fig_height}{Default width (in inches) for figures}
 
 \item{fig_retina}{Scaling to perform for retina displays (defaults to 2, which
-currently works for all widely used retina displays). Set to\code{NULL} to
-prevent retina scaling. Note that this will always be\code{NULL} when
+currently works for all widely used retina displays). Set to \code{NULL} to
+prevent retina scaling. Note that this will always be \code{NULL} when
 \code{keep_md} is specified (this is because \code{fig_retina} relies on
 outputting HTML directly into the markdown document).}
 
@@ -79,6 +79,11 @@ additional details.}
 outputs to use instead of those produced by evaluating the
 underlying \R code). See \code{\link{html_notebook_output}} for
 more details.}
+
+\item{self_contained}{Produce a standalone HTML file with no external
+dependencies. Defaults to \code{TRUE}. In notebooks, setting this to
+\code{FALSE} is not recommended, since the setting does not apply to
+embedded notebook output such as plots and HTML widgets.}
 
 \item{...}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link{html_document_base}}}

--- a/tests/testthat/resources/r-notebook.Rmd
+++ b/tests/testthat/resources/r-notebook.Rmd
@@ -15,6 +15,10 @@ This is a plot.
 plot(cars)
 ```
 
+This plot is static.
+
+![plot](tinyplot.png)
+
 This is an HTML widget.
 
 ```{r chunk-three}

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -197,3 +197,18 @@ test_that("resources are discovered in CSS files", {
   expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
   expect_equal(resources, expected)
 })
+
+test_that("resources are discovered in notebook files", {
+  skip_on_cran()
+
+  resources <- find_external_resources("resources/r-notebook.Rmd")
+  expected <- data.frame(
+    path = c("tinyplot.png"),
+    explicit = c(FALSE),
+    web      = c(TRUE),
+    stringsAsFactors = FALSE)
+
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
+  expect_equal(resources, expected)
+})


### PR DESCRIPTION
This change fixes a couple of problems which conspired to prevent resource discovery (and therefore certain modes of publishing) from working with notebook files.

1. The notebook output format can produce a different output file name than was requested (i.e. `.nb.html` rather than `.html`). This is now accounted for.

2. Notebooks forced the `self_contained` option to `TRUE`. This is fundamentally incompatible with resource discovery since discovery requires analysis of the HTML with file references intact. 

If we wanted to be very strict about `self_contained` we could plumb some sort of manual override through, but this seemed like more complexity than was warranted (let me know if you disagree). 