### PR TITLE
Fix #910: pdf_document(extra_dependencies) should work without knit_meta

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.3
+Version: 1.3.1
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),

--- a/R/latex_dependencies.R
+++ b/R/latex_dependencies.R
@@ -8,6 +8,23 @@ latex_dependency <- function(name, options = NULL) {
   validate_latex_dependency(output)
 }
 
+latex_dependencies <- function(x = list()) {
+  if (length(x) == 0) return()
+  if (is_latex_dependency(x)) return(list(x))
+  nms <- names(x)
+  if (is.list(x)) {
+    if (is.null(nms)) return(x)  # assume it is just a list of latex_dependency()
+    # turn the named list to a named character vector
+    x <- unlist(lapply(x, paste, collapse = ', '))
+  }
+  if (is.character(x)) {
+    if (is.null(nms)) {
+      lapply(x, latex_dependency)
+    } else {
+      mapply(latex_dependency, nms, x, SIMPLIFY = FALSE, USE.NAMES = FALSE)
+    }
+  }
+}
 
 # Write the LaTeX dependencies to a text file, suitable for passing it
 # to an include LaTeX command

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -21,8 +21,12 @@
 #'   created.  See the documentation on
 #'   \href{http://pandoc.org/README.html}{pandoc online documentation}
 #'   for details on creating custom templates.
-#' @param extra_dependencies Add \code{latex_dependency()} dependencies. It can
-#'   can be used to add custom LaTeX packages to the .tex header.
+#' @param extra_dependencies A LaTeX dependency \code{latex_dependency()}, a
+#'   list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
+#'   \code{c("framed", "hyperref")}), or a named list of LaTeX package options
+#'   with the names being package names (e.g. \code(list(hypreref =
+#'   c("unicode=true", "breaklinks=true"), lmodern = NULL))). It can be used to
+#'   add custom LaTeX packages to the .tex header.
 #'
 #' @return R Markdown output format to pass to \code{\link{render}}
 #'
@@ -173,12 +177,9 @@ pdf_document <- function(toc = FALSE,
     if (!has_geometry(readLines(input_file, warn = FALSE)))
       args <- c(args, "--variable", "geometry:margin=1in")
 
-    format_deps <- list()
-    format_deps <- append(format_deps, extra_dependencies)
-
-    if (has_latex_dependencies(knit_meta)) {
-      all_dependencies <- if (is.null(format_deps)) list() else format_deps
-      all_dependencies <- append(all_dependencies, flatten_latex_dependencies(knit_meta))
+    if (length(extra_dependencies) || has_latex_dependencies(knit_meta)) {
+      extra_dependencies <- latex_dependencies(extra_dependencies)
+      all_dependencies <- append(extra_dependencies, flatten_latex_dependencies(knit_meta))
       filename <- tempfile()
       latex_dependencies_as_text_file(all_dependencies, filename)
       args <- c(args, includes_to_pandoc_args(includes(in_header = filename)))

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -24,8 +24,8 @@
 #' @param extra_dependencies A LaTeX dependency \code{latex_dependency()}, a
 #'   list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
 #'   \code{c("framed", "hyperref")}), or a named list of LaTeX package options
-#'   with the names being package names (e.g. \code(list(hypreref =
-#'   c("unicode=true", "breaklinks=true"), lmodern = NULL))). It can be used to
+#'   with the names being package names (e.g. \code{list(hypreref =
+#'   c("unicode=true", "breaklinks=true"), lmodern = NULL)}). It can be used to
 #'   add custom LaTeX packages to the .tex header.
 #'
 #' @return R Markdown output format to pass to \code{\link{render}}

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,14 @@
+rmarkdown 1.4 (unreleased)
+--------------------------------------------------------------------------------
+
+* Fix #910: the extra_dependencies argument of pdf_document() does not work when
+  no code chunks contain LaTeX dependencies.
+
+* The extra_dependencies of pdf_document() can also take a character vector of
+  LaTeX package names, or a named list of LaTeX package options (with names
+  being package names), which makes it much easier to express LaTeX dependencies
+  via YAML.
+
 rmarkdown 1.3
 --------------------------------------------------------------------------------
 

--- a/man/pdf_document.Rd
+++ b/man/pdf_document.Rd
@@ -69,8 +69,12 @@ additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 
-\item{extra_dependencies}{Add \code{latex_dependency()} dependencies. It can
-can be used to add custom LaTeX packages to the .tex header.}
+\item{extra_dependencies}{A LaTeX dependency \code{latex_dependency()}, a
+list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
+\code{c("framed", "hyperref")}), or a named list of LaTeX package options
+with the names being package names (e.g. \code(list(hypreref =
+c("unicode=true", "breaklinks=true"), lmodern = NULL))). It can be used to
+add custom LaTeX packages to the .tex header.}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}

--- a/man/pdf_document.Rd
+++ b/man/pdf_document.Rd
@@ -72,8 +72,8 @@ additional details.}
 \item{extra_dependencies}{A LaTeX dependency \code{latex_dependency()}, a
 list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
 \code{c("framed", "hyperref")}), or a named list of LaTeX package options
-with the names being package names (e.g. \code(list(hypreref =
-c("unicode=true", "breaklinks=true"), lmodern = NULL))). It can be used to
+with the names being package names (e.g. \code{list(hypreref =
+c("unicode=true", "breaklinks=true"), lmodern = NULL)}). It can be used to
 add custom LaTeX packages to the .tex header.}
 }
 \value{

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -95,8 +95,12 @@ additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 
-\item{extra_dependencies}{Add \code{latex_dependency()} dependencies. It can
-can be used to add custom LaTeX packages to the .tex header.}
+\item{extra_dependencies}{A LaTeX dependency \code{latex_dependency()}, a
+list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
+\code{c("framed", "hyperref")}), or a named list of LaTeX package options
+with the names being package names (e.g. \code(list(hypreref =
+c("unicode=true", "breaklinks=true"), lmodern = NULL))). It can be used to
+add custom LaTeX packages to the .tex header.}
 
 \item{...}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link{html_document_base}}}

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -98,8 +98,8 @@ additional details.}
 \item{extra_dependencies}{A LaTeX dependency \code{latex_dependency()}, a
 list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
 \code{c("framed", "hyperref")}), or a named list of LaTeX package options
-with the names being package names (e.g. \code(list(hypreref =
-c("unicode=true", "breaklinks=true"), lmodern = NULL))). It can be used to
+with the names being package names (e.g. \code{list(hypreref =
+c("unicode=true", "breaklinks=true"), lmodern = NULL)}). It can be used to
 add custom LaTeX packages to the .tex header.}
 
 \item{...}{Additional function arguments to pass to the


### PR DESCRIPTION
Besides the bug fix, this PR also introduced a new feature that makes it much easier to specify LaTeX dependencies in YAML, e.g.

```yaml
extra_dependencies: ["multirow", "threeparttable"]

extra_dependencies:
    hyperref: ["unicode=true", "breaklinks=true"]
    lmodern: null
```

cc @haozhu233 