### PR TITLE
github_document body background white

### DIFF
--- a/inst/rmarkdown/templates/github_document/resources/preview.html
+++ b/inst/rmarkdown/templates/github_document/resources/preview.html
@@ -18,6 +18,7 @@ body {
   margin: 0 auto;
   padding: 45px;
   padding-top: 0px;
+  background: white;
 }
 </style>
 


### PR DESCRIPTION
The new RStudio Dailies are taking the theme setting literally and the black background in my theme setting propagates into the Viewer window when previewing knitted github R markdown docs.

This is a super-simple change to force-set the background of the `body` tag to be `white` in `github_document`.

The contributor agreement is on it's way in e-mail.