### PR TITLE
Allow the suppression of default params in interactive configurations

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -48,31 +48,54 @@ params_label <- function(inputControlFn, param) {
   label
 }
 
-params_value_to_ui <- function(inputControlFn, value) {
+params_value_to_ui <- function(inputControlFn, value, showDefault) {
+  if (is.null(showDefault)) {
+    showDefault <- TRUE
+  }
+
+  isNumericInput <- identical(inputControlFn, shiny::numericInput) ||
+    identical(inputControlFn, shiny::sliderInput)
+
   if (identical(inputControlFn, shiny::fileInput)) {
     NULL
   } else if (identical(inputControlFn, shiny::textInput)) {
     ## TODO: if long input, maybe truncate textInput values for display
 
-    classes <- class(value)
-    if ("POSIXct" %in% classes) {
-      as.character(value)
+    if (showDefault){
+      classes <- class(value)
+      if ("POSIXct" %in% classes) {
+        as.character(value)
+      } else {
+        value
+      }
     } else {
-      value
+      NULL
     }
   } else if (is.null(value)) {
-    numerics <- c(shiny::numericInput,
-                  shiny::sliderInput)
     # The numerics can't deal with a NULL value, but everything else is fine.
-    if (identical(inputControlFn, shiny::numericInput) ||
-        identical(inputControlFn, shiny::sliderInput)) {
+    if (isNumericInput) {
       0
     } else {
       value
     }
   } else {
-    ## A type/control that doesn't need special handling; just emit the value.
-    value
+    if (showDefault){
+      ## A type/control that doesn't need special handling; just emit the value.
+      value
+    } else {
+      if (isNumericInput){
+        0
+      } else if (identical(inputControlFn, shiny::dateInput)) {
+        # Use NA to clear date inputs:
+        # https://github.com/rstudio/shiny/pull/1299
+        NA
+      } else if (identical(inputControlFn, shiny::radioButtons)){
+        # As suggested in ?radioButtons
+        character(0)
+      } else {
+        NULL
+      }
+    }
   }
 }
 
@@ -82,7 +105,13 @@ params_value_from_ui <- function(inputControlFn, value, uivalue) {
   } else if (identical(inputControlFn, shiny::textInput)) {
     classes <- class(value)
     if ("POSIXct" %in% classes) {
-      as.POSIXct(uivalue)
+      if (identical(uivalue, "")){
+        # show_default: false produces this situation
+        # Empty POSIXct
+        Sys.time()[-1]
+      } else {
+        as.POSIXct(uivalue)
+      }
     } else {
       uivalue
     }
@@ -96,8 +125,6 @@ params_get_input <- function(param) {
   # Maps between value types and input: XXX
   default_inputs <- list(
       logical = "checkbox",
-      ## BUG: dateInput does not allow the user to not specify a value.
-      ##     https://github.com/rstudio/shiny/issues/896
       Date = "date",
       ## BUG: shiny does not support datetime selectors
       ##     https://github.com/rstudio/shiny/issues/897
@@ -271,7 +298,8 @@ knit_params_ask <- function(file = NULL,
             }
           }
           # Now, transform into something that the input control can handle.
-          current_value <- params_value_to_ui(inputControlFn, current_value)
+          current_value <- params_value_to_ui(inputControlFn, current_value,
+                                              param$show_default)
 
           # value maps to either "value" or "selected" depending on the control.
           if ("value" %in% inputControlFnFormals) {
@@ -279,6 +307,8 @@ knit_params_ask <- function(file = NULL,
           } else if ("selected" %in% inputControlFnFormals) {
             arguments$selected <<- current_value
           }
+        } else if (name == "show_default"){
+          # No-op
         } else {
           ## Not a special field. Blindly promote to the input control.
           arguments[[name]] <<- if (inherits(param[[name]], 'knit_param_expr')) {
@@ -290,7 +320,7 @@ knit_params_ask <- function(file = NULL,
       ## This is based on param$value not current_value because we want to
       ## understand deviation from the report default, not any (optional)
       ## call-time override.
-      uidefault <- params_value_to_ui(inputControlFn, param$value)
+      uidefault <- params_value_to_ui(inputControlFn, param$value, param$show_default)
       hasDefaultValue <- function(value) {
         identical(uidefault, value)
       }

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -46,3 +46,34 @@ test_that("params render their UI", {
   ui <- params_value_to_ui(NULL, myobj, TRUE)
   expect_equal(ui, myobj)
 })
+
+test_that("params hidden w/o show_default", {
+
+  skip_on_cran()
+
+  # file input is always NULL
+  ui <- params_value_to_ui(shiny::fileInput, "anything", FALSE)
+  expect_null(ui)
+
+  # text input suppressed
+  ui <- params_value_to_ui(shiny::textInput, "some char", FALSE)
+  expect_equal(ui, NULL)
+
+  # Date gets scrubbed
+  ui <- params_value_to_ui(shiny::textInput, dat, FALSE)
+  expect_equal(ui, NULL)
+
+  # Numeric -> 0
+  ui <- params_value_to_ui(shiny::numericInput, 13, FALSE)
+  expect_equal(ui, 0)
+
+  # Slider -> 0
+  # TODO: should this be MIN?
+  ui <- params_value_to_ui(shiny::sliderInput, 13, FALSE)
+  expect_equal(ui, 0)
+
+  # Everything else is scrubbed
+  myobj <- list(a=123, b=NULL, c="huh")
+  ui <- params_value_to_ui(function(){}, myobj, FALSE)
+  expect_equal(ui, NULL)
+})

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -17,3 +17,32 @@ test_that("setting of params works", {
   # Invalid
   expect_error(knit_params_get(params_sample, "new value"))
 })
+
+test_that("params render their UI", {
+
+  skip_on_cran()
+
+  # file input is always NULL
+  ui <- params_value_to_ui(shiny::fileInput, "anything", TRUE)
+  expect_null(ui)
+
+  # text input is a pass-through
+  ui <- params_value_to_ui(shiny::textInput, "some char", TRUE)
+  expect_equal(ui, "some char")
+
+  # Date gets converted to char
+  dat <- Sys.time()
+  ui <- params_value_to_ui(shiny::textInput, dat, TRUE)
+  expect_equal(ui, as.character(dat))
+
+  # NULLs get massaged for numeric/slider
+  ui <- params_value_to_ui(shiny::numericInput, NULL, TRUE)
+  expect_equal(ui, 0)
+  ui <- params_value_to_ui(shiny::sliderInput, NULL, TRUE)
+  expect_equal(ui, 0)
+
+  # Everything else is a passthrough
+  myobj <- list(a=123, b=NULL, c="huh")
+  ui <- params_value_to_ui(NULL, myobj, TRUE)
+  expect_equal(ui, myobj)
+})

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -1,0 +1,19 @@
+context("params")
+
+test_that("setting of params works", {
+
+  skip_on_cran()
+
+  params_sample <- '---\ntitle: "test"\noutput: html_document\nparams:\n  field1:\n    value: "defaulthere"\n---'
+
+  # No overrides
+  params <- knit_params_get(params_sample, NULL)
+  expect_equal(params$field1, "defaulthere")
+
+  # With overrides
+  params <- knit_params_get(params_sample, list(field1="new value"))
+  expect_equal(params$field1, "new value")
+
+  # Invalid
+  expect_error(knit_params_get(params_sample, "new value"))
+})


### PR DESCRIPTION
(This will conflict with #912, but if we want to take both I'll resolve the conflicts.)

This adds a `show_default` config for parameters in an RMD. When set to `TRUE`, it will prevent the default from being shown during an interactive parameter configuration process. Non-interactive knits of the doc are not affected by this change.

The use case we'd like to support is to allow a developer to communicate that users should be responsible for configuring certain parameters from scratch, while still allowing them to iterate quickly when locally knitting the document on their machines using the defaults.

In my opinion, this change behaves well for:

 - Text
 - Date
 - DateTime (to the extent that it's supported at all)
 - Radio buttons
 - Select with `multiple: true`
 - file (no effect)

It behaves acceptably for:

 - checkbox (defaults to unselected, or `FALSE`)

And it does not perform as one might hope for: 

 - select with `multiple: false` (the first option is still selected)
 - numeric selector (set to 0 rather than leaving it empty)
 - slider (it attempts to set the default to 0)

As best I can tell, these are limitations in Shiny's input functions. We could consider adding an empty first choice in the "select w/ multiple: false" case, but that felt a little too invasive IMHO.

As an example:

```
params:
  numericField:
    value: 13
    input: numeric
    show_default: false
  textField:
    value: "abc"
    show_default: false
  selector:
    value: east
    choices: [east, west, north, south]
    input: select
    multiple: true
    show_default: false
  slider:
    value: 10
    min: 0
    max: 20
    input: slider
    show_default: false
  date:
    value: !r as.Date("2015-01-01")
    input: date
    show_default: false
  datetime:
    value: !r as.POSIXct("2015-01-01 12:30:00")
    input: datetime
    show_default: false
  checkbox:
    value: TRUE
    input: checkbox
    show_default: false
  radio:
    value: "option1"
    input: radio
    choices: [option1, option2]
    show_default: false
```

produces:

<img width="615" alt="screen shot 2016-12-15 at 2 41 08 pm" src="https://cloud.githubusercontent.com/assets/1593639/21241291/932acc00-c2d4-11e6-98e7-5ac38b82497f.png">
