### PR TITLE
Fix #133: remove the id of the preserved HTML chunk when it is in a section id attribute

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -132,9 +132,12 @@ html_document_base <- function(smart = TRUE,
     if (length(preserved_chunks) > 0) {
       # Pandoc adds an empty <p></p> around the IDs of preserved chunks, and we
       # need to remove these empty tags, otherwise we may have invalid HTML like
-      # <p><div>...</div></p>
+      # <p><div>...</div></p>. For the reason of the second gsub(), see
+      # https://github.com/rstudio/rmarkdown/issues/133.
       for (i in names(preserved_chunks)) {
         output_str <- gsub(paste0("<p>", i, "</p>"), i, output_str,
+                           fixed = TRUE, useBytes = TRUE)
+        output_str <- gsub(paste0(' id="section-', i, '" '), ' ', output_str,
                            fixed = TRUE, useBytes = TRUE)
       }
       output_str <- restorePreserveChunks(output_str, preserved_chunks)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -14,6 +14,7 @@ rmarkdown 1.7 (unreleased)
 
 # Execute prerender with globalenv as parent, rather than parent frame (#1124)
 
+# `shiny::renderText()` does not work in Markdown section headings (#133).
 
 rmarkdown 1.6
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This should be a fairly safe fix. It should be very rare that an HTML fragment is written in the middle of a string ` id="section-*" `.