### PR TITLE
Make the "show code" buttons more CSS-friendly

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -245,6 +245,12 @@ $$(document).ready(function () {
 
 <!-- code folding -->
 $if(code_menu)$
+<style type="text/css">
+.code-folding-btn { 
+  float: right;
+  margin-bottom: 4px;
+}
+</style>
 <script src="$navigationjs$/codefolding.js"></script>
 $if(source_embed)$
 <script src="$navigationjs$/FileSaver.min.js"></script>

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -246,10 +246,7 @@ $$(document).ready(function () {
 <!-- code folding -->
 $if(code_menu)$
 <style type="text/css">
-.code-folding-btn { 
-  float: right;
-  margin-bottom: 4px;
-}
+.code-folding-btn { margin-bottom: 4px; }
 </style>
 <script src="$navigationjs$/codefolding.js"></script>
 $if(source_embed)$

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -36,7 +36,7 @@ window.initializeCodeFolding = function(show) {
     showCodeButton
         .attr('data-toggle', 'collapse')
         .attr('data-target', '#' + id)
-        .attr('aria-expanded', true)
+        .attr('aria-expanded', show)
         .attr('aria-controls', id)
         .css('margin-bottom', '4px');
 

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -31,14 +31,13 @@ window.initializeCodeFolding = function(show) {
 
     // add a show code button right above
     var showCodeText = $('<span>' + (show ? 'Hide' : 'Code') + '</span>');
-    var showCodeButton = $('<button type="button" class="btn btn-default btn-xs code-folding-btn pull-right"></button>');
+    var showCodeButton = $('<button type="button" class="btn btn-default btn-xs code-folding-btn"></button>');
     showCodeButton.append(showCodeText);
     showCodeButton
         .attr('data-toggle', 'collapse')
         .attr('data-target', '#' + id)
         .attr('aria-expanded', show)
-        .attr('aria-controls', id)
-        .css('margin-bottom', '4px');
+        .attr('aria-controls', id);
 
     var buttonRow = $('<div class="row"></div>');
     var buttonCol = $('<div class="col-md-12"></div>');

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -31,7 +31,7 @@ window.initializeCodeFolding = function(show) {
 
     // add a show code button right above
     var showCodeText = $('<span>' + (show ? 'Hide' : 'Code') + '</span>');
-    var showCodeButton = $('<button type="button" class="btn btn-default btn-xs code-folding-btn"></button>');
+    var showCodeButton = $('<button type="button" class="btn btn-default btn-xs code-folding-btn pull-right"></button>');
     showCodeButton.append(showCodeText);
     showCodeButton
         .attr('data-toggle', 'collapse')


### PR DESCRIPTION
For code folding, the show/hide code buttons have some hard-coded styles, which limits the ability to use custom CSS. This PR moves those styles to CSS.