### PR TITLE
Still use the mark_utf8() trick for yaml < 2.1.14

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -3,6 +3,7 @@ knit_params_get <- function(input_lines, params) {
 
   # read the default parameters and extract them into a named list
   knit_params <- knitr::knit_params(input_lines)
+  if (packageVersion('yaml') < '2.1.14') knit_params <- mark_utf8(knit_params)
   default_params <- list()
   for (param in knit_params) {
     default_params[[param$name]] <- param$value
@@ -211,6 +212,7 @@ knit_params_ask <- function(file = NULL,
   }
 
   knit_params <- knitr::knit_params(input_lines)
+  if (packageVersion('yaml') < '2.1.14') knit_params <- mark_utf8(knit_params)
 
   ## Input validation on params (checks shared with render)
   if (!is.null(params)) {

--- a/R/util.R
+++ b/R/util.R
@@ -91,11 +91,16 @@ mark_utf8 <- function(x) {
   res
 }
 
-# originally written due to the bug https://github.com/viking/r-yaml/issues/6;
-# now no longer need the mark_utf8 trick
+# the yaml UTF-8 bug has been fixed https://github.com/viking/r-yaml/issues/6
+# but yaml >= 2.1.14 Win/Mac binaries are not available for R < 3.2.0, so we
+# still need the mark_utf8 trick
 yaml_load_utf8 <- function(string, ...) {
   string <- paste(string, collapse = '\n')
-  yaml::yaml.load(string, ...)
+  if (packageVersion('yaml') >= '2.1.14') {
+    yaml::yaml.load(string, ...)
+  } else {
+    mark_utf8(yaml::yaml.load(enc2utf8(string), ...))
+  }
 }
 
 yaml_load_file_utf8 <- function(input, ...) {


### PR DESCRIPTION
For reasons explained in #874.