### PR TITLE
Try to install latexmk automatically on Windows

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -286,7 +286,7 @@ latexmk <- function(file, engine) {
   if (latexmk_path == '') {
     # latexmk not found
     latexmk_emu(file, engine)
-  } else if (find_program('perl') != '') {
+  } else if (find_program('perl') != '' && latexmk_installed(latexmk_path)) {
     system2_quiet(latexmk_path, c(
       '-pdf -latexoption=-halt-on-error -interaction=batchmode',
       paste0('-pdflatex=', shQuote(engine)), shQuote(file)
@@ -382,6 +382,16 @@ show_latex_error <- function(file) {
     message(paste(m, collapse = '\n'))
     stop(e, ' See ', logfile, ' for more info.', call. = FALSE)
   }
+}
+
+# check if latexmk was correctly installed; see more info at
+# https://github.com/rstudio/bookdown/issues/121
+latexmk_installed <- function(latexmk_path) {
+  if (system2_quiet(latexmk_path, '-v') == 0) return(TRUE)
+  warning('The LaTeX package latexmk was not correctly installed.', call. = FALSE)
+  if (!is_windows()) return(FALSE)
+  shell('latexmk -v')  # hopefully MiKTeX can fix it automatically
+  system2_quiet(latexmk_path, '-v') == 0
 }
 
 # check the version of latexmk

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -35,6 +35,8 @@ rmarkdown 1.0
 
 * Support for `keep_md` in `html_vignette` format.
 
+* Try to install the latexmk package automatically on Windows if the executable
+  latexmk.exe exists.
 
 rmarkdown 0.9.6
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Even if latexmk.exe and perl.exe are available, the LaTeX package latexmk may not have been installed: https://github.com/rstudio/bookdown/issues/121 Executing `shell('latexmk -v')` on Windows may trigger MiKTeX's automatic installation of the missing latexmk package.

If that still fails, we just use the fallback method of calling pdflatex/xelatex/... manually, which seems to work fine https://github.com/rstudio/bookdown-demo/issues/3