### PR TITLE
Add toc_print_hide as a sub-option under toc_float

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -120,11 +120,12 @@
 #'  control the behavior of the floating table of contents. Options include:
 #'
 #'  \itemize{ \item{\code{collapsed} (defaults to \code{TRUE}) controls whether
-#'  the table of contents appers with only the top-level (H2) headers. When
+#'  the table of contents appears with only the top-level (H2) headers. When
 #'  collapsed the table of contents is automatically expanded inline when
 #'  necessary.} \item{\code{smooth_scroll} (defaults to \code{TRUE}) controls
 #'  whether page scrolls are animated when table of contents items are navigated
-#'  to via mouse clicks.} }
+#'  to via mouse clicks.} \item{\code{print_hide} (defaults to \code{FALSE}) controls
+#'  whether the table of contents appears when user prints out the HTML page.}}
 #'
 #'@section Tabbed Sections:
 #'
@@ -226,7 +227,8 @@ html_document <- function(toc = FALSE,
 
     # resolve options
     toc_float_options <- list(collapsed = TRUE,
-                              smooth_scroll = TRUE)
+                              smooth_scroll = TRUE,
+                              print_hide = FALSE)
     if (is.list(toc_float)) {
       toc_float_options <- merge_lists(toc_float_options, toc_float)
       toc_float <- TRUE
@@ -252,6 +254,8 @@ html_document <- function(toc = FALSE,
       args <- c(args, pandoc_variable_arg("toc_collapsed", "1"))
     if (toc_float_options$smooth_scroll)
       args <- c(args, pandoc_variable_arg("toc_smooth_scroll", "1"))
+    if (toc_float_options$print_hide)
+      args <- c(args, pandoc_variable_arg("toc_print_hide", "1"))
   }
 
   # template path and assets

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -124,7 +124,7 @@
 #'  collapsed the table of contents is automatically expanded inline when
 #'  necessary.} \item{\code{smooth_scroll} (defaults to \code{TRUE}) controls
 #'  whether page scrolls are animated when table of contents items are navigated
-#'  to via mouse clicks.} \item{\code{print_hide} (defaults to \code{FALSE}) controls
+#'  to via mouse clicks.} \item{\code{print} (defaults to \code{TRUE}) controls
 #'  whether the table of contents appears when user prints out the HTML page.}}
 #'
 #'@section Tabbed Sections:
@@ -228,7 +228,7 @@ html_document <- function(toc = FALSE,
     # resolve options
     toc_float_options <- list(collapsed = TRUE,
                               smooth_scroll = TRUE,
-                              print_hide = FALSE)
+                              print = TRUE)
     if (is.list(toc_float)) {
       toc_float_options <- merge_lists(toc_float_options, toc_float)
       toc_float <- TRUE
@@ -254,8 +254,8 @@ html_document <- function(toc = FALSE,
       args <- c(args, pandoc_variable_arg("toc_collapsed", "1"))
     if (toc_float_options$smooth_scroll)
       args <- c(args, pandoc_variable_arg("toc_smooth_scroll", "1"))
-    if (toc_float_options$print_hide)
-      args <- c(args, pandoc_variable_arg("toc_print_hide", "1"))
+    if (toc_float_options$print)
+      args <- c(args, pandoc_variable_arg("toc_print", "1"))
   }
 
   # template path and assets

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -27,6 +27,8 @@ rmarkdown 0.9.7 (unreleased)
 * Default highlighting engine for `html_document` now highlights bash, c++,
   css, ini, javascript, perl, python, r, ruby, scala, and xml
 
+* Added `print` sub-option to `toc_float` to control whether the table of contents appears when user prints out the HTML page.
+
 
 rmarkdown 0.9.6
 --------------------------------------------------------------------------------

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -281,6 +281,14 @@ $endif$
 }
 }
 
+$if(toc_print_hide)$
+@media print {
+#$idprefix$TOC {
+  display: none !important;
+}
+}
+$endif$
+
 .toc-content {
   padding-left: 30px;
   padding-right: 40px;

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -281,7 +281,8 @@ $endif$
 }
 }
 
-$if(toc_print_hide)$
+$if(toc_print)$
+$else$
 @media print {
 #$idprefix$TOC {
   display: none !important;

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -160,11 +160,12 @@ and Citations} article in the online documentation.
  control the behavior of the floating table of contents. Options include:
 
  \itemize{ \item{\code{collapsed} (defaults to \code{TRUE}) controls whether
- the table of contents appers with only the top-level (H2) headers. When
+ the table of contents appears with only the top-level (H2) headers. When
  collapsed the table of contents is automatically expanded inline when
  necessary.} \item{\code{smooth_scroll} (defaults to \code{TRUE}) controls
  whether page scrolls are animated when table of contents items are navigated
- to via mouse clicks.} }
+ to via mouse clicks.} \item{\code{print} (defaults to \code{TRUE}) controls
+ whether the table of contents appears when user prints out the HTML page.}}
 }
 
 \section{Tabbed Sections}{


### PR DESCRIPTION
Floating TOC is convenient on html page but sometimes it looks ugly on paper if users choose to print out the page, especially when the floating TOC is very long. So I added a sub-option called `toc_print_hide` under `toc_float`. It allows people to only print out the contents of a page while the TOC is still displayed on the webpage. The default value of this option is `FALSE` so users won't feel any differences unless they have the need. 

Also, I fixed a typo.. :)

<img width="1022" alt="screenshot 2016-05-24 13 48 43" src="https://cloud.githubusercontent.com/assets/7014590/15514271/52348174-21b6-11e6-950d-3926f5c39c35.png">
