### PR TITLE
Clean temp files on exit

### DIFF
--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -78,7 +78,12 @@ beamer_presentation <- function(toc = FALSE,
 
   # template path and assets
   if (!is.null(template)) {
-    if (identical(template, "default")) template <- patch_beamer_template()
+    if (identical(template, "default")) {
+      template <- patch_beamer_template()
+      # the default template could be a tempfile, which is a patched version of
+      # Pandoc's default template
+      if (!is.null(template)) on.exit(unlink(template), add = TRUE)
+    }
     if (!is.null(template))
       args <- c(args, "--template", pandoc_path_arg(template))
   }

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -245,5 +245,5 @@ patch_beamer_template <- function() {
     return(NULL)
 
   # write and return path to template
-  as_tmpfile(enc2utf8(template), ".tex")
+  as_tmpfile(enc2utf8(template))
 }

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -78,12 +78,7 @@ beamer_presentation <- function(toc = FALSE,
 
   # template path and assets
   if (!is.null(template)) {
-    if (identical(template, "default")) {
-      template <- patch_beamer_template()
-      # the default template could be a tempfile, which is a patched version of
-      # Pandoc's default template
-      if (!is.null(template)) on.exit(unlink(template), add = TRUE)
-    }
+    if (identical(template, "default")) template <- patch_beamer_template()
     if (!is.null(template))
       args <- c(args, "--template", pandoc_path_arg(template))
   }
@@ -250,8 +245,5 @@ patch_beamer_template <- function() {
     return(NULL)
 
   # write and return path to template
-  tempfile <- tempfile(fileext = ".tex")
-  template <- paste(template, collapse = "\n")
-  writeLines(enc2utf8(template), tempfile, useBytes = TRUE)
-  tempfile
+  as_tmpfile(enc2utf8(template), ".tex")
 }

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -351,6 +351,7 @@ discover_rmd_resources <- function(rmd_file, encoding,
 
   # render "raw" markdown to HTML
   html_file <- tempfile(fileext = ".html")
+  on.exit(unlink(html_file), add = TRUE)
 
   # check to see what format this document is going to render as; if it's a
   # format that produces HTML, let it render as-is, but if it isn't, render as
@@ -378,6 +379,7 @@ discover_rmd_resources <- function(rmd_file, encoding,
   # if this is an R Markdown file, purl the file to extract just the R code
   if (tolower(tools::file_ext(rmd_file)) == "rmd") {
     r_file <- tempfile(fileext = ".R")
+    on.exit(unlink(r_file), add = TRUE)
     knitr::purl(md_file, output = r_file, quiet = TRUE, documentation = 0,
                 encoding = "UTF-8")
     temp_files <- c(temp_files, r_file)

--- a/R/latex_dependencies.R
+++ b/R/latex_dependencies.R
@@ -26,15 +26,6 @@ latex_dependencies <- function(x = list()) {
   }
 }
 
-# Write the LaTeX dependencies to a text file, suitable for passing it
-# to an include LaTeX command
-latex_dependencies_as_text_file <- function(dependencies, filename) {
-  text <- latex_dependencies_as_string(dependencies)
-  cat(text, file = filename)
-  filename
-}
-
-
 # return the LaTeX dependencies as a string suitable for inclusion
 # in the head of a document
 latex_dependencies_as_string <- function(dependencies) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -368,6 +368,7 @@ pandoc_self_contained_html <- function(input, output) {
 
   # create a simple body-only template
   template <- tempfile(fileext = ".html")
+  on.exit(unlink(template), add = TRUE)
   writeLines("$body$", template)
 
   # convert from markdown to html to get base64 encoding

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -180,8 +180,7 @@ pdf_document <- function(toc = FALSE,
     if (length(extra_dependencies) || has_latex_dependencies(knit_meta)) {
       extra_dependencies <- latex_dependencies(extra_dependencies)
       all_dependencies <- append(extra_dependencies, flatten_latex_dependencies(knit_meta))
-      filename <- tempfile()
-      latex_dependencies_as_text_file(all_dependencies, filename)
+      filename <- as_tmpfile(latex_dependencies_as_string(all_dependencies))
       if ("header-includes" %in% names(metadata)) {
         cat(c("", metadata[["header-includes"]]), sep = "\n", file = filename, append = TRUE)
       }

--- a/R/render.R
+++ b/R/render.R
@@ -609,10 +609,7 @@ render <- function(input,
       pandoc_output_tmp <- basename(tempfile("pandoc", tmpdir = getwd(), fileext = ext))
 
       # clean up temporary file on exit
-      on.exit({
-        if (file.exists(pandoc_output_tmp))
-          unlink(pandoc_output_tmp)
-      }, add = TRUE)
+      on.exit(unlink(pandoc_output_tmp), add = TRUE)
 
       # call pandoc to render file
       status <- pandoc_convert(

--- a/R/render.R
+++ b/R/render.R
@@ -32,6 +32,8 @@ render <- function(input,
   init_render_context()
   on.exit(clear_render_context(), add = TRUE)
 
+  on.exit(clean_tmpfiles(), add = TRUE)
+
   # check for "all" output formats
   if (identical(output_format, "all")) {
     output_format <- enumerate_output_formats(input, envir, encoding)

--- a/R/util.R
+++ b/R/util.R
@@ -123,9 +123,9 @@ file_name_without_shell_chars <- function(file) {
 tmpfile_pattern <- "rmarkdown-str"
 
 # return a string as a tempfile
-as_tmpfile <- function(str) {
+as_tmpfile <- function(str, fileext = ".html") {
   if (length(str) > 0) {
-    str_tmpfile <- tempfile(tmpfile_pattern, fileext = ".html")
+    str_tmpfile <- tempfile(tmpfile_pattern, fileext = fileext)
     writeLines(str, str_tmpfile, useBytes =  TRUE)
     str_tmpfile
   } else {

--- a/R/util.R
+++ b/R/util.R
@@ -123,9 +123,9 @@ file_name_without_shell_chars <- function(file) {
 tmpfile_pattern <- "rmarkdown-str"
 
 # return a string as a tempfile
-as_tmpfile <- function(str, fileext = ".html") {
+as_tmpfile <- function(str) {
   if (length(str) > 0) {
-    str_tmpfile <- tempfile(tmpfile_pattern, fileext = fileext)
+    str_tmpfile <- tempfile(tmpfile_pattern, fileext = ".html")
     writeLines(str, str_tmpfile, useBytes =  TRUE)
     str_tmpfile
   } else {

--- a/R/util.R
+++ b/R/util.R
@@ -120,15 +120,26 @@ file_name_without_shell_chars <- function(file) {
     name
 }
 
+tmpfile_pattern <- "rmarkdown-str"
+
 # return a string as a tempfile
 as_tmpfile <- function(str) {
   if (length(str) > 0) {
-    str_tmpfile <- tempfile("rmarkdown-str", fileext = ".html")
+    str_tmpfile <- tempfile(tmpfile_pattern, fileext = ".html")
     writeLines(str, str_tmpfile, useBytes =  TRUE)
     str_tmpfile
   } else {
     NULL
   }
+}
+
+# temp files created by as_tmpfile() cannot be immediately removed because they
+# are needed later by the pandoc conversion; we have to clean up the temp files
+# that have the pattern specified in `tmpfile_pattern` when render() exits
+clean_tmpfiles <- function() {
+  unlink(list.files(
+    tempdir(), sprintf("^%s[0-9a-f]+[.]html$", tmpfile_pattern), full.names = TRUE
+  ))
 }
 
 dir_exists <- function(x) {

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -23,6 +23,8 @@ rmarkdown 1.7 (unreleased)
 * HTML widgets in an Rmd document cannot be rendered if another Rmd document is
   rendered via `rmarkdown::render()` in this document (#993).
 
+* Try harder to clean up temporary files created during `render()` (#820).
+
 rmarkdown 1.6
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #819: a few temp files are never cleaned up after `render()` is done. I went through the code that called `tempfile()`, and added `on.exit(unlink())` to clean up those temp files. The `as_tmpfile()` ones are a little tricky, since they cannot be immediately removed and we need to wait until `pandoc_convert()` is done, so I added `clean_tmpfiles()` in `render()`, hoping that the pattern `rmarkdown-str` is unique and it does not hurt to aggressively clean up files in `tempdir()`  that happen to have the same pattern but not created by `as_tmpfile()`.
