### PR TITLE
BUGFIX: Bump knitr version floor to 1.18

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,7 @@ Depends:
 Imports:
     tools,
     utils,
-    knitr (>= 1.14),
+    knitr (>= 1.18),
     yaml (>= 2.1.5),
     htmltools (>= 0.3.5),
     evaluate (>= 0.8),


### PR DESCRIPTION
Good morning from Chicago, @yihui ! I ran into an issue today with the newest release of `rmarkdown`. I think that the version floor for `knitr` needs to be raised.

**The Story**

My builds were breaking with this error:

```
'is_latex_output' is not an exported object from 'namespace:knitr'
```

So I did some digging and found a few things. It looks like `rmarkdown` release [went out yesterday](https://github.com/rstudio/rmarkdown/releases/tag/v1.9), and I started having problems shortly after.

I see [this commit](https://github.com/rstudio/rmarkdown/commit/06afdc1d86d8d0ba417be763b5b4dfece7460b5b) in v1.9. That commit changes to the exported `knitr::is_latex_output` call.

However, here's the issue. `rmarkdown` requires `knitr >= 1.14` but [the change to export that](https://github.com/yihui/knitr/commit/2a3244225e914da06084834e242265af81fa9734) happened on release 1.20. 

**Proposed Fix**

I'd like to propose bumping the version floor for `knitr` to 1.20. I think that because of the issue above, `rmarkdown 1.9` is actually not compatible with pre-1.20 `knitr`. Please consider this PR to increase the `knitr` version requirement for `rmarkdown`.

I am working on trying to reproduce this locally and will share results on here when I do.