### PR TITLE
avoid line breaks between non-print data.table expressions

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -307,10 +307,11 @@ html_document <- function(toc = FALSE,
       try(action())
   }
 
-  # capture the source code if requested
   source_code <- NULL
   source_file <- NULL
   pre_knit <- function(input, ...) {
+
+    # capture the source code if requested
     if (code_download) {
       source_file <<- basename(input)
       source_code <<- paste0(
@@ -318,6 +319,22 @@ html_document <- function(toc = FALSE,
         base64enc::base64encode(input),
         '</div>')
     }
+
+    # custom evaluate hook to ensure empty data.table outputs
+    # are removed
+    evaluate_hook <- knitr::knit_hooks$get("evaluate")
+    exit_actions <<- c(exit_actions, function() {
+      knitr::knit_hooks$set(evaluate = evaluate_hook)
+    })
+
+    knitr::knit_hooks$set(evaluate = function(...) {
+      result <- evaluate_hook(...)
+      if (is.list(result)) {
+        filter <- function(e) !inherits(e, "empty_output")
+        result <- Filter(filter, result)
+      }
+      result
+    })
   }
 
   # pagedtable

--- a/R/knit_print.R
+++ b/R/knit_print.R
@@ -15,7 +15,7 @@ knit_print.data.frame <- function(x, ...) {
   }
 
   if (!printable)
-    return()
+    return(structure(list(), class = "empty_output"))
 
   if (!is.null(context$df_print)) {
     if (identical(context$df_print, knitr::kable)) {

--- a/tests/testthat/test-notebook.R
+++ b/tests/testthat/test-notebook.R
@@ -1,16 +1,10 @@
 context("notebook")
 
-# expect that the default evaluate hook points to the evaluate package
-expect_default_evaluate_hook <- function() {
-  evaluate <- knitr::knit_hooks$get("evaluate")
-  expect_identical(environment(evaluate), asNamespace("evaluate"))
-}
-
 test_that("an example R Notebook document can be rendered and parsed", {
   skip_on_cran()
 
   # check initial status of hook
-  expect_default_evaluate_hook()
+  hook <- knitr::knit_hooks$get("evaluate")
 
   # generate the file
   path <- test_path("resources/r-notebook.Rmd")
@@ -19,7 +13,7 @@ test_that("an example R Notebook document can be rendered and parsed", {
   rmarkdown::render(path, output_file = file, quiet = TRUE)
 
   # confirm the evaluate hook has been restored post-render
-  expect_default_evaluate_hook()
+  expect_equal(hook, knitr::knit_hooks$get("evaluate"))
 
   # if running interactively, try running the following code to open the
   # generated document -- in RStudio, you should see the source .Rmd opened,
@@ -96,12 +90,12 @@ test_that("a custom output_source can be used on render", {
   on.exit(unlink(output_file), add = TRUE)
 
   # check initial status of hook
-  expect_default_evaluate_hook()
+  hook <- knitr::knit_hooks$get("evaluate")
 
   render(input_file, output_options = output_options, output_file = output_file, quiet = TRUE)
 
   # confirm the evaluate hook has been restored post-render
-  expect_default_evaluate_hook()
+  expect_equal(hook, knitr::knit_hooks$get("evaluate"))
 
   # parse notebook
   parsed <- parse_html_notebook(output_file)


### PR DESCRIPTION
This PR fixes an issue where multiple consecutive non-printing `data.table` statements would print with spaces between the statements, e.g.:

<img width="318" alt="screen shot 2017-02-24 at 11 28 54 am" src="https://cloud.githubusercontent.com/assets/1976582/23317721/74220dea-fa84-11e6-840c-0bd7c9eb4b8f.png">

There's a chance that we might want to change this downstream in `knitr`; e.g. by filtering out any `NULL` or empty outputs, but this should be sufficient for now.