### PR TITLE
Support embedding raw RTF content in RTF output

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -106,13 +106,7 @@ html_document_base <- function(smart = TRUE,
                                         lib_dir,
                                         output_dir))
 
-    # The input file is converted to UTF-8 from its native encoding prior
-    # to calling the preprocessor (see ::render)
-    input_str <- readLines(input_file, warn = FALSE, encoding = "UTF-8")
-    preserve <- extractPreserveChunks(input_str)
-    if (!identical(preserve$value, input_str))
-      writeLines(preserve$value, input_file, useBytes = TRUE)
-    preserved_chunks <<- preserve$chunks
+    preserved_chunks <<- extract_preserve_chunks(input_file)
 
     args
   }
@@ -182,5 +176,15 @@ html_document_base <- function(smart = TRUE,
     intermediates_generator = intermediates_generator,
     post_processor = post_processor
   )
+}
+
+extract_preserve_chunks <- function(input_file, extract = extractPreserveChunks) {
+  # The input file is converted to UTF-8 from its native encoding prior
+  # to calling the preprocessor (see ::render)
+  input_str <- readLines(input_file, warn = FALSE, encoding = "UTF-8")
+  preserve <- extract(input_str)
+  if (!identical(preserve$value, input_str))
+    writeLines(enc2utf8(preserve$value), input_file, useBytes = TRUE)
+  preserve$chunks
 }
 

--- a/R/rtf_document.R
+++ b/R/rtf_document.R
@@ -62,13 +62,22 @@ rtf_document <- function(toc = FALSE,
 
   preserved_chunks <- character()
 
+  check_knitr_version <- function() {
+    if (packageVersion('knitr') < '1.15') {
+      warning('You need to install a newer version of the knitr package')
+      FALSE
+    } else TRUE
+  }
+
   pre_processor <- function(metadata, input_file, runtime, knit_meta,
                              files_dir, output_dir) {
+    if (!check_knitr_version()) return()
     preserved_chunks <<- extract_preserve_chunks(input_file, knitr::extract_raw_output)
     NULL
   }
 
   post_processor <- function(metadata, input_file, output_file, clean, verbose) {
+    if (!check_knitr_version()) return(output_file)
     output_str <- readLines(output_file, encoding = 'UTF-8')
     output_res <- knitr::restore_raw_output(output_str, preserved_chunks)
     if (!identical(output_str, output_res))

--- a/R/rtf_document.R
+++ b/R/rtf_document.R
@@ -60,13 +60,30 @@ rtf_document <- function(toc = FALSE,
   # pandoc args
   args <- c(args, pandoc_args)
 
+  preserved_chunks <- character()
+
+  pre_processor <- function(metadata, input_file, runtime, knit_meta,
+                             files_dir, output_dir) {
+    preserved_chunks <<- extract_preserve_chunks(input_file, knitr::extract_raw_output)
+    NULL
+  }
+
+  post_processor <- function(metadata, input_file, output_file, clean, verbose) {
+    output_str <- readLines(output_file, encoding = 'UTF-8')
+    output_res <- knitr::restore_raw_output(output_str, preserved_chunks)
+    if (!identical(output_str, output_res))
+      writeLines(enc2utf8(output_res), output_file, useBytes = TRUE)
+    output_file
+  }
+
   # return output format
   output_format(
     knitr = knitr,
     pandoc = pandoc_options(to = "rtf",
                             from = from_rmarkdown(extensions = md_extensions),
                             args = args),
-    keep_md = keep_md
+    keep_md = keep_md,
+    pre_processor = pre_processor,
+    post_processor = post_processor
   )
 }
-


### PR DESCRIPTION
I didn't add a NEWS item for this PR because I guess only one of our customers is interested in it. There may be more, but let's ask them to test it more thoroughly before we publicize this feature.

Basically this allows users to embed raw RTF content generated by other packages (e.g. the rtf package) in R Markdown. The idea is similar to HTML widgets: first the raw content is extracted to bypass Pandoc, then reinsert it to the final output. Nathan has a full example here: https://github.com/rstudio/sol-eng-sales/tree/master/vignettes/rtf