### PR TITLE
suppress printing of certain 'data.table' generating expressions (#829)

### DIFF
--- a/R/knit_print.R
+++ b/R/knit_print.R
@@ -1,5 +1,22 @@
 knit_print.data.frame = function(x, ...) {
   context <- render_context()
+
+  # printing of certain expressions producing
+  # 'data.table' objects should be suppressed
+  printable <- TRUE
+  if ("data.table" %in% loadedNamespaces() &&
+      exists("shouldPrint", envir = asNamespace("data.table")))
+  {
+    shouldPrint <- get("shouldPrint", envir = asNamespace("data.table"))
+    printable <- tryCatch(
+      shouldPrint(x) || !inherits(x, "data.table"),
+      error = function(e) TRUE
+    )
+  }
+
+  if (!printable)
+    return()
+
   if (!is.null(context$df_print)) {
     if (identical(context$df_print, knitr::kable)) {
       res = paste(c('<div class="kable-table">', '', knitr::kable(x), '', '</div>'),


### PR DESCRIPTION
This is a potential fix for #829.
