### PR TITLE
mark_utf8 should set encoding to the name of lists

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -87,6 +87,7 @@ mark_utf8 <- function(x) {
   attrs <- attributes(x)
   res <- lapply(x, mark_utf8)
   attributes(res) <- attrs
+  names(res) <- mark_utf8(names(res))
   res
 }
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -10,6 +10,8 @@ rmarkdown 1.2 (unreleased)
 
 * Fix issue with positioning of show/hide code button (#839)
 
+* Non-ASCII keys in yaml file should be marked to UTF8 as well, when read
+  into R as the name of a list (#841)
 
 rmarkdown 1.1
 --------------------------------------------------------------------------------


### PR DESCRIPTION
or when read the yaml files, the Chinese var names display messes still.