### PR TITLE
Check for NA in chunk lines (tolerate mismatched encodings); fixes #924

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -329,7 +329,7 @@ discover_rmd_resources <- function(rmd_file, encoding,
                             perl = TRUE)
     for (idx in seq_along(chunk_lines)) {
       chunk_line <- chunk_lines[idx][[1]]
-      if (chunk_line < 0)
+      if (is.na(chunk_line) || chunk_line < 0)
         next
       chunk_start <- attr(chunk_line, "capture.start", exact = TRUE) + 1
       chunk_text <- substr(rmd_content[idx], chunk_start,


### PR DESCRIPTION
This change fixes an issue in which Shiny R Markdown deployed to shinyapps.io does not always render properly there. It's caused when files with Latin1 Windows encoding are treated as UTF-8 on shinyapps.io and there are certain Latin characters in the file (in this case it's ñ). 

This is just a workaround which allows the app to function even though the encoding is not correct; it does not solve the underlying issue. What's really needed is work in the bundle to persist the file's encoding in its deployment bundle so that it can be used as an argument to `rmarkdown::run` on shinyapps.io and Connect, or to translate all code-bearing files in the bundle from native encodings to UTF-8 prior to bundling them. 