### PR TITLE
expand markdown image paths

### DIFF
--- a/R/hooks.R
+++ b/R/hooks.R
@@ -1,0 +1,55 @@
+md_document_hook <- function(hook) {
+  force(hook)
+
+  # regular expression that can capture elements of an image link
+  re_link <- paste0(
+    "^\\s*",        # initial whitespace
+    "!",            # starts with an '!'
+    "\\[(.*)\\]",   # '[...]'
+    "\\((~/.*)\\)", # '(~/...)'
+    "(.*)"          # trailing content (e.g. attributes)
+  )
+
+  function(x) {
+
+    # call old hook
+    output <- hook(x)
+
+    # split output on newlines
+    lines <- unlist(strsplit(output, "\n", fixed = TRUE))
+    replaced <- lapply(lines, function(line) {
+
+      # attempt to detect a match (returning original line of failure)
+      matches <- gregexpr(re_link, line, perl = TRUE)[[1]]
+      if (c(matches) == -1L)
+        return(line)
+
+      # extract the used path
+      start <- attr(matches, "capture.start")
+      length <- attr(matches, "capture.length")
+      pieces <- substring(line, start, start + length - 1)
+
+      # extract the path portion
+      alt <- pieces[[1]]
+      path <- pieces[[2]]
+      rest <- pieces[[3]]
+
+      # attempt path expansion
+      expanded <- tryCatch(
+        path.expand(path),
+        error = identity
+      )
+
+      if (inherits(expanded, "error"))
+        return(line)
+
+      # generate a new line with this expanded path
+      fmt <- "![%s](%s)%s"
+      sprintf(fmt, alt, expanded, rest)
+
+    })
+
+    # join back into a single string
+    paste(replaced, collapse = "\n")
+  }
+}

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -316,6 +316,8 @@ html_document <- function(toc = FALSE,
   source_code <- NULL
   source_file <- NULL
   pre_knit <- function(input, ...) {
+
+    # embed source code when requested
     if (code_download) {
       source_file <<- basename(input)
       source_code <<- paste0(
@@ -323,6 +325,14 @@ html_document <- function(toc = FALSE,
         base64enc::base64encode(input),
         '</div>')
     }
+
+    # provide a document hook that expands image links prefixed with
+    # a '~', so that pandoc will accept them
+    document_hook <- knitr::knit_hooks$get("document")
+    exit_actions <<- c(exit_actions, function() {
+      knitr::knit_hooks$set(document = document_hook)
+    })
+    knitr::knit_hooks$set(document = md_document_hook(document_hook))
   }
 
   # pagedtable

--- a/R/util.R
+++ b/R/util.R
@@ -591,4 +591,3 @@ shell_exec <- function(cmd, intern = FALSE, wait = TRUE, ...) {
   else
     system(cmd, intern = intern, wait = wait, ...)
 }
-


### PR DESCRIPTION
This PR expands Markdown images paths of the form e.g.

    ![hello](~/plot.png)

replacing `~` with the actual home directory. Doing this allows `pandoc` to successfully convert the  resulting Markdown file.

This is implemented as a `knitr` hook as it seemed the most natural place to perform this transformation in the current `render()` infrastructure, but let me know if there's a better spot (or if we should avoid this altogether).

The underlying motivation: currently, image paths prefixed with `~/` can be previewed from the IDE; this change is required to ensure such documents can be rendered by `pandoc` as well. (We could also just turn off preview for images of that form on the IDE side instead, if preferred)