### PR TITLE
Add support for loading slide deck after document is loaded

### DIFF
--- a/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
+++ b/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
@@ -782,15 +782,28 @@ SlideDeck.prototype.loadAnalytics_ = function() {
 };
 
 
-// Polyfill missing APIs (if we need to), then create the slide deck.
-// iOS < 5 needs classList, dataset, and window.matchMedia. Modernizr contains
-// the last one.
-document.addEventListener("DOMContentLoaded", function(event) {
+var loadDeck = function(event) {
+  // Polyfill missing APIs (if we need to), then create the slide deck.
+  // iOS < 5 needs classList, dataset, and window.matchMedia. Modernizr contains
+  // the last one.
   Modernizr.load({
     complete: function() {
       window.slidedeck = new SlideDeck();
     }
   });
-});
+};
+
+if (document.readyState !== "loading" &&
+    document.querySelector('slides') === null) { 
+  // if the document is done loading but our element hasn't yet appeared, defer
+  // loading of the deck
+  window.setTimeout(function() {
+    loadDeck(null);
+  }, 0);
+} else {
+  // still loading the DOM, so wait until it's finished
+  document.addEventListener("DOMContentLoaded", loadDeck);
+}
+
 
 


### PR DESCRIPTION
This changes fixes a problem which causes ioslides not to initialize when used in a Shiny document.

The problem is basically that, in a Shiny document, the outer document has already loaded when the ioslides deck is injected. For this reason, the `DOMContentLoaded` event does not ever fire. 

The fix is to initialize the deck (almost) right away if the document is already loaded.