### PR TITLE
Fix missing newline bug in clean_site()

### DIFF
--- a/R/render_site.R
+++ b/R/render_site.R
@@ -72,7 +72,7 @@ clean_site <- function(input = ".", preview = FALSE, quiet = FALSE,
   else {
     if (!quiet) {
       cat("Removing files: \n")
-      cat(paste0(paste(paste0(" ", files), collapse = "\n"), "\n"))
+      cat(paste0(" ", files), sep = "\n"))
     }
     unlink(file.path(input, files), recursive = TRUE)
   }

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -72,7 +72,7 @@ clean_site <- function(input = ".", preview = FALSE, quiet = FALSE,
   else {
     if (!quiet) {
       cat("Removing files: \n")
-      cat(paste(paste0(" ", files), collapse = "\n"))
+      cat(paste0(paste(paste0(" ", files), collapse = "\n"), "\n"))
     }
     unlink(file.path(input, files), recursive = TRUE)
   }


### PR DESCRIPTION
Hello,

Thank you for the `render_site()` functionality in `rmarkdown`! I've been playing with it for the last week and I'm really digging it.

I've noticed that whenever I run `rmarkdown::clean_site()`, the printout that shows which files were deleted is missing a newline. I used `clean_site()` as part of a larger automated thing, so this make the logs slightly harder to read. I see something like this at the edge of the `clean_site` output:

```
Removing files:
 _site/[INFO] some other message
```

Where `[INFO] some other message` is the start of the next process's logs.

Please consider this PR to address this.

Thanks!

-James