### PR TITLE
Quote output.var consistently

### DIFF
--- a/authoring_knitr_engines.html
+++ b/authoring_knitr_engines.html
@@ -366,7 +366,7 @@ SELECT * FROM trials
 <div id="assigning-results-to-a-data-frame" class="section level3">
 <h3>Assigning Results to a Data Frame</h3>
 <p>If you want to assign the results of the SQL query to an R data frame, you can do this using the <code>output.var</code> option, for example:</p>
-<pre class="markdown"><code>&#96;&#96;&#96;{sql, connection=db, output.var=trials}
+<pre class="markdown"><code>&#96;&#96;&#96;{sql, connection=db, output.var="trials"}
 SELECT * FROM trials
 &#96;&#96;&#96;
 </code></pre>

--- a/authoring_knitr_engines.md
+++ b/authoring_knitr_engines.md
@@ -126,7 +126,7 @@ You can specify that you want no caption all via `tab.cap = NA`.
 
 If you want to assign the results of the SQL query to an R data frame, you can do this using the `output.var` option, for example:
 
-<pre class="markdown"><code>&#96;&#96;&#96;{sql, connection=db, output.var=trials}
+<pre class="markdown"><code>&#96;&#96;&#96;{sql, connection=db, output.var="trials"}
 SELECT * FROM trials
 &#96;&#96;&#96;
 </code></pre>


### PR DESCRIPTION
The knitr engine documentation has `output.var` quoted on all chunks but one; this change just adds quotes to the name of the variable in the remaining chunk. 