### PR TITLE
add ellipsis to pagedtable column names

### DIFF
--- a/inst/rmd/h/pagedtable-1.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-1.1/css/pagedtable.css
@@ -126,6 +126,11 @@ a.pagedtable-index-current:hover {
   text-overflow: ellipsis;
 }
 
+.pagedtable-header-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .pagedtable-header-type {
   color: #999;
   font-weight: 400;

--- a/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
@@ -539,6 +539,7 @@ var PagedTable = function (pagedTable) {
       }
 
       var columnName = document.createElement("div");
+      columnName.setAttribute("class", "pagedtable-header-name");
       if (columnData.label === "") {
         columnName.innerHTML = "&nbsp;";
       }


### PR DESCRIPTION
Minor fix to `pagedtables` to truncate column name with ellipsis. RStudio planning to take this for `v1.1` so no need to merge yet.