### PR TITLE
puts extra_dependencies at the end of format_deps

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -83,7 +83,6 @@ html_document_base <- function(smart = TRUE,
     # resolve and inject extras, including dependencies specified by the format
     # and dependencies specified by the user (via extra_dependencies)
     format_deps <- list()
-    format_deps <- append(format_deps, extra_dependencies)
     if (!is.null(theme)) {
       format_deps <- append(format_deps, list(html_dependency_jquery(),
                                               html_dependency_bootstrap(theme)))
@@ -93,6 +92,7 @@ html_document_base <- function(smart = TRUE,
       format_deps <- append(format_deps,
                             list(html_dependency_bootstrap("bootstrap")))
     }
+    format_deps <- append(format_deps, extra_dependencies)
 
     extras <- html_extras_for_document(knit_meta, runtime, dependency_resolver,
                                        format_deps)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,10 @@
 rmarkdown 0.9.7 (unreleased)
 --------------------------------------------------------------------------------
 
+* Switched the order in which format dependencies are added for
+  `html_document` so that `extra_dependencies` are added at the end, after
+  bootstrap, etc. (#737)
+
 * `toc_float` no longer automatically sets `toc = TRUE`
 
 * Added an argument `error` to `pandoc_available()` to signal an error when (if


### PR DESCRIPTION
This way, custom formats can work "on top of" bootstrap, etc.

Please see https://github.com/ijlyttle/user2016docdemo/issues/1 for example and further rationale.