### PR TITLE
Use mathjax.rstudio.com over deprecated mathjax CDN

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -43,10 +43,10 @@
 #'@param highlight Syntax highlighting style. Supported styles include
 #'  "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",
 #'  "haddock", and "textmate". Pass \code{NULL} to prevent syntax highlighting.
-#'@param mathjax Include mathjax. The "default" option uses an https URL from
-#'  the official MathJax CDN. The "local" option uses a local version of MathJax
-#'  (which is copied into the output directory). You can pass an alternate URL
-#'  or pass \code{NULL} to exclude MathJax entirely.
+#'@param mathjax Include mathjax. The "default" option uses an https URL from a
+#'  MathJax CDN. The "local" option uses a local version of MathJax (which is
+#'  copied into the output directory). You can pass an alternate URL or pass
+#'  \code{NULL} to exclude MathJax entirely.
 #'@param section_divs Wrap sections in <div> tags (or <section> tags in HTML5),
 #'  and attach identifiers to the enclosing <div> (or <section>) rather than the
 #'  header itself.
@@ -506,7 +506,7 @@ html_highlighters <- function() {
 }
 
 default_mathjax <- function() {
-  paste("https://cdn.mathjax.org/mathjax/latest/",
+  paste("https://mathjax.rstudio.com/latest/",
         mathjax_config(), sep="")
 }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -367,7 +367,7 @@ shinyHTML_with_deps <- function(html_file, deps) {
   if (nzchar(Sys.getenv("RSTUDIO"))) {
     local_mathjax <- Sys.getenv("RMARKDOWN_MATHJAX_PATH")
     if (nzchar(local_mathjax)) {
-      html <- gsub(pattern = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?",
+      html <- gsub(pattern = "https://mathjax.rstudio.com/latest/MathJax.js?",
                    replacement = "mathjax-local/MathJax.js?",
                    x = html,
                    fixed = TRUE,

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -6,6 +6,8 @@ rmarkdown 1.5 (unreleased)
 
 * Add `includes` parameter to `html_fragment` format.
 
+* Use RStudio redirection URL to replace deprecated MathJax CDN
+
 
 rmarkdown 1.4
 --------------------------------------------------------------------------------

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -84,10 +84,10 @@ use the \code{css} parameter to add your own styles).}
 "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",
 "haddock", and "textmate". Pass \code{NULL} to prevent syntax highlighting.}
 
-\item{mathjax}{Include mathjax. The "default" option uses an https URL from
-the official MathJax CDN. The "local" option uses a local version of MathJax
-(which is copied into the output directory). You can pass an alternate URL
-or pass \code{NULL} to exclude MathJax entirely.}
+\item{mathjax}{Include mathjax. The "default" option uses an https URL from a
+MathJax CDN. The "local" option uses a local version of MathJax (which is
+copied into the output directory). You can pass an alternate URL or pass
+\code{NULL} to exclude MathJax entirely.}
 
 \item{template}{Pandoc template to use for rendering. Pass "default" to use
 the rmarkdown package default template; pass \code{NULL} to use pandoc's

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -30,10 +30,10 @@ it's size).}
 bootstrap, etc.) into. By default this will be the name of the document with
 \code{_files} appended to it.}
 
-\item{mathjax}{Include mathjax. The "default" option uses an https URL from
-the official MathJax CDN. The "local" option uses a local version of MathJax
-(which is copied into the output directory). You can pass an alternate URL
-or pass \code{NULL} to exclude MathJax entirely.}
+\item{mathjax}{Include mathjax. The "default" option uses an https URL from a
+MathJax CDN. The "local" option uses a local version of MathJax (which is
+copied into the output directory). You can pass an alternate URL or pass
+\code{NULL} to exclude MathJax entirely.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -56,10 +56,10 @@ use the \code{css} parameter to add your own styles).}
 "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",
 "haddock", and "textmate". Pass \code{NULL} to prevent syntax highlighting.}
 
-\item{mathjax}{Include mathjax. The "default" option uses an https URL from
-the official MathJax CDN. The "local" option uses a local version of MathJax
-(which is copied into the output directory). You can pass an alternate URL
-or pass \code{NULL} to exclude MathJax entirely.}
+\item{mathjax}{Include mathjax. The "default" option uses an https URL from a
+MathJax CDN. The "local" option uses a local version of MathJax (which is
+copied into the output directory). You can pass an alternate URL or pass
+\code{NULL} to exclude MathJax entirely.}
 
 \item{extra_dependencies}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link{html_document_base}}}

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -66,10 +66,10 @@ it's size).}
 "default", "tango", "pygments", "kate", "monochrome", "espresso",
 "zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
 
-\item{mathjax}{Include mathjax. The "default" option uses an https URL from
-the official MathJax CDN. The "local" option uses a local version of MathJax
-(which is copied into the output directory). You can pass an alternate URL
-or pass \code{NULL} to exclude MathJax entirely.}
+\item{mathjax}{Include mathjax. The "default" option uses an https URL from a
+MathJax CDN. The "local" option uses a local version of MathJax (which is
+copied into the output directory). You can pass an alternate URL or pass
+\code{NULL} to exclude MathJax entirely.}
 
 \item{template}{Pandoc template to use for rendering. Pass "default" to use
 the rmarkdown package default template; pass \code{NULL} to use pandoc's


### PR DESCRIPTION
This change replaces the deprecated MathJax CDN URL with a URL that uses the `mathjax.rstudio.com` redirector to the [cdnjs MathJax](https://cdnjs.com/libraries/mathjax).