### PR TITLE
Allow paged tables to render for long delayed loads

### DIFF
--- a/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
+++ b/inst/rmd/h/pagedtable-1.1/js/pagedtable.js
@@ -897,16 +897,12 @@ var PagedTable = function (pagedTable) {
     me.render();
 
     // retry seizing columns later if the host has not provided space
-    var retries = 100;
     function retryFit() {
-      retries = retries - 1;
-      if (retries > 0) {
-        if (tableDiv.clientWidth <= 0) {
-          setTimeout(retryFit, 100);
-        } else {
-          me.render();
-          triggerOnChange();
-        }
+      if (tableDiv.clientWidth <= 0) {
+        setTimeout(retryFit, 100);
+      } else {
+        me.render();
+        triggerOnChange();
       }
     }
     if (tableDiv.clientWidth <= 0) {


### PR DESCRIPTION
Originally, paged tables design assumed that they would be rendered on documents (notebooks, markdown, etc) and were not fully designed to support interactive docs where a paged table might be hidden for long periods of time.

Ideally, there is a way to monitor the size of the parent element and render the paged table when the size is ready. This will become available with [ResizeObserver](https://wicg.github.io/ResizeObserver/) but this is still far from even being an experimental feature.

Therefore, for now, the fix is to keep waiting for the size to become available. From a few online benchmarks, there is no real cost of running timers unless there are 100Ks running on a page, which is unlikely for paged tables.