### PR TITLE
Save render intermediates when generating beamer presentations (fixes #1106)

### DIFF
--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -125,6 +125,25 @@ beamer_presentation <- function(toc = FALSE,
   # custom args
   args <- c(args, pandoc_args)
 
+  # initialize saved files dir
+  saved_files_dir <- NULL
+
+  pre_processor <- function(metadata, input_file, runtime, knit_meta,
+                                files_dir, output_dir) {
+    # save files dir (for generating intermediates)
+    saved_files_dir <<- files_dir
+
+    # no-op other than caching dir location
+    invisible(NULL)
+  }
+
+  # generate intermediates (required to make resources available for publish)
+  intermediates_generator <- function(original_input, encoding,
+                                      intermediates_dir) {
+    return(pdf_intermediates_generator(saved_files_dir, original_input,
+                                        encoding, intermediates_dir))
+  }
+
   # return format
   output_format(
     knitr = knitr_options_pdf(fig_width, fig_height, fig_crop, dev),
@@ -133,6 +152,8 @@ beamer_presentation <- function(toc = FALSE,
                             args = args,
                             latex_engine = latex_engine,
                             keep_tex = keep_tex),
+    pre_processor = pre_processor,
+    intermediates_generator = intermediates_generator,
     clean_supporting = !keep_tex,
     df_print = df_print
   )

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -206,20 +206,8 @@ pdf_document <- function(toc = FALSE,
 
   intermediates_generator <- function(original_input, encoding,
                                       intermediates_dir) {
-    # copy all intermediates (pandoc will need to bundle them in the PDF)
-    intermediates <- copy_render_intermediates(original_input, encoding,
-                                               intermediates_dir, FALSE)
-
-    # we need figures from the supporting files dir to be available during
-    # render as well; if we have a files directory, copy its contents
-    if (!is.null(saved_files_dir) && dir_exists(saved_files_dir)) {
-      file.copy(saved_files_dir, intermediates_dir, recursive = TRUE)
-      intermediates <- c(intermediates, list.files(
-        path = file.path(intermediates_dir, basename(saved_files_dir)),
-        all.files = TRUE, recursive = TRUE, full.names = TRUE))
-    }
-
-    intermediates
+    return(pdf_intermediates_generator(saved_files_dir, original_input,
+                                        encoding, intermediates_dir))
   }
 
   # return format
@@ -235,4 +223,22 @@ pdf_document <- function(toc = FALSE,
     pre_processor = pre_processor,
     intermediates_generator = intermediates_generator
   )
+}
+
+pdf_intermediates_generator <- function(saved_files_dir, original_input,
+                                        encoding, intermediates_dir) {
+  # copy all intermediates (pandoc will need to bundle them in the PDF)
+  intermediates <- copy_render_intermediates(original_input, encoding,
+                                             intermediates_dir, FALSE)
+
+  # we need figures from the supporting files dir to be available during
+  # render as well; if we have a files directory, copy its contents
+  if (!is.null(saved_files_dir) && dir_exists(saved_files_dir)) {
+    file.copy(saved_files_dir, intermediates_dir, recursive = TRUE)
+    intermediates <- c(intermediates, list.files(
+      path = file.path(intermediates_dir, basename(saved_files_dir)),
+      all.files = TRUE, recursive = TRUE, full.names = TRUE))
+  }
+
+  intermediates
 }


### PR DESCRIPTION
This change makes PDF render intermediates available when generating Beamer presentations. This is required when using an intermediates directory which is different than the render directory, which isn't the case when rendering locally (so this code won't generally run during a typical `render`), but is the case when rendering from a read-only folder (which is often the case when rendering on a sever). 

Note that in order for this to fix the issue described in #1106, the version of the rmarkdown package that contains this fix must be present on the server (not the publishing client), since that's where the render is happening. 
