### PR TITLE
Fix #779: generate .tex before .pdf

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -522,10 +522,10 @@ render <- function(input,
       if ((texfile != output_file) && !output_format$pandoc$keep_tex)
         on.exit(unlink(texfile), add = TRUE)
     } else {
+      # generate .tex if we want to keep the tex source
+      if (output_format$pandoc$keep_tex) convert(texfile, run_citeproc)
       # run the main conversion if the output file is not .tex
       convert(output_file, run_citeproc)
-      # run conversion again to .tex if we want to keep the tex source
-      if (output_format$pandoc$keep_tex) convert(texfile, run_citeproc)
     }
 
     # pandoc writes the output alongside the input, so if we rendered from an

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -27,6 +27,8 @@ rmarkdown 1.1 (unreleased)
   `html_document` so that `extra_dependencies` are added at the end, after
   bootstrap, etc. (#737)
 
+* `pdf_document(keep_tex = TRUE)` will generate the .tex document even if PDF
+  conversion fails (#779).
 
 rmarkdown 1.0
 --------------------------------------------------------------------------------


### PR DESCRIPTION
So that .tex is preserved when pandoc fails to convert Markdown to PDF