### PR TITLE
Do not use output_options in default_site()

### DIFF
--- a/R/render_site.R
+++ b/R/render_site.R
@@ -173,8 +173,9 @@ default_site <- function(input, encoding = getOption("encoding"), ...) {
                      quiet,
                      encoding, ...) {
 
-    site_yml <- patch_html_document_options(config, encoding)
-    on.exit(file.rename(site_yml, '_site.yml'), add = TRUE)
+    site_yml  <- file.path(input, '_site.yml')
+    site_yml2 <- patch_html_document_options(config, encoding, site_yml)
+    on.exit(file.rename(site_yml2, site_yml), add = TRUE)
 
     # track outputs
     outputs <- c()
@@ -420,7 +421,7 @@ site_config_file <- function(input) {
 }
 
 # make sure the html_document format has options `lib_dir` and `self_contained`
-patch_html_document_options <- function(config, encoding) {
+patch_html_document_options <- function(config, encoding, site_yml) {
   opts <- config$output[['html_document']]
   if (identical(opts, 'default')) opts <- list()
   opts <- merge_lists(as.list(opts), list(
@@ -428,8 +429,8 @@ patch_html_document_options <- function(config, encoding) {
   ))
   config$output[['html_document']] <- opts
   tmp <- tempfile()
-  file.rename('_site.yml', tmp)
-  con <- file('_site.yml', open = 'w', encoding = encoding)
+  file.rename(site_yml, tmp)
+  con <- file(site_yml, open = 'w', encoding = encoding)
   on.exit(close(con), add = TRUE)
   writeLines(yaml::as.yaml(config), con)
   tmp

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -173,6 +173,9 @@ default_site <- function(input, encoding = getOption("encoding"), ...) {
                      quiet,
                      encoding, ...) {
 
+    site_yml <- patch_html_document_options(config, encoding)
+    on.exit(file.rename(site_yml, '_site.yml'), add = TRUE)
+
     # track outputs
     outputs <- c()
 
@@ -192,8 +195,6 @@ default_site <- function(input, encoding = getOption("encoding"), ...) {
       output <- suppressMessages(
         rmarkdown::render(x,
                           output_format = output_format,
-                          output_options = list(lib_dir = "site_libs",
-                                                self_contained = FALSE),
                           envir = envir,
                           quiet = quiet,
                           encoding = encoding)
@@ -418,4 +419,18 @@ site_config_file <- function(input) {
   file.path(input, "_site.yml")
 }
 
-
+# make sure the html_document format has options `lib_dir` and `self_contained`
+patch_html_document_options <- function(config, encoding) {
+  opts <- config$output[['html_document']]
+  if (identical(opts, 'default')) opts <- list()
+  opts <- merge_lists(as.list(opts), list(
+    lib_dir = "site_libs", self_contained = FALSE
+  ))
+  config$output[['html_document']] <- opts
+  tmp <- tempfile()
+  file.rename('_site.yml', tmp)
+  con <- file('_site.yml', open = 'w', encoding = encoding)
+  on.exit(close(con), add = TRUE)
+  writeLines(yaml::as.yaml(config), con)
+  tmp
+}

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -41,6 +41,8 @@ rmarkdown 1.7 (unreleased)
 
 * Added two new output formats `latex_document()` and `latex_fragment()` (#626).
 
+* `render_site()` does not support multiple output formats for a single Rmd (#793).
+
 rmarkdown 1.6
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #793.

Because these options (`lib_dir` and `self_contained`) are not supported by all output formats, e.g. `pdf_document`. Instead, temporarily patch the `html_document` format options in `_site.yml` during `render()`.