### PR TITLE
More resilient icons dependencies detection

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -107,7 +107,7 @@ navbar_icon_dependencies <- function(navbar) {
   source <- readLines(navbar)
 
   # find icon references
-  res <- regexec('<(span|i) class=("|\')(fa fa|ion ion)-', source)
+  res <- regexec('<(span|i) +class *= *("|\') *(fa fa|ion ion)-', source)
   matches <- regmatches(source, res)
   libs <- c()
   for (match in matches) {

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -107,12 +107,12 @@ navbar_icon_dependencies <- function(navbar) {
   source <- readLines(navbar)
 
   # find icon references
-  res <- regexec('<span class="(fa fa|ion ion)-', source)
+  res <- regexec('<(span|i) class=("|\')(fa fa|ion ion)-', source)
   matches <- regmatches(source, res)
   libs <- c()
   for (match in matches) {
     if (length(match) > 0)
-      libs <- c(libs, match[[2]])
+      libs <- c(libs, match[[4]])
   }
   libs <- unique(libs)
 


### PR DESCRIPTION
I wanted to use fa-icons in a navbar, but rmarkdown would not inject their html dependencies. I looked into the code and found that only if a <span> tag is used for the icons, it works. But I have used the function `shiny::icon()` that returns an <i> tag.

I decided to change the code. One can now use both <span> and <i> and also it does not matter whether one uses double or single quote. Even more resilience is added by also ignoring some whitespace.