### PR TITLE
remove the warning about Perl

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -296,7 +296,6 @@ latexmk <- function(file, engine) {
     })
     system2(latexmk_path, '-c', stdout = FALSE)  # clean up nonessential files
   } else {
-    warning("Perl must be installed and put on PATH for latexmk to work")
     latexmk_emu(file, engine)
   }
 }


### PR DESCRIPTION
it is fine if Perl is not installed, so the warning is actually very confusing (e.g. rstudio/bookdown#169)