### PR TITLE
Place folding button inside code box

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -246,7 +246,8 @@ $$(document).ready(function () {
 <!-- code folding -->
 $if(code_menu)$
 <style type="text/css">
-.code-folding-btn { margin-bottom: 4px; }
+.code-folding-btn { margin-bottom: -22px; }
+.code-folding-btn.collapsed { margin-bottom: 4px; }
 </style>
 <script src="$navigationjs$/codefolding.js"></script>
 $if(source_embed)$


### PR DESCRIPTION
Places the folding button inside the code box (the same place the controls are placed in the Rmd), removing that ugly white space:

------

![screen shot 2016-10-06 at 12 00 28 pm](https://cloud.githubusercontent.com/assets/216319/19148340/87cf9164-8bbc-11e6-8a12-889c8310160a.png)
