### PR TITLE
Clean up output for test snapshots

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -304,9 +304,28 @@ rmarkdown_shiny_server <- function(dir, file, encoding, auto_reload, render_args
       }
       shinyHTML_with_deps(result_path, dependencies)
     })
-    output$`__reactivedoc__` <- shiny::renderUI({
+
+    doc_ui <- shiny::renderUI({
       doc()
     })
+
+    # For test snapshots. (The snapshotPreprocessOutput function was added
+    # in shiny 1.0.4.)
+    if (exists("snapshotPreprocessOutput", asNamespace("shiny"))) {
+      doc_ui <- shiny::snapshotPreprocessOutput(
+        doc_ui,
+        function(value) {
+          # Since the html data can be very large, just record a hash of it.
+          value$html <- sprintf("[html data sha1: %s]",
+            digest::digest(value$html, algo = "sha1", serialize = FALSE)
+          )
+
+          value
+        }
+      )
+    }
+
+    output$`__reactivedoc__` <- doc_ui
   }
 }
 


### PR DESCRIPTION
When taking snapshots with shinytest, shiny docs would also record all of the HTML generated by the dynamic UI. This changes it so that in the snapshots, it simply records a hash of the HTML. This also blanks out the value for `meta$rstudio_origin`, because it uses a port number that can change.

(For rstudio/shinytest#125)