### PR TITLE
Update params.R to support passwordInput

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -194,6 +194,7 @@ params_get_control <- function(param) {
       date     = shiny::dateInput,
       datetime = shiny::textInput, # placeholder for future datetime picker
       text     = shiny::textInput,
+      password = shiny::passwordInput,
       file     = shiny::fileInput,
       radio    = shiny::radioButtons,
       select   = shiny::selectInput


### PR DESCRIPTION
It's useful to be able to enter a password as a knitr parameter. This allows passing login credentials, e.g. to a database, that may be required to generate a reproducible report.