### PR TITLE
render code as markdown rather than HTML

### DIFF
--- a/R/html_notebook_output.R
+++ b/R/html_notebook_output.R
@@ -88,10 +88,7 @@ html_notebook_output_code <- function(code,
   )
 
   # update metadata
-  if ("data" %in% names(meta)) {
-    warning("'data' element of metadata will be overwritten")
-    meta$data <- code
-  }
+  meta$data <- code
 
   # render
   html_notebook_annotated_output(code, "source", meta)

--- a/R/html_notebook_output.R
+++ b/R/html_notebook_output.R
@@ -80,12 +80,12 @@ html_notebook_output_code <- function(code,
                                       attributes = list(class = "r"),
                                       meta = NULL)
 {
-  # normalize code
-  joined <- htmltools::htmlEscape(join(code, collapse = "\n"))
-
-  # generate html
-  format <- '<pre%s><code>%s</code></pre>'
-  html <- sprintf(format, to_html_attributes(attributes), joined)
+  # generate code
+  code <- sprintf(
+    "```%s\n%s\n```",
+    attributes$class,
+    paste(code, collapse = "\n")
+  )
 
   # update metadata
   if ("data" %in% names(meta)) {
@@ -94,5 +94,5 @@ html_notebook_output_code <- function(code,
   }
 
   # render
-  html_notebook_annotated_output(html, "source", meta)
+  html_notebook_annotated_output(code, "source", meta)
 }


### PR DESCRIPTION
This PR resolves an issue where attempting to preview an HTML notebook would not preserve custom (pandoc-generated) highlighting schemes.

The overarching issue was that, because we rendered code directly as HTML (rather than as Markdown), the pandoc highlighter did not run on that chunk. The resolution here is to just render the code as markdown instead, so that the pandoc highlighter (if active) can take charge in rendering the code as desired.