### PR TITLE
handle spaces in output path

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -433,10 +433,24 @@ render <- function(input,
     perf_timer_start("pandoc")
 
     convert <- function(output, citeproc = FALSE) {
-      pandoc_convert(
-        utf8_input, pandoc_to, output_format$pandoc$from, output, citeproc,
-        output_format$pandoc$args, !quiet
+
+      # render to temporary file (preserve extension)
+      # this also ensures we don't pass a file path with invalid
+      # characters to our pandoc invocation
+      ext <- paste(".", tools::file_ext(output), sep = "")
+      pandoc_output_tmp <- tempfile("pandoc", getwd(), ext)
+
+      # call pandoc to render file
+      status <- pandoc_convert(
+        utf8_input, pandoc_to, output_format$pandoc$from, pandoc_output_tmp,
+        citeproc, output_format$pandoc$args, !quiet
       )
+
+      # rename output file to desired location
+      file.rename(pandoc_output_tmp, output)
+
+      # return status
+      status
     }
     texfile <- file_with_ext(output_file, "tex")
     # compile Rmd to tex when we need to generate bibliography with natbib/biblatex

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -28,3 +28,26 @@ test_that("formats successfully produce a document", {
   if (requireNamespace("tufte", quietly = TRUE))
     testFormat(tufte_handout())
 })
+
+test_that("documents with spaces in names can be rendered", {
+
+  # get path to notebook
+  rmd_path <- "resources/empty.Rmd"
+
+  # attempt to write to directory with spaces
+  output_file <- "directory with spaces/r output.nb.html"
+  dir.create(dirname(output_file))
+  on.exit(unlink("directory with spaces", recursive = TRUE), add = TRUE)
+
+  # generate copy with space in name
+  with_spaces <- "directory with spaces/no content.Rmd"
+  file.copy(rmd_path, with_spaces)
+
+  output <- rmarkdown::render(with_spaces,
+                              output_format = "html_notebook",
+                              output_file = output_file,
+                              quiet = TRUE)
+
+  expect_true(file.exists(output))
+
+})


### PR DESCRIPTION
This PR fixes an issue where attempting to render a file to a path containing spaces could fail (when that output path was provided explicitly by the user, rather than generated by rmarkdown).