### PR TITLE
Very small typo in rmarkdown-package

### DIFF
--- a/man/rmarkdown-package.Rd
+++ b/man/rmarkdown-package.Rd
@@ -25,7 +25,7 @@ You can also specify a plain markdown file in which case knitting will be bypass
 Additional options can be specified along with the output format:
 
 \preformatted{render("input.Rmd", html_document(toc = TRUE))
-render("input.Rmd", pdf_document(latex.engine = "lualatex"))
+render("input.Rmd", pdf_document(latex_engine = "lualatex"))
 render("input.Rmd", beamer_presentation(incremental = TRUE))
 }
 


### PR DESCRIPTION
Just fixed up this typo that I found when I tried to use the example code and got a error.