### PR TITLE
Move latex header to just before \begin{document}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
   person("Jeff", "Allen", role = "aut", email = "jeff@rstudio.com"),
   person("Hadley", "Wickham", role = "aut", email = "hadley@rstudio.com"),
   person("Aron", "Atkins", role = "aut", email = "aron@rstudio.com"),
-  person("Rob", "Hyndman", role = "aut", email = "robjhyndman@gmail.com"),
+  person("Rob", "Hyndman", role = "aut", email = "Rob.Hyndman@monash.edu"),
   person(family = "RStudio, Inc.", role = "cph"),
   person(family = "jQuery Foundation", role = "cph",
          comment = "jQuery library"),

--- a/inst/rmd/latex/default-1.14.tex
+++ b/inst/rmd/latex/default-1.14.tex
@@ -179,10 +179,6 @@ $else$
   \predate{}\postdate{}
 $endif$
 
-$for(header-includes)$
-$header-includes$
-$endfor$
-
 % Redefines (sub)paragraphs to behave more like sections
 \ifx\paragraph\undefined\else
 \let\oldparagraph\paragraph
@@ -192,6 +188,10 @@ $endfor$
 \let\oldsubparagraph\subparagraph
 \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
 \fi
+
+$for(header-includes)$
+$header-includes$
+$endfor$
 
 \begin{document}
 \maketitle

--- a/inst/rmd/latex/default-1.15.2.tex
+++ b/inst/rmd/latex/default-1.15.2.tex
@@ -213,10 +213,6 @@ $else$
 $endif$
 
 
-$for(header-includes)$
-$header-includes$
-$endfor$
-
 $if(subparagraph)$
 $else$
 % Redefines (sub)paragraphs to behave more like sections
@@ -229,6 +225,10 @@ $else$
 \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
 \fi
 $endif$
+
+$for(header-includes)$
+$header-includes$
+$endfor$
 
 \begin{document}
 $if(title)$

--- a/inst/rmd/latex/default-1.17.0.2.tex
+++ b/inst/rmd/latex/default-1.17.0.2.tex
@@ -185,9 +185,6 @@ $if(dir)$
   \newenvironment{LTR}{\beginL}{\endL}
 \fi
 $endif$
-$for(header-includes)$
-$header-includes$
-$endfor$
 
 %%% Use protect on footnotes to avoid problems with footnotes in titles
 \let\rmarkdownfootnote\footnote%
@@ -232,6 +229,10 @@ $else$
   \date{}
   \predate{}\postdate{}
 $endif$
+
+$for(header-includes)$
+$header-includes$
+$endfor$
 
 \begin{document}
 $if(title)$

--- a/inst/rmd/latex/default.tex
+++ b/inst/rmd/latex/default.tex
@@ -180,7 +180,6 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
-
 \begin{document}
 
 \maketitle


### PR DESCRIPTION
This addresses https://github.com/rstudio/rmarkdown/issues/736
It just involves moving the user-defined preamble to the last thing processed before \begin{document} to allow users to make any changes they want.