### PR TITLE
add readme option to html_vignette to produce package README.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 0.9.6.11
+Version: 0.9.6.12
 Date: 2016-04-28
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -20,7 +20,8 @@
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}
 #' @param readme Use this vignette as the package README.md file (i.e. render
-#'   it as README.md to the package root)
+#'   it as README.md to the package root). Note that if there are image files
+#'   within your vignette you should be sure to add README_files to .Rbuildignore
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @export
 html_vignette <- function(fig_width = 3,

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -41,7 +41,8 @@ html_vignette <- function(fig_width = 3,
                         output_format = "github_document",
                         output_options = list(html_preview = FALSE),
                         output_file = "README.md",
-                        output_dir = dirname(dirname(input)))
+                        output_dir = dirname(dirname(input)),
+                        quiet = TRUE)
     }
   }
 

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -19,12 +19,15 @@
 #'
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}
+#' @param readme Use this vignette as the package README.md file (i.e. render
+#'   it as README.md to the package root)
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @export
 html_vignette <- function(fig_width = 3,
                           fig_height = 3,
                           dev = 'png',
                           css = NULL,
+                          readme = FALSE,
                           ...) {
 
   if (is.null(css)) {
@@ -32,12 +35,26 @@ html_vignette <- function(fig_width = 3,
       "vignette.css", package = "rmarkdown")
   }
 
-  html_document(fig_width = fig_width,
-                fig_height = fig_height,
-                dev = dev,
-                fig_retina = NULL,
-                css = css,
-                theme = NULL,
-                highlight = "pygments",
-                ...)
+  pre_knit <- function(input, ...) {
+    if (readme && !is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
+      rmarkdown::render(input,
+                        output_format = "github_document",
+                        output_file = "README.md",
+                        output_dir = dirname(dirname(input)))
+    }
+  }
+
+  output_format(
+    knitr = NULL,
+    pandoc = NULL,
+    pre_knit = pre_knit,
+    base_format = html_document(fig_width = fig_width,
+                                fig_height = fig_height,
+                                dev = dev,
+                                fig_retina = NULL,
+                                css = css,
+                                theme = NULL,
+                                highlight = "pygments",
+                                ...)
+  )
 }

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -39,6 +39,7 @@ html_vignette <- function(fig_width = 3,
     if (readme) {
       rmarkdown::render(input,
                         output_format = "github_document",
+                        output_options = list(html_preview = FALSE),
                         output_file = "README.md",
                         output_dir = dirname(dirname(input)))
     }

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -36,7 +36,7 @@ html_vignette <- function(fig_width = 3,
   }
 
   pre_knit <- function(input, ...) {
-    if (readme && !is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
+    if (readme) {
       rmarkdown::render(input,
                         output_format = "github_document",
                         output_file = "README.md",

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -27,7 +27,11 @@ rmarkdown 0.9.7 (unreleased)
 * Default highlighting engine for `html_document` now highlights bash, c++,
   css, ini, javascript, perl, python, r, ruby, scala, stan and xml
 
-* Added `print` sub-option to `toc_float` to control whether the table of contents appears when user prints out the HTML page.
+* Added `print` sub-option to `toc_float` to control whether the table of
+  contents appears when user prints out the HTML page.
+
+* Added `readme` option to `html_vignette` which automatically creates a
+  package level README.md (for GitHub) in addition to rendering the vignette.
 
 
 rmarkdown 0.9.6

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -17,7 +17,8 @@ html_vignette(fig_width = 3, fig_height = 3, dev = "png", css = NULL,
 \item{css}{One or more css files to include}
 
 \item{readme}{Use this vignette as the package README.md file (i.e. render
-it as README.md to the package root)}
+it as README.md to the package root). Note that if there are image files
+within your vignette you should be sure to add README_files to .Rbuildignore}
 
 \item{...}{Additional arguments passed to \code{\link{html_document}}}
 }

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -5,7 +5,7 @@
 \title{Convert to an HTML vignette.}
 \usage{
 html_vignette(fig_width = 3, fig_height = 3, dev = "png", css = NULL,
-  ...)
+  readme = FALSE, ...)
 }
 \arguments{
 \item{fig_width}{Default width (in inches) for figures}
@@ -15,6 +15,9 @@ html_vignette(fig_width = 3, fig_height = 3, dev = "png", css = NULL,
 \item{dev}{Graphics device to use for figure output (defaults to png)}
 
 \item{css}{One or more css files to include}
+
+\item{readme}{Use this vignette as the package README.md file (i.e. render
+it as README.md to the package root)}
 
 \item{...}{Additional arguments passed to \code{\link{html_document}}}
 }


### PR DESCRIPTION
@yihui and @hadley I thought it would be useful to specify that a given vignette should also be used as the package README.md. This is my first pass at an implementation. Some questions:

1. Do you agree this is a good idea?

2. Is this done in the right place? (or should it e.g. be a property of the vignette builder)

3. I'm doing this only when not on CRAN. Is that the right thing or should we not care about whether we are on CRAN? (this imposed some cost as currently the Knit button in RStudio doesn't set NOT_CRAN=true although it certainly could).
