### PR TITLE
No longer need the mark_utf8() trick after yaml 2.1.15 has been released

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -2,7 +2,7 @@
 knit_params_get <- function(input_lines, params) {
 
   # read the default parameters and extract them into a named list
-  knit_params <- mark_utf8(knitr::knit_params(input_lines))
+  knit_params <- knitr::knit_params(input_lines)
   default_params <- list()
   for (param in knit_params) {
     default_params[[param$name]] <- param$value
@@ -210,7 +210,7 @@ knit_params_ask <- function(file = NULL,
     input_lines <- read_lines_utf8(file, encoding)
   }
 
-  knit_params <- mark_utf8(knitr::knit_params(input_lines))
+  knit_params <- knitr::knit_params(input_lines)
 
   ## Input validation on params (checks shared with render)
   if (!is.null(params)) {

--- a/R/util.R
+++ b/R/util.R
@@ -91,10 +91,11 @@ mark_utf8 <- function(x) {
   res
 }
 
-# TODO: remove this when fixed upstream https://github.com/viking/r-yaml/issues/6
+# originally written due to the bug https://github.com/viking/r-yaml/issues/6;
+# now no longer need the mark_utf8 trick
 yaml_load_utf8 <- function(string, ...) {
   string <- paste(string, collapse = '\n')
-  mark_utf8(yaml::yaml.load(enc2utf8(string), ...))
+  yaml::yaml.load(string, ...)
 }
 
 yaml_load_file_utf8 <- function(input, ...) {


### PR DESCRIPTION
Unfortunately I forgot to do the same thing in knitr (https://github.com/yihui/knitr/commit/dd851513aa9bd88d5f1c4d455d0bf88d128bb833) when I released it last week, so knitr and rmarkdown have to go to CRAN at the same time next time.