### PR TITLE
Couple fixes to paged tables

### DIFF
--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -78,9 +78,13 @@ paged_table_obj_sum <- function(x) {
     paste0(" [", dim_desc(x), "]" )
   }
 
+  obj_sum.default <- function(x) {
+    paste0(paged_table_type_sum(x), size_sum(x))
+  }
+
   switch(class(x)[[1]],
          POSIXlt = rep("POSIXlt", length(x)),
-         list = vapply(x, paged_table_obj_sum, character(1L)),
+         list = vapply(x, obj_sum.default, character(1L)),
          paste0(paged_table_type_sum(x), size_sum(x))
   )
 }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -6,6 +6,9 @@ rmarkdown 1.6 (unreleased)
 
 * Support code folding for bash, python, sql, Rcpp, and Stan chunks.
 
+* Fixed two issue with `df_print: paged`, one would prevent rendering data with
+  lists of lists and the other where the column type would get cut off.
+
 
 rmarkdown 1.5
 --------------------------------------------------------------------------------

--- a/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
@@ -357,7 +357,11 @@ var PagedTable = function (pagedTable) {
 
     me.calculateWidths = function(measures) {
       columns.forEach(function(column) {
-        var maxChars = column.label.toString().length;
+        var maxChars = Math.max(
+          column.label.toString().length,
+          column.type.toString().length
+        );
+
         for (var idxRow = 0; idxRow < Math.min(widthsLookAhead, data.length); idxRow++) {
           maxChars = Math.max(maxChars, data[idxRow][column.name.toString()].length);
         }


### PR DESCRIPTION
1. Using `df_print: paged` as an option followed by `tibble::tibble(x = 1, y = list(list(list(1, 2, 3))))` causes an error instead of printing the paged table. The problem here is that we are missing to port this fix: https://github.com/tidyverse/tibble/commit/275e465a3b5f4e72f2c44d1d8c3ac6cd77f610b7
2. Columns with small names and medium types get cut off, the problem was that we were only using the column name and data, but not the column type label, to calculate the column width.