### PR TITLE
Use the +smart extension instead of the --smart argument for Pandoc 2.0

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -226,6 +226,8 @@ html_document <- function(toc = FALSE,
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
+  md_extensions <- smart_extension(smart, md_extensions)
+
   # toc_float
   if (toc && !identical(toc_float, FALSE)) {
 

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -33,8 +33,9 @@ html_document_base <- function(smart = TRUE,
 
   args <- c()
 
+  pandoc2.0 <- pandoc_version() >= "2.0"
   # smart quotes, etc.
-  if (smart)
+  if (smart && !pandoc2.0)
     args <- c(args, "--smart")
 
   # no email obfuscation

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -342,6 +342,11 @@ rmarkdown_format <- function(extensions = NULL) {
   paste(format, collapse = "")
 }
 
+# Add the +smart extension for Pandoc >= 2.0
+smart_extension <- function(smart, extension) {
+  c(extension, if (smart && pandoc_available("2.0")) "+smart")
+}
+
 #' Determine the default output format for an R Markdown document
 #'
 #' Read the YAML metadata (and any common _output.yml file) for the

--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -93,6 +93,8 @@ slidy_presentation <- function(incremental = FALSE,
     args <- c(args, pandoc_variable_arg("font-size-adjustment",
                                         font_adjustment))
 
+  md_extensions <- smart_extension(smart, md_extensions)
+
   # content includes
   args <- c(args, includes_to_pandoc_args(includes))
 

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -64,8 +64,11 @@ word_document <- function(toc = FALSE,
   args <- c()
 
   # smart quotes, etc.
-  if (smart)
+  if (smart && !pandoc_available("2.0")) {
     args <- c(args, "--smart")
+  } else {
+    md_extensions <- smart_extension(smart, md_extensions)
+  }
 
   # table of contents
   if (pandoc_available("1.14"))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -35,6 +35,8 @@ rmarkdown 1.7 (unreleased)
 
 * `beamer_presentation()` doesn't work when `citation_package != 'none'` (#1161).
 
+* rmarkdown is compatible with Pandoc 2.0 (not released yet) now (#1120).
+
 rmarkdown 1.6
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1120.