### PR TITLE
Fix typo in draft.R

### DIFF
--- a/R/draft.R
+++ b/R/draft.R
@@ -10,7 +10,7 @@
 #'   within the \code{rmarkdown/templates} directory of a package.
 #' @param package (Optional) Name of package where the template is located.
 #' @param create_dir \code{TRUE} to create a new directory for the document
-#'   (the "default" setting leaves this beahvior up to the creator of the
+#'   (the "default" setting leaves this behavior up to the creator of the
 #'   template).
 #' @param edit \code{TRUE} to edit the template immediately
 #'

--- a/man/draft.Rd
+++ b/man/draft.Rd
@@ -16,7 +16,7 @@ within the \code{rmarkdown/templates} directory of a package.}
 \item{package}{(Optional) Name of package where the template is located.}
 
 \item{create_dir}{\code{TRUE} to create a new directory for the document
-(the "default" setting leaves this beahvior up to the creator of the
+(the "default" setting leaves this behavior up to the creator of the
 template).}
 
 \item{edit}{\code{TRUE} to edit the template immediately}


### PR DESCRIPTION
I fixed a small typo. I used the spelling "behavior" because this was more common in this repo than the alternative "behaviour" ([behavior search](https://github.com/rstudio/rmarkdown/search?utf8=%E2%9C%93&q=behavior) vs. [behaviour search](https://github.com/rstudio/rmarkdown/search?utf8=%E2%9C%93&q=behaviour&type=Code)).

I signed the RStudio Individual Contributor Agreement back in March 2015.

