### PR TITLE
Byte-encode Rmd source to retain utf-8 encoding

### DIFF
--- a/inst/rmd/h/navigation-1.1/sourceembed.js
+++ b/inst/rmd/h/navigation-1.1/sourceembed.js
@@ -3,7 +3,13 @@
 window.initializeSourceEmbed = function(filename) {
   $("#rmd-download-source").click(function() {
     var src = window.atob($("#rmd-source-code").html());
-    var blob = new Blob([src], {type: "text/x-r-markdown"});
+
+    var uint8 = new Uint8Array(src.length);
+    for (var i = 0; i < uint8.length; i++) {
+      uint8[i] = src.charCodeAt(i);
+    }
+
+    var blob = new Blob([uint8], {type: "text/x-r-markdown"});
     saveAs(blob, filename);
   });
 };


### PR DESCRIPTION
Fixes the issue that utf-8 encoded special characters in the downloadable Rmd source file get scrambled, see https://github.com/rstudio/rmarkdown/issues/722.
