### PR TITLE
Quote date for df_print paged option

### DIFF
--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -8,7 +8,7 @@ paged_table_type_sum <- function(x) {
                           factor = "fctr",
                           POSIXt = "dttm",
                           difftime = "time",
-                          Date = date,
+                          Date = "date",
                           data.frame = class(x)[[1]],
                           tbl_df = "tibble",
                           NULL


### PR DESCRIPTION
Date column types not printing correctly with `df_print` set to `paged`, code with this issue follows. Fix is to use correct quotes while comparing types.

````
---
title: "R Notebook"
output:
  html_document:
    df_print: paged
---

```{r}
date <- as.Date(c('2016-8-10', '2015-2-18', '2015-2-18', '2015-2-18', '2015-2-18'))
data.frame(foo = date)
```
````