### PR TITLE
Update Imports to stringr (>= 1.2.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,7 +73,7 @@ Imports:
     jsonlite,
     rprojroot,
     methods,
-    stringr
+    stringr (>= 1.2.0)
 Suggests:
     shiny (>= 0.11),
     tufte,


### PR DESCRIPTION
This PR closes #1071.

Now rmarkdown package needs the newer versions than 1.2.0 of stringr due to #1050.