### PR TITLE
be more permissive of 'params' objects discovered

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -367,18 +367,27 @@ render <- function(input,
 
       params <- knit_params_get(input_lines, params)
 
-      # make the params available in the knit environment
-      if (!exists("params", envir = envir, inherits = FALSE)) {
-        assign("params", params, envir = envir)
-        lockBinding("params", envir)
-        on.exit({
-          do.call("unlockBinding", list("params", envir))
-          remove("params", envir = envir)
-        }, add = TRUE)
-      } else {
-        stop("params object already exists in knit environment ",
-             "so can't be overwritten by render params", call. = FALSE)
+      # bail if an object called 'params' exists in this environment,
+      # and it seems to be an unrelated user-created object
+      if (exists("params", envir = envir, inherits = FALSE)) {
+        envirParams <- get("params", envir = envir, inherits = FALSE)
+        isKnownParamsObject <-
+          inherits(envirParams, "knit_param_list") ||
+          inherits(envirParams, "knit_param")
+
+        if (!isKnownParamsObject) {
+          stop("params object already exists in knit environment ",
+               "so can't be overwritten by render params", call. = FALSE)
+        }
       }
+
+      # make the params available in the knit environment
+      assign("params", params, envir = envir)
+      lockBinding("params", envir)
+      on.exit({
+        do.call("unlockBinding", list("params", envir))
+        remove("params", envir = envir)
+      }, add = TRUE)
     }
 
     # make the yaml_front_matter available as 'metadata' within the


### PR DESCRIPTION
This is part one of a fix for parameterized R Notebooks.

As part of the Notebook workflow, when parameters are discovered in the YAML header, we inject an object `params` into the global environment to ensure that it's available for code execution. However, this breaks subsequent renders, as `rmarkdown::render()` then detects a pre-existing `params` variable and bails.

The fix here is to permit `params` objects with class `knit_param` and `knit_param_list`, and ensure that RStudio injects the `params` object with that class. The `rmarkdown` package will then overwrite that variable as it is known to be 'safe' for overwriting during render.

Let me know if this sounds reasonable or if you think there's an alternate solution we should consider here.

(associated change on RStudio side, to be merged: https://github.com/rstudio/rstudio/commit/c8b0c6d786acd105e7858ee49d9a332e1738ca20)

cc: @jjallaire, @jmcphers