### PR TITLE
Get rid of caTools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,6 @@ Imports:
     knitr (>= 1.14),
     yaml (>= 2.1.5),
     htmltools (>= 0.3.5),
-    caTools,
     evaluate (>= 0.8),
     base64enc,
     jsonlite,

--- a/R/base64.R
+++ b/R/base64.R
@@ -136,10 +136,8 @@ base64_encode_images <- function(html, encoder) {
   process_html_res(html, "<[^>]*style=\"[^\"]*url\\(([^\\)]+)\\)", base64_encode_img)
 }
 
-# get a base64 image encoder based on caTools
-# TODO: consider using 'base64enc::base64encode'
-base64_image_encoder <- function() {
-  function(data) base64_encode_images(data, caTools::base64encode)
+base64_image_encode <- function(data) {
+  base64_encode_images(data, base64enc::base64encode)
 }
 
 

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -202,8 +202,7 @@ ioslides_presentation <- function(logo = NULL,
 
     # base64 encode if needed
     if (self_contained) {
-      base64_encoder <- base64_image_encoder()
-      slides_lines <- base64_encoder(slides_lines)
+      slides_lines <- base64_image_encode(slides_lines)
     }
 
     # read the output file


### PR DESCRIPTION
Since we have already introduced the dependency **base64enc**, there is no need to use caTools anymore.