### PR TITLE
Better error messages when unable to prerender a document

### DIFF
--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -77,6 +77,9 @@ shiny_prerendered_html <- function(input_rmd, encoding, render_args) {
   prerender_option <- tolower(Sys.getenv("RMARKDOWN_RUN_PRERENDER", "1"))
 
   if (file.access(output_dir, 2) != 0) {
+    if (!file.exists(rendered_html))
+      stop("Unable to write prerendered HTML file to ", rendered_html)
+
     prerender <- FALSE
   }
   else if (identical(prerender_option, "0")) {
@@ -125,6 +128,10 @@ shiny_prerendered_html <- function(input_rmd, encoding, render_args) {
                              envir = new.env()),
                         render_args)
     rendered_html <- do.call(render, args)
+  }
+
+  if (!file.exists(rendered_html)) {
+    stop("Prerendered HTML file not found at ", rendered_html)
   }
 
   # normalize paths

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -10,6 +10,8 @@ rmarkdown 1.7 (unreleased)
 
 * Fixed issues when specifying NULL/null/empty parameter values (#729 and #762).
 
+* Better error message when unable to prerender a document. (#1125)
+
 
 rmarkdown 1.6
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #1125. I added errors in two separate places because the unwritable directory case will probably be a common one, and deserves its own error message.