### PR TITLE
Better NULL support

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -1,4 +1,5 @@
-
+# Get the combined list of parameters given the defaults provided in the lines
+# of the RMD file and the list of overridden parameters passed in.
 knit_params_get <- function(input_lines, params) {
 
   # read the default parameters and extract them into a named list
@@ -6,7 +7,8 @@ knit_params_get <- function(input_lines, params) {
   if (packageVersion('yaml') < '2.1.14') knit_params <- mark_utf8(knit_params)
   default_params <- list()
   for (param in knit_params) {
-    default_params[[param$name]] <- param$value
+    # Obscure setting syntax allows for setting of NULL values.
+    default_params[param$name] <- list(param$value)
   }
 
   # validate params passed to render

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -4,7 +4,7 @@ test_that("setting of params works", {
 
   skip_on_cran()
 
-  params_sample <- '---\ntitle: "test"\noutput: html_document\nparams:\n  field1:\n    value: "defaulthere"\n---'
+  params_sample <- '---\nparams:\n  field1:\n    value: "defaulthere"\n---'
 
   # No overrides
   params <- knit_params_get(params_sample, NULL)
@@ -16,4 +16,13 @@ test_that("setting of params works", {
 
   # Invalid
   expect_error(knit_params_get(params_sample, "new value"))
+
+  # NULL defaults
+  params_null <- '---\nparams:\n  field1:\n    value: NULL\n---'
+  params <- knit_params_get(params_null, NULL)
+  expect_equal(params, list(field1=NULL))
+
+  # NULL overrides
+  params <- knit_params_get(params_sample, list(field1=NULL))
+  expect_equal(params, list(field1=NULL))
 })

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -1,0 +1,19 @@
+context("params")
+
+test_that("setting of params works", {
+
+  skip_on_cran()
+
+  params_sample <- '---\ntitle: "test"\noutput: html_document\nparams:\n  field1:\n    value: "defaulthere"\n---'
+
+  # No overrides
+  params <- knit_params_get(params_sample, NULL)
+  expect_equal(params$field1, "defaulthere")
+
+  # With overrides
+  params <- knit_params_get(params_sample, list(field1="new value"))
+  expect_equal(params$field1, "new value")
+
+  # Invalid
+  expect_error(knit_params_get(params_sample, "new value"))
+})


### PR DESCRIPTION
Touches #3050

I'm not entirely clear whether this PR is worth taking, but the work is done so I'll let you make the call.

This avoids clobbering the parameter field when the default value is set to NULL. This likely isn't a pattern we would recommend at this point, but I'm opening this PR because I'd argue that it makes our behavior more consistent, even if this isn't an encouraged/documented practice.

Before this change, a document containing:

```
params:
  textField:
    value: NULL
    input: text
```

would be unable to "Knit with parameters" with a custom/overridden value of `textField`. If you attempted, you would get the following error:

```
Error in knit_params_get(input_lines, params) : 
  render params not declared in YAML: textField
Calls: <Anonymous> -> knit_params_get
Execution halted
```

because the parameter was being removed when we attempted to make a NULL assignment.

This avoids deleting the parameter entry from the list in the event that the parameter value is NULL. But I have not fully worked out the implications of allowing a NULL to propagate through the pipeline beyond a couple of simple tests like this.