### PR TITLE
Fix 'parmaeters' typo

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -43,7 +43,7 @@
 #'   any intermediate files required to render the \code{input_file}.
 #' @param post_processor An optional post-processor function that receives the
 #'   \code{metadata}, \code{input_file}, \code{output_file}, \code{clean},
-#'   and \code{verbose} parmaeters, and can return an alternative
+#'   and \code{verbose} parameters, and can return an alternative
 #'   \code{output_file}.
 #' @param on_exit A function to call when \code{rmarkdown::render()} finishes
 #'   execution (as registered with a \code{\link{on.exit}} handler).


### PR DESCRIPTION
Fix 'parmaeters' typo in output_format documentaion