### PR TITLE
render_site compatibility with Rmd params.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@ rmarkdown 1.13
 
 - TOC items are not correctly indented when `toc_float` is enabled for the `html_document` format (thanks, @carolynwclayton #1235 and @RLesur #1243).
 
+- `render_site` can spin R source files. Use `autospin: true` in the `_site.yml`.
+  (#892, @zeehio)
+
+- `render_site` can render Rmd files with parameters. Use the new `output_files`
+  field in `_site.yml`. See `?render_site` for further details. (#903, @zeehio)
+
 
 rmarkdown 1.12
 ================================================================================

--- a/man/render_site.Rd
+++ b/man/render_site.Rd
@@ -21,7 +21,8 @@ site_config(input = ".", encoding = "UTF-8")
 default_site_generator(input, encoding = "UTF-8", ...)
 }
 \arguments{
-\item{input}{Website directory (or the name of a file within the directory).}
+\item{input}{Website directory (or the name of an html file within the
+directory to be rendered).}
 
 \item{output_format}{R Markdown format to convert to (defaults to "all").}
 
@@ -138,6 +139,27 @@ functions from different packages (namespaces) that share a common name, such
 as \code{here::here} and \code{lubridate::here} or \code{dplyr::filter} and
 \code{MASS::filter}. The default behaviour of \code{render_site} is to use a
 common R session.
+
+\code{autospin: true} causes \code{.R} files to be spinned and rendered
+(as well as \code{.Rmd} files). If \code{autospin} is set to false (the default),
+it is still possible to spin specific R files by using the \code{output_files} field.
+
+\code{output_files} can be used to describe which Rmd file is used to render
+each html file and, if necessary, pass R markdown parameters. If an html file does
+not appear in output files it will be rendered using the Rmd file with the same
+name. This is an example of how the \code{output_files} can be used to generate
+two html files from the same Rmd file (that accepts a parameter "flight_type"):
+
+\preformatted{output_files:
+ flights_domestic.html:
+   src: "flights_analysis.Rmd"
+   params:
+     flight_type: "domestic"
+ flights_international.html:
+   src: "flights_analysis.Rmd"
+   params:
+     flight_type: "international"
+}
 }
 
 \section{Custom Site Generation}{

--- a/tests/testthat/site/PageB.rmd
+++ b/tests/testthat/site/PageB.rmd
@@ -1,11 +1,15 @@
 ---
 title: "Page B"
 output: html_document
+params:
+  var1: "default_val1"
 ---
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 ```
+
+Parameter var1: `r params$var1`
 
 ## Section 1
 

--- a/tests/testthat/site/PageD.R
+++ b/tests/testthat/site/PageD.R
@@ -1,0 +1,21 @@
+#'---
+#' title: "Page D"
+#' output: html_document
+#'---
+
+knitr::opts_chunk$set(echo = TRUE)
+
+#'
+#' ## Section 1
+#'
+#' Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sapien nisl, egestas ut erat eu, egestas porttitor tellus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed pellentesque volutpat justo, et cursus lorem pulvinar luctus. Curabitur porta, diam a pretium egestas, dui dolor tempus sem, non facilisis turpis tortor a lectus. Morbi nec enim aliquam, eleifend libero eget, efficitur quam. Fusce dapibus elit vitae tellus hendrerit tristique. Donec felis elit, gravida non orci consectetur, finibus sollicitudin justo. Curabitur imperdiet pellentesque elit ac ultricies. Vestibulum erat leo, tristique non felis a, fringilla pellentesque dolor. Vivamus sem justo, commodo sit amet ultrices in, lobortis sit amet lacus. Donec feugiat sem vel arcu feugiat, sed maximus elit aliquam. Pellentesque justo leo, pellentesque a mollis eget, suscipit ac turpis. Duis ornare dui quis nisi dictum, at consequat justo auctor.
+#'
+plot(cars)
+#' ## Section 2
+#'
+#' Nullam ullamcorper ac nunc sed tempus. Suspendisse sagittis tortor auctor magna aliquam, eu porta libero pretium. Vestibulum placerat feugiat mattis. Nulla ornare luctus quam vel iaculis. Nulla ornare justo venenatis viverra mollis. Aliquam pretium dui sed sem accumsan blandit. Integer aliquam posuere odio, ac interdum lorem egestas in. Vivamus sed est dolor. Nulla cursus blandit elit nec porta. Etiam dictum libero vel magna pulvinar convallis. Proin lacinia elementum ligula a malesuada. Ut rhoncus tortor vitae lorem ultrices luctus. Aenean sit amet libero non metus fringilla lacinia id quis massa. Nulla sollicitudin tortor non turpis suscipit, in imperdiet ex finibus.
+#'
+#' ## Section 3
+#'
+#' Sed leo tortor, sagittis sit amet lacus eu, tincidunt ornare lacus. Integer lorem lacus, facilisis nec turpis et, fermentum scelerisque felis. Pellentesque ultrices nibh lacus, ut tincidunt metus finibus quis. Nunc tincidunt eget urna a lacinia. Sed auctor lorem eu ultrices interdum. Aliquam vehicula ornare massa, ut placerat mi imperdiet et. Sed facilisis eleifend tortor, id semper nisl congue eu. Donec malesuada dolor eget ex rutrum, nec consequat erat ultrices. Maecenas iaculis leo id est lacinia laoreet. Donec tempor cursus orci. Suspendisse potenti. Etiam cursus iaculis tincidunt.
+#'

--- a/tests/testthat/site/_site.yml
+++ b/tests/testthat/site/_site.yml
@@ -1,5 +1,6 @@
 name: "mysite"
 output_dir: "_site"
+autospin: false
 include: script.R
 exclude: docs.txt
 navbar:
@@ -11,9 +12,11 @@ navbar:
     - text: "More"
       menu:
         - { text: "Page B", href: PageB.html }
+        - { text: "Page B2", href: PageB2.html }
         - { text: "-----------------" }
         - { text: "Header" }
         - { text: "Page C", href: PageC.html }
+        - { text: "Page D", href: PageD.html }
   right:
     - text: "GitHub"
       href: https://github.com
@@ -21,3 +24,11 @@ output:
   html_document:
     css: styles.css
     theme: united
+
+output_files:
+  PageB2.html:
+    src: PageB.rmd
+    params:
+      var1: "value1"
+  PageD.html:
+    src: PageD.R

--- a/tests/testthat/site/index.Rmd
+++ b/tests/testthat/site/index.Rmd
@@ -1,11 +1,15 @@
 ---
 title: "R Markdown Website"
 output: html_document
+params:
+  var1: "default_val1"
 ---
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 ```
+
+Parameter var1: `r params$var1`
 
 ## Section 1
 

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -8,7 +8,7 @@ test_that("render_site", {
   site_dir <- tempfile()
   dir.create(site_dir)
   files <- c("_site.yml", "index.Rmd", "PageA.Rmd",
-             "PageB.rmd", "PageC.md", "styles.css",
+             "PageB.rmd", "PageC.md", "PageD.R", "styles.css",
              "script.R", "docs.txt")
   file.copy(file.path("site", files), site_dir, recursive = TRUE)
 
@@ -16,7 +16,8 @@ test_that("render_site", {
   capture.output(render_site(site_dir))
 
   # did the html files get rendered and the css get copied?
-  html_files <- c("index.html", "PageA.html", "PageB.html", "PageC.html")
+  html_files <- c("index.html", "PageA.html", "PageB.html",
+                  "PageB2.html", "PageC.html", "PageD.html")
   html_files <- file.path(site_dir, "_site", html_files)
   expect_true(all(file.exists(html_files)))
 
@@ -42,7 +43,7 @@ test_that("render_site respects 'new_session' in the config", {
   # copy parts of our demo site to a tempdir
   site_dir <- tempfile()
   dir.create(site_dir)
-  files <- c("_site.yml", "index.Rmd", "PageA.Rmd", "PageB.rmd")
+  files <- c("_site.yml", "index.Rmd", "PageA.Rmd", "PageB.rmd", "PageD.R")
   file.copy(file.path("site", files), site_dir, recursive = TRUE)
 
   # default behaviour --> new_session: false


### PR DESCRIPTION
This PR provides a solution to #903 and #892 as as a side effect.

@jjallaire I used "output_files" as you suggested. Feel free to suggest changes, although I do not have much more time to devote to this.

## Highlights:

 - `render_site` understands the `output_files` field in the `_site.yml`. If `output_files` is missing
   it uses the Rmd file with the same name. Example of `output_files` field:
 ````yaml
output_files:
  flights_domestic.html:
    src: "flights_analysis.Rmd"
    params:
      flight_type: "domestic"
  flights_international.html:
    src: "flights_analysis.Rmd"
    params:
      flight_type: "international"
````

- The `output_files` feature can be used as well to set as source for an html file a R script that will be spinned:

 ````yaml
output_files:
  flights_domestic.html:
    src: "flights_analysis.R"
````
- `render_site` also understands the `autospin` field in `_site.yml`. If `autospin: true` is set, `render_site` will render all R scripts spinning them first. (closes #892)

- Tests have been enhanced a bit to cover these features and documentation has been added as well to the `?render_site` man page.

I already signed the contribution agreement when I submitted my previous PR (#647)

Comments, patches and merges are very welcome