### PR TITLE
Fix #1162: use parent.frame() of run() instead of new.env() inside rmarkdown_shiny_server() to evaluate code chunks

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -138,6 +138,8 @@ run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
     else
       render_args$encoding
 
+  if (is.null(render_args$envir)) render_args$envir <- parent.frame()
+
   # determine the runtime of the target file
   target_file <- ifelse(!is.null(file), file, default_file)
   if (!is.null(target_file))
@@ -273,8 +275,7 @@ rmarkdown_shiny_server <- function(dir, file, encoding, auto_reload, render_args
                                output_dir = dirname(output_dest),
                                output_options = output_opts,
                                intermediates_dir = dirname(output_dest),
-                               runtime = "shiny",
-                               envir = new.env()),
+                               runtime = "shiny"),
                           render_args)
       result_path <- shiny::maskReactiveContext(do.call(render, args))
 

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -123,10 +123,7 @@ shiny_prerendered_html <- function(input_rmd, encoding, render_args) {
   if (prerender) {
 
     # execute the render
-    args <- merge_lists(list(input = input_rmd,
-                             encoding = encoding,
-                             envir = new.env(parent = globalenv())),
-                        render_args)
+    args <- merge_lists(list(input = input_rmd, encoding = encoding), render_args)
     rendered_html <- do.call(render, args)
   }
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -25,6 +25,8 @@ rmarkdown 1.7 (unreleased)
 
 * Try harder to clean up temporary files created during `render()` (#820).
 
+* Wrong environment for evaluating R code chunks in Shiny R Markdown docs (#1162).
+
 rmarkdown 1.6
 --------------------------------------------------------------------------------
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -12,8 +12,6 @@ rmarkdown 1.7 (unreleased)
 
 * Better error message when unable to prerender a document. (#1125)
 
-* Execute prerender with globalenv as parent, rather than parent frame (#1124)
-
 * `shiny::renderText()` does not work in Markdown section headings (#133).
 
 * The `value` argument of `pandoc_variable_arg()` can be missing now (#287).
@@ -25,7 +23,8 @@ rmarkdown 1.7 (unreleased)
 
 * Try harder to clean up temporary files created during `render()` (#820).
 
-* Wrong environment for evaluating R code chunks in Shiny R Markdown docs (#1162).
+* Wrong environment for evaluating R code chunks in Shiny R Markdown docs
+  (#1162, #1124).
 
 rmarkdown 1.6
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #1162. BTW, I believe this should also be the correct fix to #619 (I have tested it), instead of the PR #624, which introduced `new.env()`.