### PR TITLE
ignore theme, highlight and fig_retina in html_vignette()

### DIFF
--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -22,7 +22,7 @@
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}. Please
 #'   note that \code{theme}, \code{fig_retina} and \code{highlight} are hard
-#'   coded. They will be silently overwriten when set.
+#'   coded. Setting them will yield an error.
 #' @param readme Use this vignette as the package README.md file (i.e. render
 #'   it as README.md to the package root). Note that if there are image files
 #'   within your vignette you should be sure to add README_files to .Rbuildignore
@@ -52,21 +52,19 @@ html_vignette <- function(fig_width = 3,
                         quiet = TRUE)
     }
   }
-  dots <- list(...)
-  dots$theme <- NULL
-  dots$fig_width <- fig_width
-  dots$fig_height <- fig_height
-  dots$dev <- dev
-  dots$fig_retina <- NULL
-  dots$css <- css
-  dots$highlight <- "pygments"
-
   output_format(
     knitr = NULL,
     pandoc = NULL,
     df_print = df_print,
     pre_knit = pre_knit,
     keep_md = keep_md,
-    base_format = do.call(html_document, dots)
+    base_format = html_document(fig_width = fig_width,
+                                fig_height = fig_height,
+                                dev = dev,
+                                fig_retina = NULL,
+                                css = css,
+                                theme = NULL,
+                                highlight = "pygments",
+                                ...)
   )
 }

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -11,6 +11,7 @@
 #'   \item never uses a theme
 #'   \item has a smaller default figure size
 #'   \item uses a custom css stylesheet
+#'   \item uses a custom highlight scheme
 #'  }
 #'
 #' @details
@@ -20,8 +21,8 @@
 #'
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}. Please
-#'   note that \code{theme} is hard coded to \code{NULL} in order to have a
-#'   smaller html file.
+#'   note that \code{theme}, \code{fig_retina} and \code{highlight} are hard
+#'   coded. They will be silently overwriten when set.
 #' @param readme Use this vignette as the package README.md file (i.e. render
 #'   it as README.md to the package root). Note that if there are image files
 #'   within your vignette you should be sure to add README_files to .Rbuildignore
@@ -52,9 +53,6 @@ html_vignette <- function(fig_width = 3,
     }
   }
   dots <- list(...)
-  if ("theme" %in% names(dots)) {
-    warnings("theme is not available with html_vignette and will be ignored")
-  }
   dots$theme <- NULL
   dots$fig_width <- fig_width
   dots$fig_height <- fig_height

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -8,6 +8,7 @@
 #'
 #' \itemize{
 #'   \item never uses retina figures
+#'   \item never uses a theme
 #'   \item has a smaller default figure size
 #'   \item uses a custom css stylesheet
 #'  }
@@ -18,7 +19,9 @@
 #' documentation} for additional details on using the \code{html_vignette} format.
 #'
 #' @inheritParams html_document
-#' @param ... Additional arguments passed to \code{\link{html_document}}
+#' @param ... Additional arguments passed to \code{\link{html_document}}. Please
+#'   note that \code{theme} is hard coded to \code{NULL} in order to have a
+#'   smaller html file.
 #' @param readme Use this vignette as the package README.md file (i.e. render
 #'   it as README.md to the package root). Note that if there are image files
 #'   within your vignette you should be sure to add README_files to .Rbuildignore
@@ -48,6 +51,17 @@ html_vignette <- function(fig_width = 3,
                         quiet = TRUE)
     }
   }
+  dots <- list(...)
+  if ("theme" %in% names(dots)) {
+    warnings("theme is not available with html_vignette and will be ignored")
+  }
+  dots$theme <- NULL
+  dots$fig_width <- fig_width
+  dots$fig_height <- fig_height
+  dots$dev <- dev
+  dots$fig_retina <- NULL
+  dots$css <- css
+  dots$highlight <- "pygments"
 
   output_format(
     knitr = NULL,
@@ -55,13 +69,6 @@ html_vignette <- function(fig_width = 3,
     df_print = df_print,
     pre_knit = pre_knit,
     keep_md = keep_md,
-    base_format = html_document(fig_width = fig_width,
-                                fig_height = fig_height,
-                                dev = dev,
-                                fig_retina = NULL,
-                                css = css,
-                                theme = NULL,
-                                highlight = "pygments",
-                                ...)
+    base_format = do.call(html_document, dots)
   )
 }

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -52,6 +52,7 @@ html_vignette <- function(fig_width = 3,
                         quiet = TRUE)
     }
   }
+
   output_format(
     knitr = NULL,
     pandoc = NULL,

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -22,7 +22,7 @@
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}. Please
 #'   note that \code{theme}, \code{fig_retina} and \code{highlight} are hard
-#'   coded. Setting them will yield an error.
+#'   coded. Setting any of those will yield an error.
 #' @param readme Use this vignette as the package README.md file (i.e. render
 #'   it as README.md to the package root). Note that if there are image files
 #'   within your vignette you should be sure to add README_files to .Rbuildignore

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -34,7 +34,9 @@ by setting the option \code{rmarkdown.df_print} to \code{FALSE}.}
 it as README.md to the package root). Note that if there are image files
 within your vignette you should be sure to add README_files to .Rbuildignore}
 
-\item{...}{Additional arguments passed to \code{\link{html_document}}}
+\item{...}{Additional arguments passed to \code{\link{html_document}}. Please
+note that \code{theme} is hard coded to \code{NULL} in order to have a
+smaller html file.}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}
@@ -49,6 +51,7 @@ Compared to \code{html_document}, it:
 
 \itemize{
   \item never uses retina figures
+  \item never uses a theme
   \item has a smaller default figure size
   \item uses a custom css stylesheet
  }

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -36,7 +36,7 @@ within your vignette you should be sure to add README_files to .Rbuildignore}
 
 \item{...}{Additional arguments passed to \code{\link{html_document}}. Please
 note that \code{theme}, \code{fig_retina} and \code{highlight} are hard
-coded. Setting them will yield an error.}
+coded. Setting any of those will yield an error.}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -36,7 +36,7 @@ within your vignette you should be sure to add README_files to .Rbuildignore}
 
 \item{...}{Additional arguments passed to \code{\link{html_document}}. Please
 note that \code{theme}, \code{fig_retina} and \code{highlight} are hard
-coded. They will be silently overwriten when set.}
+coded. Setting them will yield an error.}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -35,8 +35,8 @@ it as README.md to the package root). Note that if there are image files
 within your vignette you should be sure to add README_files to .Rbuildignore}
 
 \item{...}{Additional arguments passed to \code{\link{html_document}}. Please
-note that \code{theme} is hard coded to \code{NULL} in order to have a
-smaller html file.}
+note that \code{theme}, \code{fig_retina} and \code{highlight} are hard
+coded. They will be silently overwriten when set.}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}
@@ -54,6 +54,7 @@ Compared to \code{html_document}, it:
   \item never uses a theme
   \item has a smaller default figure size
   \item uses a custom css stylesheet
+  \item uses a custom highlight scheme
  }
 
 

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -25,6 +25,7 @@ test_that("formats successfully produce a document", {
   testFormat(pdf_document(), df_print = "kable")
   testFormat(beamer_presentation(), df_print = "kable")
   testFormat(word_document(), df_print = "kable")
+  testFormat(html_vignette())
 
   if (requireNamespace("tufte", quietly = TRUE))
     testFormat(tufte_handout())

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -26,6 +26,7 @@ test_that("formats successfully produce a document", {
   testFormat(beamer_presentation(), df_print = "kable")
   testFormat(word_document(), df_print = "kable")
   testFormat(html_vignette())
+  testFormat(html_vignette(theme = "z", fig_retina = TRUE, highlight = "x"))
 
   if (requireNamespace("tufte", quietly = TRUE))
     testFormat(tufte_handout())

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -26,7 +26,6 @@ test_that("formats successfully produce a document", {
   testFormat(beamer_presentation(), df_print = "kable")
   testFormat(word_document(), df_print = "kable")
   testFormat(html_vignette())
-  testFormat(html_vignette(theme = "z", fig_retina = TRUE, highlight = "x"))
 
   if (requireNamespace("tufte", quietly = TRUE))
     testFormat(tufte_handout())
@@ -54,5 +53,27 @@ test_that("documents with spaces in names can be rendered", {
                               quiet = TRUE)
 
   expect_true(file.exists(output))
+
+})
+
+test_that(
+  "setting theme, highlight or fig_retina yields an error on html_vignette",
+  {
+
+  skip_on_cran()
+
+  testFormat <- function(output_format) {
+    output_file <- tempfile()
+    expect_error(
+      render("test-formats.Rmd",
+           output_format = output_format,
+           output_file = output_file,
+           quiet = TRUE)
+    )
+  }
+
+  testFormat(html_vignette(theme = "z"))
+  testFormat(html_vignette(highlight = "z"))
+  testFormat(html_vignette(fig_retina = 2))
 
 })


### PR DESCRIPTION
The arguments are silently overwritten. This behaviour is documented in the help file. 

I've tried to set a warning but that wasn't displayed. Hence I removed the warning again.

solved issue #1110 