### PR TITLE
Use the intpu format gfm instead of markdown_github for Pandoc 2.0

### DIFF
--- a/R/github_document.R
+++ b/R/github_document.R
@@ -33,7 +33,7 @@ github_document <- function(toc = FALSE,
                     "rmarkdown/templates/github_document/resources/default.md")))
 
   # use md_document as base
-  variant <- "markdown_github"
+  variant <- if (pandoc_available("2.0")) "gfm" else "markdown_github"
   if (!hard_line_breaks)
     variant <- paste0(variant, "-hard_line_breaks")
 


### PR DESCRIPTION
See https://github.com/jgm/pandoc/releases/tag/2.0