### PR TITLE
Remove knit_meta_add from rmarkdown and use knitr::knit_meta_add

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -132,23 +132,6 @@ html_dependencies_fonts <- function(font_awesome, ionicons) {
   deps
 }
 
-# local implementation of knit_meta_add until we can depend on a later
-# version of knitr
-knit_meta_add = function(meta, label = '') {
-  # if (packageVersion("knitr") >= "1.12.20") {
-  #   knitr::knit_meta_add(meta, label)
-  # } else {
-  knitrNamespace <- asNamespace("knitr")
-  knitEnv <- get(".knitEnv", envir = knitrNamespace)
-  if (length(meta)) {
-    meta_id = attr(knitEnv$meta, 'knit_meta_id')
-    knitEnv$meta <- c(knitEnv$meta, meta)
-    attr(knitEnv$meta, "knit_meta_id") = c(meta_id, rep(label, length(meta)))
-  }
-  knitEnv$meta
-  # }
-}
-
 
 # flattens an arbitrarily nested list and returns all of the dependency
 # objects it contains

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -385,7 +385,7 @@ html_document <- function(toc = FALSE,
         # navbar icon dependencies
         iconDeps <- navbar_icon_dependencies(navbar)
         if (length(iconDeps) > 0)
-          knit_meta_add(list(iconDeps))
+          knitr::knit_meta_add(list(iconDeps))
       }
     }
 


### PR DESCRIPTION
Currently knitr >= 1.14 in DESCRIPTION, so it is safe to remove the internal `knit_meta_add` now.