### PR TITLE
Allow internationalization of code folding buttons using pandoc

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -247,6 +247,18 @@ $if(code_folding)$
   window.initializeCodeFolding("$code_folding$" === "show");
 $endif$
 });
+// Show/Hide button names internationalization.
+// Variables used in codefolding.js.
+$if(code_folding_show_btn)$
+var ShowCode = $code_folding_show_btn$;
+$else$
+var ShowCode = 'Show';
+$endif$
+$if(code_folding_hide_btn)$
+var HideCode = $code_folding_hide_btn$;
+$else$
+var HideCode = 'Hide';
+$endif$
 </script>
 $endif$
 
@@ -386,11 +398,18 @@ $if(theme)$
 
 $if(code_menu)$
 <div class="btn-group pull-right">
-<button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span>Code</span> <span class="caret"></span></button>
+<button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	<span>$if(code_folding_button)$$code_folding_button$$else$Code$endif$</span>
+	<span class="caret"></span>
+</button>
 <ul class="dropdown-menu" style="min-width: 50px;">
 $if(code_folding)$
-<li><a id="rmd-show-all-code" href="#">Show All Code</a></li>
-<li><a id="rmd-hide-all-code" href="#">Hide All Code</a></li>
+<li><a id="rmd-show-all-code" href="#">
+	$if(code_folding_show)$$code_folding_show$$else$Show All Code$endif$
+</a></li>
+<li><a id="rmd-hide-all-code" href="#">
+	$if(code_folding_hide)$$code_folding_hide$$else$Hide All Code$endif$
+</a></li>
 $if(source_embed)$
 <li role="separator" class="divider"></li>
 $endif$
@@ -400,11 +419,8 @@ $if(source_embed)$
 $endif$
 </ul>
 </div>
-
 $endif$
-
 $endif$
-
 $if(title)$
 <h1 class="title toc-ignore">$title$</h1>
 $if(subtitle)$

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -1,3 +1,6 @@
+// Variables defined in default.html.
+// var ShowCode = 'Show';
+// var HideCode = 'Hide';
 
 window.initializeCodeFolding = function(show) {
 
@@ -30,7 +33,7 @@ window.initializeCodeFolding = function(show) {
     $(this).detach().appendTo(div);
 
     // add a show code button right above
-    var showCodeText = $('<span>' + (show ? 'Hide' : 'Code') + '</span>');
+    var showCodeText = $('<span>' + (show ? HideCode : ShowCode) + '</span>');
     var showCodeButton = $('<button type="button" class="btn btn-default btn-xs code-folding-btn pull-right"></button>');
     showCodeButton.append(showCodeText);
     showCodeButton
@@ -49,10 +52,10 @@ window.initializeCodeFolding = function(show) {
 
     // update state of button on show/hide
     div.on('hidden.bs.collapse', function () {
-      showCodeText.text('Code');
+      showCodeText.text(ShowCode);
     });
     div.on('show.bs.collapse', function () {
-      showCodeText.text('Hide');
+      showCodeText.text(HideCode);
     });
   });
 


### PR DESCRIPTION
Edit default.html and codefolding.js to reveive pandoc
arguments and set text. This allow user set names for
header code folding button, his menu, and buttons before 
code chunks. User must define such variables using pandoc_args in YAML. 
A full example is below. It uses text in Portuguese and unicode
code for up and down triangles.

```
html_document:
  pandoc_args: [
      "--variable", "code_folding_button=Código",
      "--variable", "code_folding_show=Mostrar",
      "--variable", "code_folding_hide=Esconder",
      "--variable", "code_folding_show_btn='\u25BE'",
      "--variable", "code_folding_hide_btn='\u25B4'"
    ]
```