### PR TITLE
New `citeproc` agrument in YAML header. Resolves #831.

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -770,7 +770,12 @@ is_pandoc_to_html <- function(options) {
 }
 
 citeproc_required <- function(yaml_front_matter, input_lines = NULL) {
-  !is.null(yaml_front_matter$bibliography) ||
-  !is.null(yaml_front_matter$references) ||
-  length(grep("^references\\:\\s*$", input_lines)) > 0
+  (
+    is.null(yaml_front_matter$citeproc) ||
+      yaml_front_matter$citeproc
+  ) && (
+    !is.null(yaml_front_matter$bibliography) ||
+      !is.null(yaml_front_matter$references) ||
+      length(grep("^references\\:\\s*$", input_lines)) > 0
+  )
 }

--- a/R/render.R
+++ b/R/render.R
@@ -229,10 +229,6 @@ render <- function(input,
   }
   pandoc_to <- output_format$pandoc$to
 
-  # determine whether we need to run citeproc (based on whether we
-  # have references in the input)
-  run_citeproc <- citeproc_required(yaml_front_matter, input_lines)
-
   # generate outpout file based on input filename
   if (is.null(output_file))
     output_file <- pandoc_output_file(input, output_format$pandoc)
@@ -559,7 +555,7 @@ render <- function(input,
     # if we are running citeproc then explicitly forward the bibliography
     # on the command line (works around pandoc-citeproc issue whereby yaml
     # strings that begin with numbers are interpreted as numbers)
-    if (!is.null(bibliography <- yaml_front_matter$bibliography)) {
+    if ((is.null(yaml_front_matter$citeproc) || yaml_front_matter$citeproc) && !is.null(bibliography <- yaml_front_matter$bibliography)) {
       # remove the .bib extension since it does not work with MikTeX's BibTeX
       if (need_bibtex && is_windows()) bibliography <- sub('[.]bib$', '', bibliography)
       output_format$pandoc$args <- c(
@@ -650,6 +646,9 @@ render <- function(input,
       if ((texfile != output_file) && !output_format$pandoc$keep_tex)
         on.exit(unlink(texfile), add = TRUE)
     } else {
+      # determine whether we need to run citeproc (based on whether we
+      # have references in the input)
+      run_citeproc <- citeproc_required(yaml_front_matter, input_lines)
       # generate .tex if we want to keep the tex source
       if (output_format$pandoc$keep_tex) convert(texfile, run_citeproc)
       # run the main conversion if the output file is not .tex

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -7,6 +7,8 @@ rmarkdown 1.3
 
 * Ensure that html_prerendered UI is never cached.
 
+* Add `citeproc` argument to YAML header; controls whether pandoc-citeproc is used (#831)
+
 
 rmarkdown 1.2
 --------------------------------------------------------------------------------


### PR DESCRIPTION
As discussed in #831 this pull request adds a new option `citeproc` to the YAML front matter. If it is set to `TRUE` or omitted `pandoc-citeproc` is invoked as usual. Thus, the change should not break backward compatibility. If it is set to `FALSE` the `pandoc-citeproc`-filter argument is omitted from the call to `pandoc`. This makes it possible to call additional filters after adding the `pandoc-citeproc`-filter argument manually.

I deferred the automated check if `pandoc-citeproc` is needed via `citeproc_required()` to line [651](https://github.com/rstudio/rmarkdown/compare/master...crsh:master#diff-e446088a017e6c3093395c7f863509caR651) of `render.R`. Thereby the check is performed after the pre-processor of a format is invoked and enables changing the default setting for the `citeproc` option. I did not see any earlier reference to the `run_citeproc` variable so as far as I can tell this change should not have any side effects. Tests and checks are passing fine.

Let me know what you think.