### PR TITLE
Escape end tags in prerendered code contexts (fixes #943)

### DIFF
--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -433,7 +433,7 @@ shiny_prerendered_extract_context <- function(html_lines, context) {
   }
 
   # unescape code, see https://github.com/rstudio/rmarkdown/issues/943
-  context_lines <- gsub("<\\u002", "</", context_lines, fixed = TRUE)
+  context_lines <- gsub("<\\u002f", "</", context_lines, fixed = TRUE)
   context_lines
 }
 
@@ -488,7 +488,7 @@ shiny_prerendered_append_context <- function(con, name, code) {
              paste0('<script type="application/shiny-prerendered" ',
                     'data-context="', name ,'">'),
              # escape code, see https://github.com/rstudio/rmarkdown/issues/943
-             gsub("</", "<\\u002", code, fixed = TRUE),
+             gsub("</", "<\\u002f", code, fixed = TRUE),
              '</script>',
              '<!--/html_preserve-->')
   writeLines(lines, con = con)

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -431,6 +431,9 @@ shiny_prerendered_extract_context <- function(html_lines, context) {
     if (in_context)
       context_lines <- c(context_lines, html_lines[[i]])
   }
+
+  # unescape code, see https://github.com/rstudio/rmarkdown/issues/943
+  context_lines <- gsub("<\\u002", "</", context_lines, fixed = TRUE)
   context_lines
 }
 
@@ -484,7 +487,8 @@ shiny_prerendered_append_context <- function(con, name, code) {
   lines <- c('<!--html_preserve-->',
              paste0('<script type="application/shiny-prerendered" ',
                     'data-context="', name ,'">'),
-             code,
+             # escape code, see https://github.com/rstudio/rmarkdown/issues/943
+             gsub("</", "<\\u002", code, fixed = TRUE),
              '</script>',
              '<!--/html_preserve-->')
   writeLines(lines, con = con)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -11,6 +11,8 @@ rmarkdown 1.4 (unreleased)
 
 * Automatically ignore packrat directory for render_site
 
+* Fix #943: escape end tags in shiny_prerendered code contexts
+
 
 rmarkdown 1.3
 --------------------------------------------------------------------------------


### PR DESCRIPTION
@wch Could you review this pls?
