### PR TITLE
Enable pagedtables in notebook preview for ide 1.0

### DIFF
--- a/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
@@ -1122,7 +1122,7 @@ var PagedTableDoc;
   PagedTableDoc.initAll = function() {
     allPagedTables = [];
 
-    var pagedTables = [].slice.call(document.querySelectorAll('[data-pagedtable="false"]'));
+    var pagedTables = [].slice.call(document.querySelectorAll('[data-pagedtable="false"],[data-pagedtable=""]'));
     pagedTables.forEach(function(pagedTable, idx) {
       pagedTable.setAttribute("data-pagedtable", "true");
       pagedTable.setAttribute("pagedtable-page", 0);


### PR DESCRIPTION
The RStudio IDE `1.0` inserts a `<div data-pagedtable>` div but `rmarkdown` `1.2`reads this with `document.querySelectorAll('[data-pagedtable="false"])`. Fix is to also look for IDE `1.0` divs with: `document.querySelectorAll('[data-pagedtable="false"],[data-pagedtable=""])`.

Related to:
 - https://github.com/rstudio/rmarkdown/commit/ee5d8d4db58d02f249ef7627189cd87c87455de5
 - https://github.com/rstudio/rstudio/commit/66f9c25ffa71588a8c26c478021467df7cf7ec5c