### PR TITLE
Add new knit_root_dir option to render

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -17,6 +17,7 @@ render <- function(input,
                    output_dir = NULL,
                    output_options = NULL,
                    intermediates_dir = NULL,
+                   knit_root_dir = NULL,
                    runtime =  c("auto", "static", "shiny", "shiny_prerendered"),
                    clean = TRUE,
                    params = NULL,
@@ -51,6 +52,7 @@ render <- function(input,
                        output_dir = output_dir,
                        output_options = output_options,
                        intermediates_dir = intermediates_dir,
+                       knit_root_dir = knit_root_dir,
                        runtime = runtime,
                        clean = clean,
                        params = params,
@@ -134,6 +136,9 @@ render <- function(input,
         intermediates_dir <- NULL
     }
   }
+
+  # force evaluation of knitr root dir before we change directory context
+  force(knit_root_dir)
 
   # execute within the input file's directory
   oldwd <- setwd(dirname(tools::file_path_as_absolute(input)))
@@ -324,6 +329,13 @@ render <- function(input,
       rmarkdown.version = 2,
       rmarkdown.runtime = runtime
     )
+
+    # read root directory from argument (has precedence) or front matter
+    root_dir <- knit_root_dir
+    if (is.null(root_dir))
+      root_dir <- yaml_front_matter$knit_root_dir
+    if (!is.null(root_dir))
+      knitr::opts_knit$set(root.dir = root_dir)
 
     # use filename based figure and cache directories
     figures_dir <- paste(files_dir, "/figure-", pandoc_to, "/", sep = "")

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -31,6 +31,9 @@ rmarkdown 1.2 (unreleased)
 
 * Support `{.active}` attribute for setting initially active tab (#789)
 
+* Add `knit_root_dir` argument to `render()` and YAML header, a convenience
+  for setting knitr's root.dir option
+
 
 rmarkdown 1.1
 --------------------------------------------------------------------------------

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -4,6 +4,7 @@
 \usage{
 render(input, output_format = NULL, output_file = NULL, output_dir = NULL,
        output_options = NULL, intermediates_dir = NULL,
+       knit_root_dir = NULL,
        runtime = c("auto", "static", "shiny", "shiny_prerendered"),
        clean = TRUE, params = NULL, knit_meta = NULL, envir = parent.frame(),
        run_pandoc = TRUE, quiet = FALSE, encoding = getOption("encoding"))
@@ -35,6 +36,10 @@ render(input, output_format = NULL, output_file = NULL, output_dir = NULL,
   \item{intermediates_dir}{Intermediate files directory. If \code{NULL},
   intermediate files are written to the same directory as the input file;
   otherwise.}
+
+  \item{knit_root_dir}{The working directory in which to knit the document; uses
+  knitr's \code{root.dir} knit option. \code{NULL} means to follow the knitr
+  default, which is to use the parent directory of the document.}
 
   \item{runtime}{The runtime target for rendering. \code{static} produces output
   intended for static files; \code{shiny} produces output suitable for use in a


### PR DESCRIPTION
This change adds a new parameter to `render` that sets the `root.dir` knitr option. Because it is evaluated prior to entering the document's directory, it is now possible to use a command like the following to knit in the current directory:

    rmarkdown::render("mydoc.Rmd", knit_root_dir = getwd())

This parameter is primarily intended for use by the RStudio IDE, for a "knit in current directory" feature. However, it can also be used by other tools to manually supply an arbitrary working directory for knitr chunks without altering the input document.

The option may also be set in the front matter, e.g.

    ---
    output: html_document
    knit_root_dir: ~/myproj
    ---

Note that with this mechanism it is **not** possible to use the YAML header to indicate that the document should always be knit in the current working directory. For instance, this does not work:

    knit_root_dir: !expr getwd()

because we currently evaluate the expressions in the YAML header in the document's working directory, and I'm presuming we have other behavior which relies on this. 

If you want to knit in the current working directory, the plan is to use an IDE option (if you're using an IDE), and the new `knitr.use.cwd` option if not using the IDE. If a declarative, document-level option is needed, further discussion is warranted (e.g. we could add an option that drives `knitr.use.cwd`).