### PR TITLE
Code folding for different languages

### DIFF
--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -16,8 +16,8 @@ window.initializeCodeFolding = function(show) {
   // index for unique code element ids
   var currentIndex = 1;
 
-  // select all R code blocks
-  var rCodeBlocks = $('pre.r');
+  // select all language code blocks
+  var rCodeBlocks = $('pre.sourceCode');
   rCodeBlocks.each(function() {
 
     // create a collapsable div to wrap the code in


### PR DESCRIPTION
Instead of selecting `pre.R`, select `pre.sourceCode` and code folding appears to work for other languages too.