### PR TITLE
support for multi-value slider parameters

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -208,13 +208,21 @@ params_get_control <- function(param) {
 
 # Returns true if the parameter can be configurable with Shiny UI elements.
 params_configurable <- function(param) {
-  if (is.null(params_get_control(param))) {
+  inputControlFn <- params_get_control(param)
+  if (is.null(inputControlFn)) {
     return(FALSE)                       # no Shiny control
   }
+  # Some inputs (like selectInput) support the selection of
+  # multiple entries through a "multiple" argument.
   multiple_ok <- (!is.null(param$multiple) && param$multiple)
   if (multiple_ok) {
     return(TRUE)
   }
+  # sliderInput supports either one or two-value inputs.
+  if (identical(inputControlFn, shiny::sliderInput)) {
+    return(length(param$value) <= 2)
+  }
+  # Other inputs only support singular values.
   return(length(param$value) <= 1)     # multiple values only when multi-input controls
 }
 

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -58,6 +58,57 @@ test_that("params render their UI", {
   expect_equal(ui, myobj)
 })
 
+test_that("parameters are configurable", {
+  # Unknown input types are not configurable.
+  expect_error(params_configurable(list(
+      input = "unsupported")))
+
+  # Numeric (and most other controls) do not support multiple values.
+  expect_true(params_configurable(list(
+      input = "numeric",
+      value = 42)))
+  expect_false(params_configurable(list(
+      input = "numeric",
+      value = c(13, 42))))
+
+  # Selectors permit multiple values if explicitly enabled.
+  expect_true(params_configurable(list(
+      input = "select",
+      choices = c(1, 2, 3, 4),
+      value = 2)))
+  expect_true(params_configurable(list(
+      input = "select",
+      multiple = TRUE,
+      choices = c(1, 2, 3, 4),
+      value = c(2, 4))))
+  expect_false(params_configurable(list(
+      input = "select",
+      multiple = FALSE,
+      choices = c(1, 2, 3, 4),
+      value = c(2, 4))))
+  expect_false(params_configurable(list(
+      input = "select",
+      choices = c(1, 2, 3, 4),
+      value = c(2, 4))))
+
+  # Sliders permit either one or two values (singular or double-ended slider).
+  expect_true(params_configurable(list(
+      input = "slider",
+      min = 1,
+      max = 100,
+      value = 50)))
+  expect_true(params_configurable(list(
+      input = "slider",
+      min = 1,
+      max = 100,
+      value = c(45, 55))))
+  expect_false(params_configurable(list(
+      input = "slider",
+      min = 1,
+      max = 100,
+      value = c(10, 20, 30))))
+})
+
 test_that("params hidden w/o show_default", {
 
   skip_on_cran()


### PR DESCRIPTION
The "slider" parameter input type was restricted to a value containing only a
single value. The underlying Shiny `sliderInput` supports a two-value input and
builds a double-ended slider.

Adjust the "configurable" check to permit "slider" inputs with two values. The
remaining parameter management code is already good with multiple values; we
just were not permitting this scenario.

Here is a sample document that uses both single-value and multi-value sliders:

````
---
title: sliders using parameters
params:
  range:
    input: slider
    min: 1
    max: 100
    step: 1
    round: 1
    sep: ''
    value:
      - 45
      - 55
  singular:
    input: slider
    min: 1
    max: 100
    step: 1
    round: 1
    sep: ''
    value: 42
---

The singular slider parameter has value `r params$singular`.

The range slider parameter has value `r params$range`.
````