### PR TITLE
Fix #993: restore knit_meta instead of forcibly wiping it out on exit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.6.0.9004
+Version: 1.6.0.9005
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),

--- a/R/render.R
+++ b/R/render.R
@@ -257,8 +257,13 @@ render <- function(input,
   }
 
   # reset knit_meta (and ensure it's always reset before exiting render)
-  knit_meta_reset()
-  on.exit(knit_meta_reset(), add = TRUE)
+  old_knit_meta <- knit_meta_reset()
+  on.exit({
+    knit_meta_reset()
+    if (length(old_knit_meta)) {
+      knitr::knit_meta_add(old_knit_meta, attr(old_knit_meta, 'knit_meta_id'))
+    }
+  }, add = TRUE)
 
   # presume that we're rendering as a static document unless specified
   # otherwise in the parameters

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -12,13 +12,16 @@ rmarkdown 1.7 (unreleased)
 
 * Better error message when unable to prerender a document. (#1125)
 
-# Execute prerender with globalenv as parent, rather than parent frame (#1124)
+* Execute prerender with globalenv as parent, rather than parent frame (#1124)
 
-# `shiny::renderText()` does not work in Markdown section headings (#133).
+* `shiny::renderText()` does not work in Markdown section headings (#133).
 
-# The `value` argument of `pandoc_variable_arg()` can be missing now (#287).
+* The `value` argument of `pandoc_variable_arg()` can be missing now (#287).
 
-# Background colors and images are supported for ioslides presentations (#687).
+* Background colors and images are supported for ioslides presentations (#687).
+
+* HTML widgets in an Rmd document cannot be rendered if another Rmd document is
+  rendered via `rmarkdown::render()` in this document (#993).
 
 rmarkdown 1.6
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Because it is possible that knitr metadata existed before `rmarkdown::render()`. See #993.