### PR TITLE
add sticky tabs to .tabset (url hash and active tab always correspond)

### DIFF
--- a/inst/rmd/h/navigation-1.1/tabsets.js
+++ b/inst/rmd/h/navigation-1.1/tabsets.js
@@ -1,3 +1,49 @@
+/**
+ * jQuery Plugin: Sticky Tabs
+ *
+ * @author Aidan Lister <aidan@php.net>
+ * adapted by Ruben Arslan to activate parent tabs too
+ * http://www.aidanlister.com/2014/03/persisting-the-tab-state-in-bootstrap/
+ */
+(function($) {
+  "use strict";
+  $.fn.stickyStuff = function() {
+    var context = this;
+    // Show the tab corresponding with the hash in the URL, or the first tab
+    var showStuffFromHash = function() {
+      var hash = window.location.hash;
+      var selector = hash ? 'a[href="' + hash + '"]' : 'li.active > a';
+      var $selector = $(selector, context);
+      if($selector.data('toggle') === "tab") {
+        $selector.tab('show');
+        // walk up the ancestors of this element, show any hidden tabs
+        $selector.parents('.section.tabset').each(function(i, elm) {
+          var link = $('a[href="#' + $(elm).attr('id') + '"]');
+          if(link.data('toggle') === "tab") {
+            link.tab("show");
+          }
+        });
+      }
+    };
+
+
+    // Set the correct tab when the page loads
+    showStuffFromHash(context);
+
+    // Set the correct tab when a user uses their back/forward button
+    $(window).on('hashchange', function() {
+      showStuffFromHash(context);
+    });
+
+    // Change the URL when tabs are clicked
+    $('a', context).on('click', function(e) {
+      history.pushState(null, null, this.href);
+      showStuffFromHash(context);
+    });
+
+    return this;
+  };
+}(jQuery));
 
 
 window.buildTabsets = function(tocID) {
@@ -80,6 +126,8 @@ window.buildTabsets = function(tocID) {
     active.addClass('active');
     if (fade)
       active.addClass('in');
+
+    tabset.stickyStuff(); // ensure hash corresponds to active tab
   }
 
   // convert section divs with the .tabset class to tabsets


### PR DESCRIPTION
## Purpose
This should ensure that:

1. the URL hash changes when a tab is activated
2. this change is written to browser history
3. most importantly: calling up the page with this hash activates the right tab

I've been using this code in my own projects for a while now. I often generate complex analysis reports and it's very helpful to be able to link to specific sections.

It's an adapted version of Aidan Lister's stickyStuff plugin for bootstrap tabs. My changes just let it travel up the ancestors of the tabset, so that if a child tab (e.g. `.section.level3`) is activated, its parent tab is activated too.

## Test document
I've been using this simple document to test that it works, but I've tested in much bigger projects as well and I haven't noticed any problems.

```markdown
# Top heading {.tabset}

## Tab 1 {.tabset}

### Subtab 1
1

### Subtab 2
2

## Tab 2 {.tabset}

### Subtab 3
3

### Subtab 4
4
```