### PR TITLE
Add github links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -81,6 +81,7 @@ Suggests:
     digest,
     tibble
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
-URL: http://rmarkdown.rstudio.com
+URL: http://rmarkdown.rstudio.com, https://github.com/rstudio/rmarkdown
+BugReports: https://github.com/rstudio/rmarkdown/issues
 License: GPL-3
 RoxygenNote: 6.0.1


### PR DESCRIPTION
If these are intentionally omitted, then just close.

But I was testing some GitHub URL detection and parsing code and happened to choose this package as an example. Thus I noticed they aren't here!