### PR TITLE
remove key-column special-case alignment in pagedtables

### DIFF
--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -55,12 +55,6 @@ paged_table_html <- function(x) {
     paste0("<", summary, ">")
   })
 
-  if (length(columns) > 0) {
-    first_column = data[[1]]
-    if (is.numeric(first_column) && isTRUE(all(diff(first_column) == 1)))
-      columns[[1]]$align <- "left"
-  }
-
   data <- as.data.frame(
     lapply(
       data,


### PR DESCRIPTION
On pagedtables, functionality was added to left align a numeric column if it looked like a key column. This was performed by checking if numeric and incrementing. However, this introduced to problems:

1) Users (Hadley for instance), suggest that this is confusing since simple tables with similar first columns, say, `[1, 2, 3]` and `[1, 1, 2]` will have different alignments.

2) In `tibble`, which we've tried to have partify with in notebook data tables, does not perform this alignment.