### PR TITLE
Ensure supporting files are writeable

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -646,7 +646,8 @@ render_supporting_files <- function(from, files_dir, rename_to = NULL) {
   if (!dir_exists(target_dir) && !dir_exists(target_stage_dir)) {
     file.copy(from = from,
               to = files_dir,
-              recursive = TRUE)
+              recursive = TRUE,
+              copy.mode = FALSE)
     if (!is.null(rename_to)) {
       file.rename(from = target_stage_dir,
                   to = target_dir)


### PR DESCRIPTION
This is related to https://github.com/rstudio/htmltools/pull/68.

Rmarkdown copies dependencies to a temporary directory and tries to remove the directory afterwards. When a dependency's file mode was set to 444 at package installation time (as is the case on Guix), the copied file cannot be removed by R.

Setting `copy.mode` to `FALSE` ensures that the files can be removed by the user (or by the same R process at a later point).
