### PR TITLE
bug fixed for pdf_document extra_dependencies + a new feature

### DIFF
--- a/R/latex_dependencies.R
+++ b/R/latex_dependencies.R
@@ -61,15 +61,20 @@ has_latex_dependencies <- function(knit_meta) {
   has_dependencies(knit_meta, "latex_dependency")
 }
 
-# Convert a string to a list of basic latex dependencies (no options)
-string_to_latex_dependencies <- function(x){
-  if(grepl("\\[|\\]", x)){
-    x <- gsub("\\[(.*?)\\]", "", x)
-    warning("You have to use `latex_dependency` to set options for latex",
-            " dependencies. Options set here in the string will be",
-            " ignored. ")
+# Convert a yaml structured input to a list of latex dependencies
+yaml_to_latex_dependencies <- function(x){
+  x_yaml <- try(yaml_load_utf8(x))
+  if(class(x_yaml) == "try-error"){
+    stop("Please check the yaml syntax of extra_dependencies.")
   }
-  latex_package_names <- strsplit(x, ",|\\s")[[1]]
-  latex_package_names <- latex_package_names[latex_package_names != ""]
-  lapply(latex_package_names, latex_dependency)
+  if(is.list(x_yaml)){
+    lapply(seq(length(x_yaml)), function(i){
+      latex_dependency(names(x_yaml)[i], x_yaml[[i]])
+      })
+  }else{
+    if(length(x_yaml) == 1 && grepl(",", x_yaml)){
+      x_yaml <- yaml_load_utf8(paste0("[", x_yaml, "]"))
+    }
+    lapply(x_yaml, latex_dependency)
+  }
 }

--- a/R/latex_dependencies.R
+++ b/R/latex_dependencies.R
@@ -60,3 +60,16 @@ validate_latex_dependency <- function(list) {
 has_latex_dependencies <- function(knit_meta) {
   has_dependencies(knit_meta, "latex_dependency")
 }
+
+# Convert a string to a list of basic latex dependencies (no options)
+string_to_latex_dependencies <- function(x){
+  if(grepl("\\[|\\]", x)){
+    x <- gsub("\\[(.*?)\\]", "", x)
+    warning("You have to use `latex_dependency` to set options for latex",
+            " dependencies. Options set here in the string will be",
+            " ignored. ")
+  }
+  latex_package_names <- strsplit(x, ",|\\s")[[1]]
+  latex_package_names <- latex_package_names[latex_package_names != ""]
+  lapply(latex_package_names, latex_dependency)
+}

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -22,9 +22,7 @@
 #'   \href{http://pandoc.org/README.html}{pandoc online documentation}
 #'   for details on creating custom templates.
 #' @param extra_dependencies Add \code{latex_dependency()} dependencies. It can
-#'   can be used to add custom LaTeX packages to the .tex header. People also
-#'   has the option to put in latex package names as a string in the YAML
-#'   section in the format of "extra_dependencies: multirow, threeparttable".
+#'   can be used to add custom LaTeX packages to the .tex header.
 #'
 #' @return R Markdown output format to pass to \code{\link{render}}
 #'
@@ -182,7 +180,7 @@ pdf_document <- function(toc = FALSE,
         extra_dependencies <- list(extra_dependencies)
       }
       if(is.character(extra_dependencies)){
-        extra_dependencies <- string_to_latex_dependencies(extra_dependencies)
+        extra_dependencies <- yaml_to_latex_dependencies(extra_dependencies)
       }
     }
 

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -22,7 +22,9 @@
 #'   \href{http://pandoc.org/README.html}{pandoc online documentation}
 #'   for details on creating custom templates.
 #' @param extra_dependencies Add \code{latex_dependency()} dependencies. It can
-#'   can be used to add custom LaTeX packages to the .tex header.
+#'   can be used to add custom LaTeX packages to the .tex header. People also
+#'   has the option to put in latex package names as a string in the YAML
+#'   section in the format of "extra_dependencies: multirow, threeparttable".
 #'
 #' @return R Markdown output format to pass to \code{\link{render}}
 #'

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -174,15 +174,17 @@ pdf_document <- function(toc = FALSE,
       args <- c(args, "--variable", "geometry:margin=1in")
 
     format_deps <- list()
+
     format_deps <- append(format_deps, extra_dependencies)
+    all_dependencies <- if (is.null(format_deps)) list() else format_deps
 
     if (has_latex_dependencies(knit_meta)) {
-      all_dependencies <- if (is.null(format_deps)) list() else format_deps
       all_dependencies <- append(all_dependencies, flatten_latex_dependencies(knit_meta))
-      filename <- tempfile()
-      latex_dependencies_as_text_file(all_dependencies, filename)
-      args <- c(args, includes_to_pandoc_args(includes(in_header = filename)))
     }
+
+    filename <- tempfile()
+    latex_dependencies_as_text_file(all_dependencies, filename)
+    args <- c(args, includes_to_pandoc_args(includes(in_header = filename)))
     args
   }
 

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -175,11 +175,21 @@ pdf_document <- function(toc = FALSE,
 
     format_deps <- list()
 
+    if(!is.null(extra_dependencies)){
+      if(is_latex_dependency(extra_dependencies)){
+        extra_dependencies <- list(extra_dependencies)
+      }
+      if(is.character(extra_dependencies)){
+        extra_dependencies <- string_to_latex_dependencies(extra_dependencies)
+      }
+    }
+
     format_deps <- append(format_deps, extra_dependencies)
     all_dependencies <- if (is.null(format_deps)) list() else format_deps
 
     if (has_latex_dependencies(knit_meta)) {
-      all_dependencies <- append(all_dependencies, flatten_latex_dependencies(knit_meta))
+      all_dependencies <- append(all_dependencies,
+                                 flatten_latex_dependencies(knit_meta))
     }
 
     filename <- tempfile()


### PR DESCRIPTION
I fixed bug 1 & 3 in #910. I didn't touch bug 2 as I'm not feeling confident enough to make changes to that part..

Also, as I said in the issue, I added a new feature that can translate a string of latex package names (but not options) to latex_dependencies so people can load latex packages (without further settings) in the follow way.
```
---
title: "Untitled"
output: 
  pdf_document:
    keep_tex: true
    extra_dependencies: multirow, threeparttable
---
```
In the future, the `string_to_latex_dependencies` function can also be extended to accept latex package options. I'm thinking a format below might be useful. However, if someone can fix bug 2 in #910, that might not be necessary. 
```
extra_dependencies: multirow[latex package options], threeparttable
```
