### PR TITLE
allow for 'pre_knit' hook on output_source

### DIFF
--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -80,6 +80,11 @@ html_notebook <- function(toc = FALSE,
         })
       }
 
+      # if our output_source comes with a pre_knit hook, evaluate that
+      output_source_pre_knit <- attr(output_source, "pre_knit", exact = TRUE)
+      if (is.function(output_source_pre_knit))
+        try(output_source_pre_knit())
+
       # track knit context
       chunk_options <- list()
 


### PR DESCRIPTION
This PR allows for a `pre_knit` attribute to be set on the `output_source` function, thereby allowing an `output_source` to take some actions on `pre_knit`.

The intention is for RStudio to provide a `pre_knit` hook on this function that can inject knitr options, as gleaned from the setup chunk, so that globally set values like e.g. `echo` can be respected.

See companion PR at https://github.com/rstudio/rstudio/pull/1175.