### PR TITLE
Fix #1100: respect knitr's chunk option 'dev' if it has been set

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -354,7 +354,7 @@ render <- function(input,
     # merge user options and hooks
     if (!is.null(output_format$knitr)) {
       knitr::opts_knit$set(as.list(output_format$knitr$opts_knit))
-      knitr::opts_chunk$set(as.list(output_format$knitr$opts_chunk))
+      knitr::opts_chunk$set(adjust_dev(as.list(output_format$knitr$opts_chunk)))
       knitr::opts_template$set(as.list(output_format$knitr$opts_template))
       knitr::knit_hooks$set(as.list(output_format$knitr$knit_hooks))
       knitr::opts_hooks$set(as.list(output_format$knitr$opts_hooks))

--- a/R/util.R
+++ b/R/util.R
@@ -597,3 +597,19 @@ shell_exec <- function(cmd, intern = FALSE, wait = TRUE, ...) {
     system(cmd, intern = intern, wait = wait, ...)
 }
 
+# Adjust the graphical device in chunk options: if the device from the output
+# format is png but knitr's global chunk option is not png, respect knitr's
+# option, because (1) users may knitr::opts_chunk$set(dev) (which usually means
+# they know what they are doing) before rmarkdown::render(), and we probably
+# should not override the user's choice; (2) the png device does not work on
+# certain platforms (e.g. headless servers without X11), in which case knitr
+# will set the device to svg instead of png by default in knitr:::set_html_dev,
+# and rmarkdown should also respect this setting, otherwise we will run into
+# issues like https://github.com/rstudio/rmarkdown/issues/1100
+adjust_dev <- function(opts) {
+  dev <- knitr::opts_chunk$get('dev')
+  if (identical(opts$dev, 'png') && length(dev) == 1 && dev != 'png') {
+    opts$dev <- dev
+  }
+  opts
+}


### PR DESCRIPTION
By default, `dev = NULL` in knitr's `opts_chunk`; for markdown output, knitr will check if the `png` device is usable in `knitr:::set_html_dev` and set `dev = 'png'` if it is, otherwise knitr uses `'svg'` as the default device, which does not depend on X11.

This should be a low-risk change since it should be rare that `png` is not usable.

Probably not worth a NEWS entry.