### PR TITLE
add support to print total rows and cols in paged tables when available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.0.9015
+Version: 1.0.9016
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),

--- a/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
@@ -182,11 +182,13 @@ var PagedTable = function (pagedTable) {
       pages: positiveIntOrNull(options.pages),
       rows: {
         min: positiveIntOrNull(rows.min),
-        max: positiveIntOrNull(rows.max)
+        max: positiveIntOrNull(rows.max),
+        total: positiveIntOrNull(rows.total)
       },
       columns: {
         min: positiveIntOrNull(columns.min),
-        max: positiveIntOrNull(columns.max)
+        max: positiveIntOrNull(columns.max),
+        total: positiveIntOrNull(columns.total)
       }
     };
   }(source);
@@ -718,16 +720,20 @@ var PagedTable = function (pagedTable) {
     var pageStart = page.getRowStart();
     var pageEnd = page.getRowEnd();
     var totalRows = data.length;
-    var totalRowsLabel = totalRows.toString().replace(/(\d)(?=(\d{3})+\.)/g, '$1,');
 
-    var infoText = (pageStart + 1) + "-" + pageEnd + " of " + totalRowsLabel + " rows";
+    var totalRowsLabel = options.rows.total ? options.rows.total : totalRows;
+    var totalRowsLabelFormat = totalRowsLabel.toString().replace(/(\d)(?=(\d{3})+\.)/g, '$1,');
+
+    var infoText = (pageStart + 1) + "-" + pageEnd + " of " + totalRowsLabelFormat + " rows";
     if (totalRows < page.rows) {
       infoText = totalRowsLabel + " row" + (totalRows != 1 ? "s" : "");
     }
     if (columns.total > columns.visible) {
+      var totalColumnsLabel = options.columns.total ? options.columns.total : columns.total;
+
       infoText = infoText + " | " + (columns.number + 1) + "-" +
         (Math.min(columns.number + columns.visible, columns.total)) +
-        " of " + columns.total + " columns";
+        " of " + totalColumnsLabel + " columns";
     }
 
     return infoText;

--- a/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-0.0.1/js/pagedtable.js
@@ -722,7 +722,7 @@ var PagedTable = function (pagedTable) {
     var totalRows = data.length;
 
     var totalRowsLabel = options.rows.total ? options.rows.total : totalRows;
-    var totalRowsLabelFormat = totalRowsLabel.toString().replace(/(\d)(?=(\d{3})+\.)/g, '$1,');
+    var totalRowsLabelFormat = totalRowsLabel.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
 
     var infoText = (pageStart + 1) + "-" + pageEnd + " of " + totalRowsLabelFormat + " rows";
     if (totalRows < page.rows) {


### PR DESCRIPTION
Allows host of paged tables to print the total number of rows in a dataset to, for instance, change the UI from this:

<img width="929" alt="screen shot 2016-09-28 at 10 26 23 am" src="https://cloud.githubusercontent.com/assets/3478847/18924850/85b659c8-8566-11e6-949e-3ddf11046993.png">

to this:

<img width="917" alt="screen shot 2016-09-28 at 12 01 12 pm" src="https://cloud.githubusercontent.com/assets/3478847/18928056/5eed2c4c-8573-11e6-852a-279f26eeca19.png">

