### PR TITLE
Include column type in paged tables and improve alignment

### DIFF
--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -47,15 +47,34 @@ html_notebook <- function(toc = FALSE,
   }
 
   paged_table_html = function(x) {
+    columns <- unname(lapply(
+      names(x),
+      function(columnName) {
+        type <- class(x[[columnName]])[[1]]
+        list(
+          name = jsonlite::unbox(columnName),
+          type = jsonlite::unbox(type),
+          align = jsonlite::unbox(
+            if (type == "character" || type == "factor") "left" else "right"
+          )
+        )
+      }
+    ))
+
+    data <- head(x, 1000)
+
+    if (length(columns) > 0) {
+      first_column = data[[1]]
+      if (is.numeric(first_column) && all(diff(first_column) == 1))
+        columns[[1]]$align <- "left"
+    }
+
     paste(
       "<div data-pagedtable>",
       "  <script data-pagedtable-source type=\"application/json\">",
       jsonlite::toJSON(list(
-        types = unlist(lapply(
-          sapply(x, class),
-          function(e) e[[1]]
-        )),
-        data = head(x, 1000)
+        columns = columns,
+        data = data
       )),
       "  </script>",
       "</div>",

--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -51,7 +51,10 @@ html_notebook <- function(toc = FALSE,
       "<div data-pagedtable>",
       "  <script data-pagedtable-source type=\"application/json\">",
       jsonlite::toJSON(list(
-        types = sapply(x, class),
+        types = unlist(lapply(
+          sapply(x, class),
+          function(e) e[[1]]
+        )),
         data = head(x, 1000)
       )),
       "  </script>",

--- a/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
@@ -104,3 +104,8 @@ a.pagedtable-index-current:hover {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+.pagedtable-header-type {
+  color: #999;
+  font-weight: 100;
+}

--- a/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
@@ -2,6 +2,7 @@
   overflow: auto;
   padding-left: 8px;
   padding-right: 8px;
+  margin-bottom: 10px;
 }
 
 .pagedtable-not-empty .pagedtable {

--- a/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
@@ -75,18 +75,6 @@ a.pagedtable-index-current:hover {
   text-align: center;
 }
 
-.pagedtable-type {
-  text-align: right;
-}
-
-.pagedtable-type-character {
-  text-align: left;
-}
-
-.pagedtable-type-factor {
-  text-align: left;
-}
-
 .pagedtable-footer {
   min-width: 380px;
   padding-top: 4px;

--- a/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
@@ -13,13 +13,14 @@ var PagedTable = function (pagedTable) {
     if (columns.length > 10) {
       columns = columns.slice(1, 10);
       columns[10] = "...";
+      types[10] = null;
     }
 
     var typedColumns = columns.map(function(columnName, columnIdx) {
       return {
         name: columnName,
         type: types[columnIdx]
-      }
+      };
     });
 
     return typedColumns;
@@ -38,7 +39,17 @@ var PagedTable = function (pagedTable) {
       column.setAttribute("align", "");
       column.setAttribute("class", "pagedtable-type pagedtable-type-" + columnData.type);
 
-      column.appendChild(document.createTextNode(columnData.name));
+      var columnName = document.createElement("div");
+      columnName.appendChild(document.createTextNode(columnData.name));
+      column.appendChild(columnName);
+
+      if (columnData.type !== null) {
+        var columnType = document.createElement("div");
+        columnType.setAttribute("class", "pagedtable-header-type");
+        columnType.appendChild(document.createTextNode("(" + columnData.type + ")"));
+        column.appendChild(columnType);
+      }
+
       header.appendChild(column);
     });
 

--- a/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
@@ -3,23 +3,26 @@ var PagedTable = function (pagedTable) {
   var pageNumber = 0;
   var pageCount;
   var data;
-  var types;
+  var columnsData;
 
-  var columnsFromJson = function(json) {
+  var columnsFromSource = function(json) {
     if (json === null || json.length === 0)
       return [];
 
-    var columns = Object.keys(json[0]);
+    var columns = json.columns;
     if (columns.length > 10) {
       columns = columns.slice(1, 10);
-      columns[10] = "...";
-      types[10] = null;
+      columns[10] = {
+        name: "...",
+        type: ""
+      };
     }
 
-    var typedColumns = columns.map(function(columnName, columnIdx) {
+    var typedColumns = columns.map(function(column) {
       return {
-        name: columnName,
-        type: types[columnIdx]
+        name: column.name,
+        type: column.type,
+        align: column.align
       };
     });
 
@@ -33,11 +36,9 @@ var PagedTable = function (pagedTable) {
     var header = document.createElement("tr");
     thead.appendChild(header);
 
-    var columnsData = columnsFromJson(data);
     columnsData.forEach(function(columnData) {
       var column = document.createElement("th");
-      column.setAttribute("align", "");
-      column.setAttribute("class", "pagedtable-type pagedtable-type-" + columnData.type);
+      column.setAttribute("align", columnData.align);
 
       var columnName = document.createElement("div");
       columnName.appendChild(document.createTextNode(columnData.name));
@@ -60,8 +61,6 @@ var PagedTable = function (pagedTable) {
     var tbody = pagedTable.querySelectorAll("tbody")[0];
     tbody.innerHTML = "";
 
-    var columnsData = columnsFromJson(data);
-
     var pageData = data.slice(pageNumber * pageSize, (pageNumber + 1) * pageSize);
 
     pageData.forEach(function(dataRow, idxRow) {
@@ -73,7 +72,7 @@ var PagedTable = function (pagedTable) {
         var dataCell = cellName === "..." ? "" : dataRow[cellName];
         var htmlCell = document.createElement("td");
         htmlCell.appendChild(document.createTextNode(dataCell));
-        htmlCell.setAttribute("class", "pagedtable-type pagedtable-type-" + columnData.type);
+        htmlCell.setAttribute("align", columnData.align);
         htmlRow.appendChild(htmlCell);
       });
 
@@ -183,9 +182,9 @@ var PagedTable = function (pagedTable) {
       throw("A single data-pagedtable-source was not found");
     }
 
-    var source = JSON.parse(sourceElems[0].innerHTML);
+    source = JSON.parse(sourceElems[0].innerHTML);
     data = source.data;
-    types = source.types;
+    columnsData = columnsFromSource(source);
   };
 
   var setPageNumber = function(newPageNumber) {


### PR DESCRIPTION
Closing on two remaining follow ups from https://github.com/rstudio/rmarkdown/pull/751:

1. Include column types in headers.
2. Left align id column.

<img width="926" alt="screen shot 2016-08-01 at 1 21 51 pm" src="https://cloud.githubusercontent.com/assets/3478847/17307645/0622235c-57eb-11e6-8745-bc575cb89d8c.png">
<img width="926" alt="screen shot 2016-08-01 at 1 22 03 pm" src="https://cloud.githubusercontent.com/assets/3478847/17307646/0633ec2c-57eb-11e6-95d5-43568bc83a0a.png">
