### PR TITLE
Fixes issues with NULL/null/empty parameters

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -6,11 +6,7 @@ knit_params_get <- function(input_lines, params) {
   if (packageVersion('yaml') < '2.1.14') knit_params <- mark_utf8(knit_params)
   default_params <- list()
   for (param in knit_params) {
-    if (is.null(param$value)) {
-      default_params[param$name] <- list(NULL)
-    } else {
-      default_params[[param$name]] <- param$value
-    }
+    default_params[param$name] <- list(param$value)
   }
 
   # validate params passed to render

--- a/R/params.R
+++ b/R/params.R
@@ -6,7 +6,11 @@ knit_params_get <- function(input_lines, params) {
   if (packageVersion('yaml') < '2.1.14') knit_params <- mark_utf8(knit_params)
   default_params <- list()
   for (param in knit_params) {
-    default_params[[param$name]] <- param$value
+    if (is.null(param$value)) {
+      default_params[param$name] <- list(NULL)
+    } else {
+      default_params[[param$name]] <- param$value
+    }
   }
 
   # validate params passed to render
@@ -30,7 +34,7 @@ knit_params_get <- function(input_lines, params) {
     invalid_params <- setdiff(names(params), names(default_params))
     if (length(invalid_params) > 0) {
       stop("render params not declared in YAML: ",
-           paste(invalid_params, sep = ", "))
+           paste(invalid_params, collapse = ", "))
     }
   }
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -6,6 +6,8 @@ rmarkdown 1.7 (unreleased)
 
 * Add `smart` option for `word_document()` format.
 
+* Save render intermediates when generating beamer presentations (fixes #1106).
+
 * Fixed issues when specifying NULL/null/empty parameter values (#729 and #762).
 
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -6,6 +6,8 @@ rmarkdown 1.7 (unreleased)
 
 * Add `smart` option for `word_document()` format.
 
+* Fixed issues when specifying NULL/null/empty parameter values (#729 and #762).
+
 
 rmarkdown 1.6
 --------------------------------------------------------------------------------

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -4,18 +4,29 @@ test_that("setting of params works", {
 
   skip_on_cran()
 
-  params_sample <- '---\ntitle: "test"\noutput: html_document\nparams:\n  field1:\n    value: "defaulthere"\n---'
+  params_sample <- '---\ntitle: "test"\noutput: html_document\nparams:\n  field1:\n    value: "defaulthere"\n  field2: null\n  field3: \n  field4: NULL\n---'
 
   # No overrides
   params <- knit_params_get(params_sample, NULL)
   expect_equal(params$field1, "defaulthere")
+  expect_null(params$field2)
+  expect_null(params$field3)
+  expect_null(params$field4)
 
   # With overrides
   params <- knit_params_get(params_sample, list(field1="new value"))
   expect_equal(params$field1, "new value")
 
+  # With overrides for NULL/null/empty params
+  params <- knit_params_get(params_sample, list(field2=NULL,field4="value"))
+  expect_null(params$field2)
+  expect_equal(params$field4, "value")
+
   # Invalid
   expect_error(knit_params_get(params_sample, "new value"))
+
+  # Params not declared in YAML
+  expect_error(knit_params_get(params_sample, list(field5="a",field6="b",field7=NULL)), regexp = "field5, field6, field7$")
 })
 
 test_that("params render their UI", {


### PR DESCRIPTION
- Fixes how the list of “render params not declared in YAML” is
formatted
- Adds support for NULL/null/empty parameters
- Adds related tests

Additionally, I'm _pretty sure_ this fixes #762.