### PR TITLE
don't repeat latex dependencies in LaTeX preamble

### DIFF
--- a/R/latex_dependencies.R
+++ b/R/latex_dependencies.R
@@ -44,7 +44,7 @@ latex_dependencies_as_string <- function(dependencies) {
     # \\usepackage[opt1,opt2]{pkgname}
     paste0("\\usepackage", opts, "{", dep$name, "}")
   })
-  paste(lines, collapse = "\n")
+  paste(unique(lines), collapse = "\n")
 }
 
 


### PR DESCRIPTION
Oneliner to avoid repetition of \usepackage{foo} in LaTeX preambles. NB: I have sent the contributor agreement off today.