### PR TITLE
Preserve the .md output file from knitr::knit() when keep_md = TRUE

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -694,11 +694,7 @@ render <- function(input,
 
   # write markdown output if requested
   if (output_format$keep_md && !md_input) {
-
-    md <- c(md_header_from_front_matter(yaml_front_matter),
-            partition_yaml_front_matter(input_text)$body)
-
-    writeLines(md, file_with_ext(output_file, "md"), useBytes = TRUE)
+    file.copy(input, file_with_ext(output_file, "md"), overwrite = TRUE)
   }
 
   if (run_pandoc) {
@@ -758,24 +754,6 @@ render_supporting_files <- function(from, files_dir, rename_to = NULL) {
 # call to knit_meta_reset), optionally scoped to a specific output class
 knit_meta_reset <- function(class = NULL) {
   knitr::knit_meta(class, clean = TRUE)
-}
-
-md_header_from_front_matter <- function(front_matter) {
-
-  md <- c()
-
-  if (!is.null(front_matter$title))
-    md <- c(md, paste("# ", front_matter$title, sep = ""))
-
-  if (is.character(front_matter$author)) {
-    authors <- paste(front_matter$author, "  ", sep = "")
-    md <- c(md, authors)
-  }
-
-  if (!is.null(front_matter$date))
-    md <- c(md, paste(front_matter$date, "  ", sep = ""))
-
-  md
 }
 
 # render context (render-related state can be stuffed here)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -37,6 +37,11 @@ rmarkdown 1.7 (unreleased)
 
 * rmarkdown is compatible with Pandoc 2.0 (not released yet) now (#1120).
 
+* The argument `keep_md = TRUE` actually preserves the Markdown output file from
+  `knitr::knit()` now (as documented). Previously, it generates a new Markdown
+  file by concatenating the YAML metadata (title, author, date) with the body of
+  the original Markdown output file (#450).
+
 rmarkdown 1.6
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #450.

The documentation of `keep_md` says "Keep the markdown file generated by knitting", but that is not exactly what it actually does. BTW, picking only the three fields `title`, `author`, and `date` seems to be an arbitrary choice, and I don't quite understand the rationale. `md_header_from_front_matter` is not used elsewhere, hence removed in this PR.