### PR TITLE
Do not use --standalone when variant = 'markdown' and perserve_yaml = TRUE in md_document()

### DIFF
--- a/R/md_document.R
+++ b/R/md_document.R
@@ -61,7 +61,7 @@ md_document <- function(variant = "markdown_strict",
                         pandoc_args = NULL) {
 
   # base pandoc options for all markdown output
-  args <- c("--standalone")
+  args <- c(if (variant != "markdown" && !preserve_yaml) "--standalone")
 
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -37,6 +37,9 @@ rmarkdown 1.7 (unreleased)
 
 * rmarkdown is compatible with Pandoc 2.0 (not released yet) now (#1120).
 
+* For `md_document()`, when `variant == 'markdown'` and `perserve_yaml = TRUE`,
+  the Pandoc argument `--standalone` should not be used (#656).
+
 rmarkdown 1.6
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #656.