### PR TITLE
add support to print paged tables in html and presentations

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -299,6 +299,17 @@ html_document <- function(toc = FALSE,
     }
   }
 
+  # pagedtable global options
+  if (identical(df_print, "paged")) {
+    options("dplyr.tibble.print" = function(x, n, width, ...) {
+      isSQL <- "tbl_sql" %in% class(x)
+      n <- if (isSQL) getOption("sql.max.print", 1000) else getOption("max.print", 1000)
+
+      df <- as.data.frame(head(x, n))
+      print(df)
+    })
+  }
+
   # pre-processor for arguments that may depend on the name of the
   # the input file AND which need to inject html dependencies
   # (otherwise we could just call the pre_processor)

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -368,6 +368,13 @@ html_document <- function(toc = FALSE,
                                                lib_dir,
                                                output_dir))
 
+    # pagedtable
+    args <- c(args, pandoc_html_pagedtable_args(df_print,
+                                               template,
+                                               self_contained,
+                                               lib_dir,
+                                               output_dir))
+
     # bootstrap navigation (requires theme)
     if (!is.null(theme)) {
 

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -305,7 +305,7 @@ html_document <- function(toc = FALSE,
       isSQL <- "tbl_sql" %in% class(x)
       n <- if (isSQL) getOption("sql.max.print", 1000) else getOption("max.print", 1000)
 
-      df <- as.data.frame(head(x, n))
+      df <- as.data.frame(utils::head(x, n))
       print(df)
     })
   }

--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -47,85 +47,6 @@ html_notebook <- function(toc = FALSE,
       try(action())
   }
 
-  paged_table_html = function(x) {
-    data <- head(x, getOption("max.print", 1000))
-    data <- if (is.null(data)) as.data.frame(list()) else data
-
-    columnNames <- names(data)
-    columnSequence <- seq_len(ncol(data))
-
-    columns <- lapply(
-      columnSequence,
-      function(columnIdx) {
-        column <- data[[columnIdx]]
-        baseType <- class(column)[[1]]
-        tibbleType <- tibble::type_sum(column)
-
-        list(
-          label = if (!is.null(columnNames)) columnNames[[columnIdx]] else "",
-          name = columnIdx,
-          type = tibbleType,
-          align = if (baseType == "character" || baseType == "factor") "left" else "right"
-        )
-      }
-    )
-
-    names(data) <- columnSequence
-
-    # add the names column
-    columns <- unname(
-      c(
-        list(
-          list(
-            label = "",
-            name = "_rn_",
-            type = "",
-            align = "left"
-          )
-        ),
-        columns
-      )
-    )
-
-    data$`_rn_` <- rownames(data)
-
-    is_list <- vapply(data, is.list, logical(1))
-    data[is_list] <- lapply(data[is_list], function(x) {
-      summary <- tibble::obj_sum(x)
-      paste0("<", summary, ">")
-    })
-
-    if (length(columns) > 0) {
-      first_column = data[[1]]
-      if (is.numeric(first_column) && all(diff(first_column) == 1))
-        columns[[1]]$align <- "left"
-    }
-
-    data <- as.data.frame(
-      lapply(
-        data,
-        function (y) format(y)),
-      stringsAsFactors = FALSE,
-      optional = TRUE)
-
-    list(
-      columns = columns,
-      data = if (length(data) == 0) list() else data
-    )
-
-    paste(
-      "<div data-pagedtable>",
-      "  <script data-pagedtable-source type=\"application/json\">",
-      jsonlite::toJSON(list(
-        columns = columns,
-        data = data
-      )),
-      "  </script>",
-      "</div>",
-      sep = "\n"
-    )
-  }
-
   paged_table_html_asis = function(x) {
     knitr::asis_output(
       paged_table_html(x)
@@ -255,7 +176,7 @@ html_notebook <- function(toc = FALSE,
 
   # these arguments to html_document are fixed so we need to
   # flag them as invalid for users
-  fixed_args <- c("keep_md", "template", "lib_dir", "dev", "df_print")
+  fixed_args <- c("keep_md", "template", "lib_dir", "dev")
   forwarded_args <- names(list(...))
   for (arg in forwarded_args) {
     if (arg %in% fixed_args)

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -1,4 +1,4 @@
-paged_table_html = function(x) {
+paged_table_html <- function(x) {
   data <- head(x, getOption("max.print", 1000))
   data <- if (is.null(data)) as.data.frame(list()) else data
 
@@ -21,11 +21,11 @@ paged_table_html = function(x) {
     }
   )
 
-  names(data) <- columnSequence
+  names(data) <- as.character(columnSequence)
 
-  # add the names column
-  columns <- unname(
-    c(
+  addRowNames = all.equal(.row_names_info(data), -50)
+  if (addRowNames) {
+    columns <- c(
       list(
         list(
           label = "",
@@ -36,9 +36,11 @@ paged_table_html = function(x) {
       ),
       columns
     )
-  )
 
-  data$`_rn_` <- rownames(data)
+    data$`_rn_` <- rownames(data)
+  }
+
+  columns <- unname(columns)
 
   is_list <- vapply(data, is.list, logical(1))
   data[is_list] <- lapply(data[is_list], function(x) {
@@ -59,13 +61,23 @@ paged_table_html = function(x) {
     stringsAsFactors = FALSE,
     optional = TRUE)
 
+  pagedTableOptions <- list(
+    columns = list(
+      min = getOption("cols.min.print"),
+      max = getOption("cols.print")
+    ),
+    rows = getOption("rows.print"),
+    pages = getOption("pages.print")
+  )
+
   list(
     columns = columns,
-    data = if (length(data) == 0) list() else data
+    data = if (length(data) == 0) list() else data,
+    options = pagedTableOptions
   )
 
   paste(
-    "<div data-pagedtable>",
+    "<div data-pagedtable=\"true\">",
     "  <script data-pagedtable-source type=\"application/json\">",
     jsonlite::toJSON(list(
       columns = columns,

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -23,7 +23,7 @@ paged_table_html <- function(x) {
 
   names(data) <- as.character(columnSequence)
 
-  addRowNames = all.equal(.row_names_info(data), -50)
+  addRowNames = .row_names_info(data, type = 1) > 0
   if (addRowNames) {
     columns <- c(
       list(

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -51,14 +51,25 @@ paged_table_html <- function(x) {
 
   if (length(columns) > 0) {
     first_column = data[[1]]
-    if (is.numeric(first_column) && all(diff(first_column) == 1))
+    if (is.numeric(first_column) && isTRUE(all(diff(first_column) == 1)))
       columns[[1]]$align <- "left"
   }
 
   data <- as.data.frame(
     lapply(
       data,
-      function (y) encodeString(format(y, digits = getOption("digits")))),
+      function (y) {
+        # escape NAs from character columns
+        if (typeof(y) == "character") {
+          y[y == "NA"] <- "__NA__"
+        }
+
+        y <- encodeString(format(y, digits = getOption("digits")))
+
+        # trim spaces
+        gsub("^\\s+|\\s+$", "", y)
+      }
+    ),
     stringsAsFactors = FALSE,
     optional = TRUE)
 

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -1,0 +1,78 @@
+paged_table_html = function(x) {
+  data <- head(x, getOption("max.print", 1000))
+  data <- if (is.null(data)) as.data.frame(list()) else data
+
+  columnNames <- names(data)
+  columnSequence <- seq_len(ncol(data))
+
+  columns <- lapply(
+    columnSequence,
+    function(columnIdx) {
+      column <- data[[columnIdx]]
+      baseType <- class(column)[[1]]
+      tibbleType <- tibble::type_sum(column)
+
+      list(
+        label = if (!is.null(columnNames)) columnNames[[columnIdx]] else "",
+        name = columnIdx,
+        type = tibbleType,
+        align = if (baseType == "character" || baseType == "factor") "left" else "right"
+      )
+    }
+  )
+
+  names(data) <- columnSequence
+
+  # add the names column
+  columns <- unname(
+    c(
+      list(
+        list(
+          label = "",
+          name = "_rn_",
+          type = "",
+          align = "left"
+        )
+      ),
+      columns
+    )
+  )
+
+  data$`_rn_` <- rownames(data)
+
+  is_list <- vapply(data, is.list, logical(1))
+  data[is_list] <- lapply(data[is_list], function(x) {
+    summary <- tibble::obj_sum(x)
+    paste0("<", summary, ">")
+  })
+
+  if (length(columns) > 0) {
+    first_column = data[[1]]
+    if (is.numeric(first_column) && all(diff(first_column) == 1))
+      columns[[1]]$align <- "left"
+  }
+
+  data <- as.data.frame(
+    lapply(
+      data,
+      function (y) format(y)),
+    stringsAsFactors = FALSE,
+    optional = TRUE)
+
+  list(
+    columns = columns,
+    data = if (length(data) == 0) list() else data
+  )
+
+  paste(
+    "<div data-pagedtable>",
+    "  <script data-pagedtable-source type=\"application/json\">",
+    jsonlite::toJSON(list(
+      columns = columns,
+      data = data
+    )),
+    "  </script>",
+    "</div>",
+    sep = "\n"
+  )
+}

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -1,5 +1,5 @@
 paged_table_html <- function(x) {
-  data <- head(x, getOption("max.print", 1000))
+  data <- utils::head(x, getOption("max.print", 1000))
   data <- if (is.null(data)) as.data.frame(list()) else data
 
   columnNames <- names(data)

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -1,4 +1,6 @@
 paged_table_html <- function(x) {
+  addRowNames = .row_names_info(data, type = 1) > 0
+
   data <- utils::head(x, getOption("max.print", 1000))
   data <- if (is.null(data)) as.data.frame(list()) else data
 
@@ -23,7 +25,6 @@ paged_table_html <- function(x) {
 
   names(data) <- as.character(columnSequence)
 
-  addRowNames = .row_names_info(data, type = 1) > 0
   if (addRowNames) {
     columns <- c(
       list(
@@ -57,7 +58,7 @@ paged_table_html <- function(x) {
   data <- as.data.frame(
     lapply(
       data,
-      function (y) format(y)),
+      function (y) encodeString(format(y, digits = getOption("digits")))),
     stringsAsFactors = FALSE,
     optional = TRUE)
 

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -35,6 +35,15 @@ ioslides_presentation <- function(logo = NULL,
   if (widescreen)
     args <- c(args, "--variable", "widescreen");
 
+  # pagedtables
+  if (identical(df_print, "paged")) {
+    pagedtable_path <- rmarkdown_system_file("rmd/h/pagedtable-0.0.1")
+    pagedtable_path <- pandoc_path_arg(pagedtable_path)
+
+    args <- c(args,
+              "--variable", paste("pagedtablejs=", pagedtable_path, sep=""))
+  }
+
   # transition
   if (is.numeric(transition))
     transition <- as.character(transition)

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -494,6 +494,30 @@ pandoc_html_navigation_args <- function(self_contained,
             "--variable", paste("navigationjs=", navigation_path, sep=""))
 }
 
+pandoc_html_pagedtable_args <- function(df_print,
+                                        template,
+                                        self_contained,
+                                        files_dir,
+                                        output_dir) {
+  args <- c()
+
+  if (identical(df_print, "paged")) {
+    pagedtable_path <- rmarkdown_system_file("rmd/h/pagedtable-0.0.1")
+    if (self_contained)
+      pagedtable_path <- pandoc_path_arg(pagedtable_path)
+    else
+    {
+      pagedtable_path <- normalized_relative_to(output_dir,
+                                                render_supporting_files(pagedtable_path, files_dir))
+    }
+
+    args <- c(args,
+              "--variable", paste("pagedtablejs=", pagedtable_path, sep=""))
+  }
+
+  args
+}
+
 pandoc_html_highlight_args <- function(highlight,
                                        template,
                                        self_contained,

--- a/R/render.R
+++ b/R/render.R
@@ -677,7 +677,7 @@ merge_render_context <- function(context) {
 resolve_df_print <- function(df_print) {
 
   # available methods
-  valid_methods <- c("default", "kable", "tibble")
+  valid_methods <- c("default", "kable", "tibble", "paged")
 
   # if we are passed NULL then select the first method
   if (is.null(df_print))
@@ -692,6 +692,8 @@ resolve_df_print <- function(df_print) {
       df_print <- knitr::kable
     else if (df_print == "tibble")
       df_print <- function(x) print(tibble::as_tibble(x))
+    else if (df_print == "paged")
+      df_print <- function(x) knitr::asis_output(paged_table_html(x))
     else if (df_print == "default")
       df_print <- print
     else

--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -91,6 +91,15 @@ slidy_presentation <- function(incremental = FALSE,
   # content includes
   args <- c(args, includes_to_pandoc_args(includes))
 
+  # pagedtables
+  if (identical(df_print, "paged")) {
+    pagedtable_path <- rmarkdown_system_file("rmd/h/pagedtable-0.0.1")
+    pagedtable_path <- pandoc_path_arg(pagedtable_path)
+
+    args <- c(args,
+              "--variable", paste("pagedtablejs=", pagedtable_path, sep=""))
+  }
+
   # additional css
   for (css_file in css)
     args <- c(args, "--css", pandoc_path_arg(css_file))

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -119,6 +119,11 @@ $for(css)$
 <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
 $endfor$
 
+$if(pagedtablejs)$
+<link rel="stylesheet" href="$pagedtablejs$/css/pagedtable.css"
+      $if(html5)$$else$type="text/css" $endif$/>
+<script src="$pagedtablejs$/js/pagedtable.js"></script>
+$endif$
 </head>
 
 <body>

--- a/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
@@ -13,7 +13,7 @@
 .pagedtable table {
   width: 100%;
   max-width: 100%;
-  margin-bottom: 0;
+  margin: 0;
 }
 
 .pagedtable th {
@@ -26,6 +26,10 @@
 
 .pagedtable-empty th {
   display: none;
+}
+
+.pagedtable td {
+  padding: 0 4px 0 4px;
 }
 
 .pagedtable .even {
@@ -49,6 +53,7 @@
   cursor: pointer;
   padding: 0 5px 0 5px;
   float: right;
+  border: 0;
 }
 
 .pagedtable-index-nav-disabled {
@@ -65,6 +70,7 @@ a.pagedtable-index-nav-disabled:hover {
 .pagedtable-indexes {
   cursor: pointer;
   float: right;
+  border: 0;
 }
 
 .pagedtable-index-current {
@@ -72,6 +78,7 @@ a.pagedtable-index-nav-disabled:hover {
   text-decoration: none;
   font-weight: bold;
   color: #333;
+  border: 0;
 }
 
 a.pagedtable-index-current:hover {
@@ -84,6 +91,7 @@ a.pagedtable-index-current:hover {
   width: 30px;
   display: inline-block;
   text-align: center;
+  border: 0;
 }
 
 .pagedtable-footer {
@@ -97,7 +105,6 @@ a.pagedtable-index-current:hover {
 
 .pagedtable-info {
   overflow: hidden;
-  max-height: 20px;
   color: #999;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-0.0.1/css/pagedtable.css
@@ -114,3 +114,8 @@ a.pagedtable-index-current:hover {
   color: #999;
   font-weight: 400;
 }
+
+.pagedtable-na-cell {
+  font-style: italic;
+  opacity: 0.3;
+}

--- a/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
@@ -632,7 +632,12 @@ var PagedTable = function (pagedTable) {
         var cellName = columnData.name;
         var dataCell = dataRow[cellName];
         var htmlCell = document.createElement("td");
-        htmlCell.appendChild(document.createTextNode(dataCell));
+
+        if (dataCell === "NA") htmlCell.setAttribute("class", "pagedtable-na-cell");
+        if (dataCell === "__NA__") dataCell = "NA";
+
+        var cellText = document.createTextNode(dataCell);
+        htmlCell.appendChild(cellText);
         if (dataCell.length > 50) {
           htmlCell.setAttribute("title", dataCell);
         }

--- a/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
@@ -191,7 +191,7 @@ var PagedTable = function (pagedTable) {
     var me = this;
 
     var defaults = {
-      max: 9,
+      max: 1,
       rows: 10
     };
 
@@ -266,7 +266,8 @@ var PagedTable = function (pagedTable) {
     var me = this;
 
     me.defaults = {
-      max: 10
+      max: 10,
+      min: 5
     };
 
     me.number = 0;
@@ -274,7 +275,7 @@ var PagedTable = function (pagedTable) {
     me.total = columns.length;
     me.subset = [];
     me.padding = 0;
-    me.min = options.columns !== null ? options.columns.min : null;
+    me.min = options.columns !== null && options.columns.min !== null ? options.columns.min : me.defaults.min;
     me.max = options.columns !== null && options.columns.max !== null ? options.columns.max : me.defaults.max;
     me.widths = {};
 
@@ -676,16 +677,17 @@ var PagedTable = function (pagedTable) {
   var getLabelInfo = function() {
     var pageStart = page.getRowStart();
     var pageEnd = page.getRowEnd();
-    var totalRecods = data.length;
+    var totalRows = data.length;
+    var totalRowsLabel = totalRows.toString().replace(/(\d)(?=(\d{3})+\.)/g, '$1,');
 
-    var infoText = (pageStart + 1) + "-" + pageEnd + " of " + totalRecods + " Records";
-    if (totalRecods < page.rows) {
-      infoText = totalRecods + " Record" + (totalRecods != 1 ? "s" : "");
+    var infoText = (pageStart + 1) + "-" + pageEnd + " of " + totalRowsLabel + " rows";
+    if (totalRows < page.rows) {
+      infoText = totalRowsLabel + " row" + (totalRows != 1 ? "s" : "");
     }
     if (columns.total > columns.visible) {
       infoText = infoText + " | " + (columns.number + 1) + "-" +
         (Math.min(columns.number + columns.visible, columns.total)) +
-        " of " + columns.total + " Columns";
+        " of " + columns.total + " columns";
     }
 
     return infoText;

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -114,7 +114,11 @@ $endfor$
 $for(header-includes)$
   $header-includes$
 $endfor$
-
+$if(pagedtablejs)$
+<link rel="stylesheet" href="$pagedtablejs$/css/pagedtable.css"
+      $if(html5)$$else$type="text/css" $endif$/>
+<script src="$pagedtablejs$/js/pagedtable.js"></script>
+$endif$
 </head>
 
 <body style="opacity: 0">

--- a/inst/rmd/slidy/default.html
+++ b/inst/rmd/slidy/default.html
@@ -13,10 +13,10 @@ $if(date-meta)$
   <meta name="date" content="$date-meta$" />
 $endif$
 $if(footer)$
-  <meta name="copyright" content="$footer$"/> 
+  <meta name="copyright" content="$footer$"/>
 $endif$
 $if(font-size-adjustment)$
-  <meta name="font-size-adjustment" content="$font-size-adjustment$"/> 
+  <meta name="font-size-adjustment" content="$font-size-adjustment$"/>
 $endif$
   <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
   <style type="text/css">code{white-space: pre;}</style>
@@ -38,6 +38,11 @@ $endfor$
     charset="utf-8" type="text/javascript"></script>
 $if(duration)$
   <meta name="duration" content="$duration$" />
+$endif$
+$if(pagedtablejs)$
+<link rel="stylesheet" href="$pagedtablejs$/css/pagedtable.css"
+      $if(html5)$$else$type="text/css" $endif$/>
+<script src="$pagedtablejs$/js/pagedtable.js"></script>
 $endif$
 </head>
 <body>


### PR DESCRIPTION
This PR adds support for `paged` as an option in `df_print` which will cause documents to use paged tables while printing data frames.

@jjallaire Any suggestions on how to respect the chunk options within the HTML render? Currently options are only supported at a global level but would be nice to respect the chunk options as well. For instance, by reading the chunk options at this level: https://github.com/rstudio/rmarkdown/blob/master/R/knit_print.R

**HTML Documents:**
<img width="1440" alt="screen shot 2016-08-17 at 2 23 09 pm" src="https://cloud.githubusercontent.com/assets/3478847/17754065/aae0c706-6487-11e6-9007-6d7a6a44011b.png">

**Presentation Documents:**
<img width="1440" alt="screen shot 2016-08-17 at 2 15 05 pm" src="https://cloud.githubusercontent.com/assets/3478847/17754064/aad4238e-6487-11e6-9cbd-e59ef5deaacc.png">
