### PR TITLE
`df_print: paged` to print row names and support `rownames.print`

### DIFF
--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -98,7 +98,8 @@ paged_table_option <- function(option, default = NULL) {
 
 #' @import methods
 paged_table_html <- function(x) {
-  addRowNames = .row_names_info(data, type = 1) > 0
+  addRowNames = paged_table_option("rownames.print")
+  addRowNames <- if (is.null(addRowNames)) (.row_names_info(x, type = 1) > 0) else addRowNames
 
   maxPrint <- paged_table_option("max.print", 1000)
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,9 @@
 rmarkdown 1.6 (unreleased)
 --------------------------------------------------------------------------------
 
+* Fixed an issue with `df_print: paged` where row names where not printed and
+  added support for `rownames.print` option to control when they print.
+
 * Fixed an issue where headers with non-ASCII text would not be linked
   to correctly in the table of contents.
 
@@ -13,8 +16,8 @@ rmarkdown 1.6 (unreleased)
 
 * Better support for `citation_package: biblatex` in `pdf_document()` (#1062).
 
-* On certain Windows platforms, compiling LaTeX to PDF may fail because 
-  `system2(stdout = FALSE)` is not supported, in which case the default `system2()` 
+* On certain Windows platforms, compiling LaTeX to PDF may fail because
+  `system2(stdout = FALSE)` is not supported, in which case the default `system2()`
   will be used (#1061).
 
 


### PR DESCRIPTION
To have parity with RStudio notebooks, fix row names and add support for `rownames.print`.