### PR TITLE
Add rsiframe dependency to classic Shiny documents

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -286,6 +286,11 @@ rmarkdown_shiny_server <- function(dir, file, encoding, auto_reload, render_args
       # save the structured dependency information
       write_shiny_deps(resource_folder, dependencies)
 
+      # attach rstudio rsiframe script if we are in rstudio (we do this after
+      # persisting the dependencies since this dependency is ephemeral)
+      if (nzchar(Sys.getenv("RSTUDIO")))
+        dependencies <- append(dependencies, list(html_dependency_rsiframe()))
+
       # when the session ends, remove the rendered document and any supporting
       # files, if they're not cacheable
       if (!isTRUE(out$cacheable)) {


### PR DESCRIPTION
We currently inject the rsiframe dependency here:

https://github.com/rstudio/rmarkdown/blob/5e2fb92362fdcd362384de763d48027f4faa3a87/R/shiny.R#L555-L557

However, this means that the rsiframe dependency is only injected for cached content:

https://github.com/rstudio/rmarkdown/blob/5e2fb92362fdcd362384de763d48027f4faa3a87/R/shiny.R#L415

"Classic" `runtime: shiny` documents do not use this codepath (they aren't cached) so they don't get the rsiframe dependency. 

This change ensures that the rsiframe dependency is injected for `runtime: shiny` documents.