### PR TITLE
Add `library()` to html_vignette template

### DIFF
--- a/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd
@@ -14,6 +14,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+#library(YOUR_PACKAGE_HERE)
 ```
 
 Vignettes are long form documentation commonly included in packages. Because they are part of the distribution of the package, they need to be as compact as possible. The `html_vignette` output type provides a custom style sheet (and tweaks some options) to ensure that the resulting html is as small as possible. The `html_vignette` format:


### PR DESCRIPTION
It seems (I haven't yet found documentation) that best practices suggest adding `library(MY_PACKAGE_NAME)` to the top of package vignettes (`devtools::check` fails without it).  In concert with discussion at https://github.com/r-lib/usethis/issues/190 , I suggest something like the following:

````
```{r setup, include = FALSE}
knitr::opts_chunk$set(
  collapse = TRUE,
  comment = "#>"
)
#library(YOUR_PACKAGE_HERE)
```
````

I added as a comment to maintain a valid Rmd.  I could not decide if this warranted an issue of its own.  