### PR TITLE
patch beamer template: restore paragraph spacing

### DIFF
--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -138,15 +138,10 @@ beamer_presentation <- function(toc = FALSE,
   )
 }
 
-patch_beamer_template <- function() {
-  pandoc_available(error = TRUE)
-  if (pandoc_version() >= '1.15.2') return()  # no need to patch the template
-  f <- tempfile(fileext = '.tex')
-  command <- paste(quoted(pandoc()), "-D beamer >", quoted(f))
-  with_pandoc_safe_environment({
-    if (system(command) != 0) stop("Failed to execute the command '", command, "'")
-  })
-  patch <- c(
+
+patch_beamer_template_pagenumber <- function(template) {
+
+  patch <- paste(
     "% Comment these out if you don't want a slide with just the",
     "% part/section/subsection/subsubsection title:", "\\AtBeginPart{",
     "  \\let\\insertpartnumber\\relax", "  \\let\\partname\\relax",
@@ -154,10 +149,69 @@ patch_beamer_template <- function() {
     "  \\let\\insertsectionnumber\\relax", "  \\let\\sectionname\\relax",
     "  \\frame{\\sectionpage}", "}", "\\AtBeginSubsection{",
     "  \\let\\insertsubsectionnumber\\relax", "  \\let\\subsectionname\\relax",
-    "  \\frame{\\subsectionpage}", "}"
+    "  \\frame{\\subsectionpage}", "}",
+    sep = "\n"
   )
-  tpl <- readLines(f, encoding = 'UTF-8')
-  tpl <- sub(paste(patch, collapse = '\n'), '', paste(tpl, collapse = '\n'), fixed = TRUE)
-  writeLines(enc2utf8(tpl), f, useBytes = TRUE)
+
+  pasted <- paste(template, collapse = "\n")
+  patched <- sub(patch, "", pasted, fixed = TRUE)
+  strsplit(patched, "\n", fixed = TRUE)[[1]]
+}
+
+patch_beamer_template_paragraph_spacing <- function(template) {
+
+  patch <- c(
+    "\\setlength{\\parindent}{0pt}",
+    "\\setlength{\\parskip}{6pt plus 2pt minus 1pt}"
+  )
+
+  lines <- unlist(lapply(patch, function(line) {
+    index <- grep(line, template, fixed = TRUE)
+    if (length(index) == 1) index else -1
+  }))
+
+  # bail if we already have these lines in the document
+  if (all(lines >= 0) && lines[[1]] == lines[[2]] - 1)
+    return(template)
+
+  # find patch location -- we insert before this line
+  targetLine <- "\\setlength{\\emergencystretch}{3em}  % prevent overfull lines"
+  targetIdx <- grep(targetLine, template, fixed = TRUE)
+  if (!length(targetIdx))
+    return(template)
+
+  # insert patch
+  c(
+    head(template, n = targetIdx - 1),
+    patch,
+    tail(template, n = -(targetIdx - 1))
+  )
+}
+
+patch_beamer_template <- function() {
+  pandoc_available(error = TRUE)
+
+  # invoke pandoc to copy default template to tempfile path, then
+  # read that in as a UTF-8 character vector
+  f <- tempfile(fileext = '.tex')
+  command <- paste(quoted(pandoc()), "-D beamer >", quoted(f))
+  with_pandoc_safe_environment({
+    if (system(command) != 0) stop("Failed to execute the command '", command, "'")
+  })
+  template <- readLines(f, encoding = "UTF-8")
+  template <- gsub("^\\s+|\\s+$", "", template, perl = TRUE)
+
+  # apply patches
+  version <- pandoc_version()
+
+  if (version < "1.15.2")
+    template <- patch_beamer_template_pagenumber(template)
+
+  if (version > "1.15.2" && version < "1.17.3")
+    template <- patch_beamer_template_paragraph_spacing(template)
+
+  # write and return path to template
+  template <- paste(template, collapse = "\n")
+  writeLines(enc2utf8(template), f, useBytes = TRUE)
   f
 }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,9 @@
 rmarkdown 1.1 (unreleased)
 --------------------------------------------------------------------------------
 
+* Fixed an issue where the default Beamer template did not provide vertical
+  padding between paragraphs with certain versions of pandoc (<= 1.17.2).
+
 * Try to install latexmk automatically on Windows
 
 * Added `df_print` option to html_document format for optionally printing data


### PR DESCRIPTION
This resolves https://github.com/rstudio/rmarkdown/issues/744.