### PR TITLE
disable 'ascii_identifiers' in github_document

### DIFF
--- a/R/github_document.R
+++ b/R/github_document.R
@@ -36,6 +36,10 @@ github_document <- function(toc = FALSE,
   variant <- "markdown_github"
   if (!hard_line_breaks)
     variant <- paste0(variant, "-hard_line_breaks")
+
+  # turn off ASCII identifiers
+  variant <- paste0(variant, "-ascii_identifiers")
+
   format <- md_document(variant = variant,
                         toc = toc,
                         toc_depth = toc_depth,
@@ -47,6 +51,10 @@ github_document <- function(toc = FALSE,
                         md_extensions = md_extensions,
                         pandoc_args = pandoc_args)
 
+  # remove 'ascii_identifiers' if necessary -- required to ensure that
+  # TOC links are correctly generated on GitHub
+  format$pandoc$from <-
+    gsub("+ascii_identifiers", "", format$pandoc$from, fixed = TRUE)
 
   # add a post processor for generating a preview if requested
   if (html_preview) {

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+rmarkdown 1.6 (unreleased)
+--------------------------------------------------------------------------------
+
+* Fixed an issue where headers with non-ASCII text would not be linked
+  to correctly in the table of contents.
+
 rmarkdown 1.5
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes an issue where the table of contents in a GitHub document would not link to headers correctly for headers containing non-ASCII characters.