### PR TITLE
Typo fix: download rmarkdown package

### DIFF
--- a/r_notebook_format.Rmd
+++ b/r_notebook_format.Rmd
@@ -5,7 +5,7 @@ title: "R Notebook HTML Format"
 **NOTE:** The functions described in this article are available in the development version of the rmarkdown package. You can install the development version using the devtools package as follows:
 
 ```{r, eval=FALSE}
-devtools::install_github("rstudio/markdown")
+devtools::install_github("rstudio/rmarkdown")
 ```
 
 ## Overview


### PR DESCRIPTION
The devtools install command was missing the r in **r**markdown.