### PR TITLE
Merge roxygen @details sections into top 3+ paragraphs

### DIFF
--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -2,10 +2,23 @@
 #'
 #' Format for converting from R Markdown to a Beamer presentation.
 #'
+#' See the \href{https://rmarkdown.rstudio.com/beamer_presentation_format.html}{online
+#' documentation} for additional details on using the \code{beamer_presentation}
+#' format.
+#'
+#' Creating Beamer output from R Markdown requires that LaTeX be installed.
+#'
+#' R Markdown documents can have optional metadata that is used to generate a
+#' document header that includes the title, author, and date. For more details
+#' see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
+#'
+#' R Markdown documents also support citations. You can find more information on
+#' the markdown syntax for citations in the
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' and Citations} article in the online documentation.
 #' @inheritParams output_format
 #' @inheritParams pdf_document
 #' @inheritParams html_document
-#'
 #' @param toc \code{TRUE} to include a table of contents in the output (only
 #'   level 1 headers will be included in the table of contents).
 #' @param slide_level The heading level which defines individual slides. By
@@ -23,27 +36,7 @@
 #' @param self_contained Whether to generate a full LaTeX document (\code{TRUE})
 #'   or just the body of a LaTeX document (\code{FALSE}). Note the LaTeX
 #'   document is an intermediate file unless \code{keep_tex = TRUE}.
-#'
 #' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
-#' See the
-#' \href{http://rmarkdown.rstudio.com/beamer_presentation_format.html}{online
-#' documentation} for additional details on using the \code{beamer_presentation}
-#' format.
-#'
-#' Creating Beamer output from R Markdown requires that LaTeX be installed.
-#'
-#' R Markdown documents can have optional metadata that is used to generate a
-#' document header that includes the title, author, and date. For more details
-#' see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
-#'
-#' R Markdown documents also support citations. You can find more information on
-#' the markdown syntax for citations in the
-#' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
-#' and Citations} article in the online documentation.
-#'
 #' @examples
 #' \dontrun{
 #'
@@ -55,7 +48,6 @@
 #' # specify an option for incremental rendering
 #' render("pres.Rmd", beamer_presentation(incremental = TRUE))
 #' }
-#'
 #' @export
 beamer_presentation <- function(toc = FALSE,
                                 slide_level = NULL,

--- a/R/draft.R
+++ b/R/draft.R
@@ -1,9 +1,12 @@
-
 #' Create a new document based on a template
 #'
 #' Create (and optionally edit) a draft of an R Markdown document based on a
 #' template.
 #'
+#' The \code{draft} function creates new R Markdown documents based on
+#' templates that are either located on the filesystem or within an R package.
+#' The template and it's supporting files will be copied to the location
+#' specified by \code{file}.
 #' @param file File name for the draft
 #' @param template Template to use as the basis for the draft. This is either
 #'   the full path to a template directory or the name of a template directory
@@ -13,14 +16,7 @@
 #'   (the "default" setting leaves this behavior up to the creator of the
 #'   template).
 #' @param edit \code{TRUE} to edit the template immediately
-#'
-#' @return The file name of the new document (invisibly)
-#'
-#' @details The \code{draft} function creates new R Markdown documents based on
-#'   templates that are either located on the filesystem or within an R package.
-#'   The template and it's supporting files will be copied to the location
-#'   specified by \code{file}.
-#'
+#' @return The file name of the new document (invisibly).
 #' @note An R Markdown template consists of a directory that contains a
 #'   description of the template, a skeleton Rmd file used as the basis for new
 #'   documents, and optionally additional supporting files that are provided
@@ -50,11 +46,8 @@
 #'
 #'   These files will automatically be copied to the directory containing the
 #'   new R Markdown draft.
-#'
-#'
 #' @examples
 #' \dontrun{
-#'
 #' rmarkdown::draft("Q4Report.Rmd",
 #'                  template="/opt/rmd/templates/quarterly_report")
 #'
@@ -85,6 +78,7 @@ draft <- function(file,
   if (!file.exists(template_yaml)) {
     stop("No template.yaml file found for template '", template, "'")
   }
+
   template_meta <- yaml_load_file_utf8(template_yaml)
   if (is.null(template_meta$name) || is.null(template_meta$description)) {
     stop("template.yaml must contain name and description fields")

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -1,6 +1,10 @@
 #' Convert to GitHub Flavored Markdown
 #'
 #' Format for converting from R Markdown to GitHub Flavored Markdown.
+#'
+#' See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online
+#' documentation} for additional details on using the \code{github_document}
+#' format.
 #' @inheritParams output_format
 #' @inheritParams html_document
 #' @inheritParams md_document
@@ -8,11 +12,6 @@
 #'   newline to represent a line break (as opposed to two-spaces and a newline).
 #' @param html_preview \code{TRUE} to also generate an HTML file for the purpose of
 #'   locally previewing what the document will look like on GitHub.
-#' @details
-#' See the
-#' \href{http://rmarkdown.rstudio.com/github_document_format.html}{online
-#' documentation} for additional details on using the \code{github_document}
-#' format.
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @export
 github_document <- function(toc = FALSE,

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -1,9 +1,20 @@
-#'Convert to an HTML document
+#' Convert to an HTML document
 #'
-#'Format for converting from R Markdown to an HTML document.
+#' Format for converting from R Markdown to an HTML document.
 #'
-#' @inheritParams output_format
+#' See the \href{https://rmarkdown.rstudio.com/html_document_format.html}{online
+#' documentation} for additional details on using the \code{html_document}
+#' format.
 #'
+#' R Markdown documents can have optional metadata that is used to generate a
+#' document header that includes the title, author, and date. For more details
+#' see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
+#'
+#' R Markdown documents also support citations. You can find more information on
+#' the markdown syntax for citations in the
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' and Citations} article in the online documentation.
+#'@inheritParams output_format
 #'@param toc \code{TRUE} to include a table of contents in the output
 #'@param toc_depth Depth of headers to include in table of contents
 #'@param toc_float \code{TRUE} to float the table of contents to the left of the
@@ -69,25 +80,7 @@
 #'@param pandoc_args Additional command line options to pass to pandoc
 #'@param extra_dependencies,... Additional function arguments to pass to the
 #'  base R Markdown HTML output formatter \code{\link{html_document_base}}
-#'
 #'@return R Markdown output format to pass to \code{\link{render}}
-#'
-#'@details
-#'
-#'See the \href{https://rmarkdown.rstudio.com/html_document_format.html}{online
-#'documentation} for additional details on using the \code{html_document}
-#'format.
-#'
-#'R Markdown documents can have optional metadata that is used to generate a
-#'document header that includes the title, author, and date. For more details
-#'see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
-#'
-#'R Markdown documents also support citations. You can find more information on
-#'the markdown syntax for citations in the
-#'\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
-#'and Citations} article in the online documentation.
-#'
-#'
 #'@section Navigation Bars:
 #'
 #'  If you have a set of html documents which you'd like to provide a common
@@ -179,15 +172,13 @@
 #'
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' render("input.Rmd", html_document())
 #'
 #' render("input.Rmd", html_document(toc = TRUE))
 #' }
-#'
-#'@export
+#' @export
 html_document <- function(toc = FALSE,
                           toc_depth = 3,
                           toc_float = FALSE,
@@ -466,14 +457,15 @@ html_document <- function(toc = FALSE,
 #' HTML output.
 #'
 #' @inheritParams html_document
-#'
 #' @return An list that can be passed as the \code{knitr} argument of the
 #'   \code{\link{output_format}} function.
-#'
 #' @seealso \link{knitr_options}, \link{output_format}
-#'
 #' @export
-knitr_options_html <- function(fig_width, fig_height, fig_retina, keep_md, dev = 'png') {
+knitr_options_html <- function(fig_width,
+                               fig_height,
+                               fig_retina,
+                               keep_md,
+                               dev = 'png') {
 
   opts_chunk <- list(dev = dev,
                      dpi = 96,
@@ -559,7 +551,6 @@ navbar_html_from_yaml <- function(navbar_yaml) {
 #' @param navbar Navbar definition
 #' @param links List of navbar links
 #' @return Path to temporary file with navbar definition
-#'
 #' @keywords internal
 #' @export
 navbar_html <- function(navbar) {
@@ -594,6 +585,7 @@ navbar_links_html <- function(links) {
 }
 
 navbar_links_tags <- function(links) {
+
   if (!is.null(links)) {
     tags <- lapply(links, function(x) {
 
@@ -628,6 +620,7 @@ navbar_links_tags <- function(links) {
 }
 
 navbar_link_text <- function(x, ...) {
+
   if (!is.null(x$icon)) {
     # find the iconset
     split <- strsplit(x$icon, "-")

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -74,7 +74,7 @@
 #'
 #'@details
 #'
-#'See the \href{http://rmarkdown.rstudio.com/html_document_format.html}{online
+#'See the \href{https://rmarkdown.rstudio.com/html_document_format.html}{online
 #'documentation} for additional details on using the \code{html_document}
 #'format.
 #'
@@ -84,7 +84,7 @@
 #'
 #'R Markdown documents also support citations. You can find more information on
 #'the markdown syntax for citations in the
-#'\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#'\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #'and Citations} article in the online documentation.
 #'
 #'

--- a/R/html_fragment.R
+++ b/R/html_fragment.R
@@ -5,16 +5,12 @@
 #' assumes you will include the output into an existing document (e.g. a blog
 #' post).
 #'
+#' See the \href{https://rmarkdown.rstudio.com/html_document_format.html}{online
+#' documentation} for additional details on using the \code{html_fragment}
+#' format.
 #' @param mathjax \code{TRUE} to convert $ and $$ math blocks into MathJax
 #'   compatible output. Note that you'll still need to ensure that the page
 #'   where the fragment is included loads the required MathJax scripts.
-#'
-#' @details
-#'
-#' See the \href{http://rmarkdown.rstudio.com/html_document_format.html}{online
-#' documentation} for additional details on using the \code{html_fragment}
-#' format.
-#'
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}
 #' @return R Markdown output format to pass to \code{\link{render}}

--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -2,6 +2,9 @@
 #'
 #' Format for converting from R Markdown to an HTML notebook.
 #'
+#' See the \href{https://rmarkdown.rstudio.com/r_notebook_format.html}{online
+#' documentation} for additional details on using the \code{html_notebook}
+#' format.
 #' @inheritParams html_document
 #' @param output_source Define an output source for \R chunks (ie,
 #'   outputs to use instead of those produced by evaluating the
@@ -11,10 +14,6 @@
 #'   dependencies. Defaults to \code{TRUE}. In notebooks, setting this to
 #'   \code{FALSE} is not recommended, since the setting does not apply to
 #'   embedded notebook output such as plots and HTML widgets.
-#'
-#' @details For more details on the HTML file format produced by
-#'  \code{html_notebook}, see \href{http://rmarkdown.rstudio.com/r_notebook_format.html}{http://rmarkdown.rstudio.com/r_notebook_format.html}.
-#'
 #' @importFrom evaluate evaluate
 #' @export
 html_notebook <- function(toc = FALSE,
@@ -237,14 +236,14 @@ html_notebook <- function(toc = FALSE,
 #' related to generated outputs in the document, as well as the
 #' original R Markdown source document.
 #'
+#' See the \href{https://rmarkdown.rstudio.com/r_notebook_format.html}{online
+#' documentation} for additional details on using the \code{html_notebook}
+#' format.
 #' @param path The path to an R Notebook file (with extension \code{.nb.html}).
 #' @param encoding The document's encoding (assumed as \code{"UTF-8"} by default).
-#'
-#' @details For more details on the HTML file format produced by
-#'  \code{html_notebook}, see \href{http://rmarkdown.rstudio.com/r_notebook_format.html}{http://rmarkdown.rstudio.com/r_notebook_format.html}.
-#'
 #' @export
-parse_html_notebook <- function(path, encoding = "UTF-8") {
+parse_html_notebook <- function(path,
+                                encoding = "UTF-8") {
 
   contents <- read_lines_utf8(path, encoding = encoding)
 

--- a/R/html_notebook_output.R
+++ b/R/html_notebook_output.R
@@ -4,6 +4,9 @@
 #' through the \code{output_source} function attached to a
 #' \code{\link{output_format}}.
 #'
+#' See the \href{https://rmarkdown.rstudio.com/r_notebook_format.html}{online
+#' documentation} for additional details on using the \code{html_notebook}
+#' format.
 #' @param path  A path to a file. For functions accepting both \code{path}
 #'   and \code{bytes}, if \code{bytes} is \code{NULL}, the bytewise contents
 #'   will be obtained by reading the file.
@@ -15,10 +18,6 @@
 #' @param meta An \R list of arbitrary meta-data. The data will
 #'   be converted to JSON, base64-encoded, and injected into the header comment.
 #' @param format The image format; one of \code{"png"} or \code{"jpeg"}.
-#'
-#' @details For more details on the HTML file format produced by
-#'  \code{html_notebook}, see \href{http://rmarkdown.rstudio.com/r_notebook_format.html}{http://rmarkdown.rstudio.com/r_notebook_format.html}.
-#'
 #' @name html_notebook_output
 NULL
 
@@ -27,7 +26,6 @@ NULL
 #' A structured helper for the construction of metadata used by the
 #' R Notebook output functions. See \code{\link{html_notebook_output}} for
 #' more details.
-#'
 #' @param iframe Boolean; should output be shown in an \code{<iframe>}?
 #' @export
 html_notebook_metadata <- function(iframe = TRUE) {
@@ -37,8 +35,7 @@ html_notebook_metadata <- function(iframe = TRUE) {
 html_notebook_render_base64_data <- function(path = NULL,
                                              bytes = NULL,
                                              attributes = NULL,
-                                             format)
-{
+                                             format) {
   # read (if necessary) and encode data
   if (is.null(bytes))
     bytes <- read_file(path, binary = TRUE)
@@ -51,8 +48,7 @@ html_notebook_render_base64_data <- function(path = NULL,
 #' @name html_notebook_output
 #' @export
 html_notebook_output_html <- function(html,
-                                      meta = NULL)
-{
+                                      meta = NULL) {
   html_notebook_annotated_output(paste(html, collapse = "\n"), "html", meta)
 }
 
@@ -62,8 +58,7 @@ html_notebook_output_img <- function(path = NULL,
                                      bytes = NULL,
                                      attributes = NULL,
                                      meta = NULL,
-                                     format = c("png", "jpeg"))
-{
+                                     format = c("png", "jpeg")) {
   template <- paste0('<img%s src="data:image/', match.arg(format),
                      ';base64,%s" />')
   html <- html_notebook_render_base64_data(path, bytes, attributes, template)
@@ -78,8 +73,7 @@ html_notebook_output_png <- html_notebook_output_img
 #' @export
 html_notebook_output_code <- function(code,
                                       attributes = list(class = "r"),
-                                      meta = NULL)
-{
+                                      meta = NULL) {
   # generate code
   code <- sprintf(
     "```%s\n%s\n```",

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -1,4 +1,4 @@
-#' Convert to an HTML vignette.
+#' Convert to an HTML vignette
 #'
 #' A HTML vignette is a lightweight alternative to \code{\link{html_document}}
 #' suitable for inclusion in packages to be released to CRAN. It reduces the
@@ -14,11 +14,8 @@
 #'   \item uses a custom highlight scheme
 #'  }
 #'
-#' @details
-#'
-#' See the \href{http://rmarkdown.rstudio.com/package_vignette_format.html}{online
+#' See the \href{https://rmarkdown.rstudio.com/package_vignette_format.html}{online
 #' documentation} for additional details on using the \code{html_vignette} format.
-#'
 #' @inheritParams html_document
 #' @param ... Additional arguments passed to \code{\link{html_document}}. Please
 #'   note that \code{theme}, \code{fig_retina} and \code{highlight} are hard

--- a/R/includes.R
+++ b/R/includes.R
@@ -2,6 +2,9 @@
 #'
 #' Specify additional content to be included within an output document.
 #'
+#' Non-absolute paths for resources referenced from the
+#' \code{in_header}, \code{before_body}, and \code{after_body}
+#' parameters are resolved relative to the directory of the input document.
 #' @param in_header One or more files with content to be included in the
 #'   header of the document.
 #' @param before_body One or more files with content to be included before
@@ -10,28 +13,21 @@
 #'   document body.
 #' @param includes Includes to convert to pandoc args.
 #' @param filter Filter to pre-process includes with.
-#'
 #' @return Includes list or pandoc args
-#'
-#' @details Non-absolute paths for resources referenced from the
-#'   \code{in_header}, \code{before_body}, and \code{after_body}
-#'   parameters are resolved relative to the directory of the input document.
-#'
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' html_document(includes = includes(before_body = "header.htm"))
 #'
 #' pdf_document(includes = includes(after_body = "footer.tex"))
-#'
 #' }
 #' @name includes
 #' @export
 includes <- function(in_header = NULL,
                      before_body = NULL,
                      after_body = NULL) {
+
   list(in_header = in_header,
        before_body = before_body,
        after_body = after_body)
@@ -40,7 +36,9 @@ includes <- function(in_header = NULL,
 
 #' @rdname includes
 #' @export
-includes_to_pandoc_args <- function(includes, filter = identity) {
+includes_to_pandoc_args <- function(includes,
+                                    filter = identity) {
+
   if (!is.null(includes))
     pandoc_include_args(in_header = filter(includes$in_header),
                         before_body = filter(includes$before_body),
@@ -50,12 +48,12 @@ includes_to_pandoc_args <- function(includes, filter = identity) {
 }
 
 
-
 # simple wrapper over normalizePath that preserves NULLs and applies pandoc-
 # friendly defaults
-normalize_path <- function(path, winslash = "/", mustWork = NA) {
+normalize_path <- function(path,
+                           winslash = "/",
+                           mustWork = NA) {
+
   if (!is.null(path))
     normalizePath(path, winslash = winslash, mustWork = mustWork)
 }
-
-

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -3,27 +3,6 @@
 #' Format for converting from R Markdown to another variant of markdown (e.g.
 #' strict markdown or github flavored markdown)
 #'
-#' @inheritParams html_document
-#'
-#' @param variant Markdown variant to produce (defaults to "markdown_strict").
-#'   Other valid values are "markdown_github", "markdown_mmd",
-#'   markdown_phpextra", or even "markdown" (which produces pandoc markdown).
-#'   You can also compose custom markdown variants, see the
-#'   \href{http://pandoc.org/README.html}{pandoc online documentation}
-#'   for details.
-#'
-#' @param preserve_yaml Preserve YAML front matter in final document.
-#'
-#' @param fig_retina Scaling to perform for retina displays. Defaults to
-#'   \code{NULL} which performs no scaling. A setting of 2 will work for all
-#'   widely used retina displays, but will also result in the output of
-#'   \code{<img>} tags rather than markdown images due to the need to set the
-#'   width of the image explicitly.
-#'
-#' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
 #' See the \href{http://rmarkdown.rstudio.com/markdown_document_format.html}{online
 #' documentation} for additional details on using the \code{md_document} format.
 #'
@@ -35,17 +14,28 @@
 #' the markdown syntax for citations in the
 #' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #' and Citations} article in the online documentation.
-#'
+#' @inheritParams html_document
+#' @param variant Markdown variant to produce (defaults to "markdown_strict").
+#'   Other valid values are "markdown_github", "markdown_mmd",
+#'   markdown_phpextra", or even "markdown" (which produces pandoc markdown).
+#'   You can also compose custom markdown variants, see the
+#'   \href{http://pandoc.org/README.html}{pandoc online documentation}
+#'   for details.
+#' @param preserve_yaml Preserve YAML front matter in final document.
+#' @param fig_retina Scaling to perform for retina displays. Defaults to
+#'   \code{NULL} which performs no scaling. A setting of 2 will work for all
+#'   widely used retina displays, but will also result in the output of
+#'   \code{<img>} tags rather than markdown images due to the need to set the
+#'   width of the image explicitly.
+#' @return R Markdown output format to pass to \code{\link{render}}
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' render("input.Rmd", md_document())
 #'
 #' render("input.Rmd", md_document(variant = "markdown_github"))
 #' }
-#'
 #' @export
 md_document <- function(variant = "markdown_strict",
                         preserve_yaml = FALSE,

--- a/R/odt_document.R
+++ b/R/odt_document.R
@@ -2,19 +2,7 @@
 #'
 #' Format for converting from R Markdown to an ODT document.
 #'
-#' @inheritParams pdf_document
-#' @inheritParams html_document
-#'
-#' @param reference_odt Use the specified file as a style reference in
-#'   producing an odt file. For best results, the reference odt should be a
-#'   modified version of an odt file produced using pandoc. Pass "default"
-#'   to use the rmarkdown default styles.
-#'
-#' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
-#' See the \href{http://rmarkdown.rstudio.com/odt_document_format.html}{online
+#' See the \href{https://rmarkdown.rstudio.com/odt_document_format.html}{online
 #' documentation} for additional details on using the \code{odt_document} format.
 #'
 #' R Markdown documents can have optional metadata that is used to generate a
@@ -23,12 +11,17 @@
 #'
 #' R Markdown documents also support citations. You can find more information on
 #' the markdown syntax for citations in the
-#' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #' and Citations} article in the online documentation.
-#'
+#' @inheritParams pdf_document
+#' @inheritParams html_document
+#' @param reference_odt Use the specified file as a style reference in
+#'   producing an odt file. For best results, the reference odt should be a
+#'   modified version of an odt file produced using pandoc. Pass "default"
+#'   to use the rmarkdown default styles.
+#' @return R Markdown output format to pass to \code{\link{render}}
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' # simple invocation
@@ -37,7 +30,6 @@
 #' # specify an option for syntax highlighting
 #' render("input.Rmd", odt_document(highlight = "zenburn"))
 #' }
-#'
 #' @export
 odt_document <- function(fig_width = 5,
                          fig_height = 4,
@@ -84,6 +76,3 @@ odt_document <- function(fig_width = 5,
     keep_md = keep_md
   )
 }
-
-
-

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -1,8 +1,7 @@
 #' Define an R Markdown output format
 #'
-#' Define an R Markdown output format based on a combination of knitr and pandoc
-#' options.
-#'
+#' Define an R Markdown output format based on a combination of
+#' knitr and pandoc options.
 #' @param knitr Knitr options for an output format (see
 #'   \code{\link{knitr_options}})
 #' @param pandoc Pandoc options for an output format (see
@@ -48,18 +47,14 @@
 #' @param on_exit A function to call when \code{rmarkdown::render()} finishes
 #'   execution (as registered with a \code{\link{on.exit}} handler).
 #' @param base_format An optional format to extend.
-#'
 #' @return An R Markdown output format definition that can be passed to
 #'   \code{\link{render}}.
-#'
 #' @seealso \link{render}, \link{knitr_options}, \link{pandoc_options}
-#'
 #' @examples
 #' \dontrun{
 #' output_format(knitr = knitr_options(opts_chunk = list(dev = 'png')),
 #'               pandoc = pandoc_options(to = "html"))
 #' }
-#'
 #' @export
 output_format <- function(knitr,
                           pandoc,
@@ -98,7 +93,9 @@ output_format <- function(knitr,
 }
 
 # merges two scalar values; picks the overlay if non-NULL and then the base
-merge_scalar <- function(base, overlay) {
+merge_scalar <- function(base,
+                         overlay) {
+
   if (is.null(base) && is.null(overlay))
     NULL
   else if (is.null(overlay))
@@ -109,7 +106,10 @@ merge_scalar <- function(base, overlay) {
 
 # merges two functions: if both are non-NULL, produces a new function that
 # invokes each and then uses the supplied operation to combine their outputs
-merge_function_outputs <- function(base, overlay, op) {
+merge_function_outputs <- function(base,
+                                   overlay,
+                                   op) {
+
   if (!is.null(base) && !is.null(overlay)) {
     function(...) {
       op(base(...), overlay(...))
@@ -121,7 +121,9 @@ merge_function_outputs <- function(base, overlay, op) {
 
 # merges two post-processors; if both are non-NULL, produces a new function that
 # calls the overlay post-processor and then the base post-processor.
-merge_post_processors <- function(base, overlay) {
+merge_post_processors <- function(base,
+                                  overlay) {
+
   if (!is.null(base) && !is.null(overlay)) {
     function(metadata, input_file, output_file, ...) {
       output_file <- overlay(metadata, input_file, output_file, ...)
@@ -134,7 +136,9 @@ merge_post_processors <- function(base, overlay) {
 }
 
 # merges two output formats
-merge_output_formats <- function(base, overlay)  {
+merge_output_formats <- function(base,
+                                 overlay) {
+
   structure(list(
     knitr = merge_lists(base$knitr, overlay$knitr),
     pandoc = merge_pandoc_options(base$pandoc, overlay$pandoc),
@@ -160,14 +164,18 @@ merge_output_formats <- function(base, overlay)  {
   ), class = "rmarkdown_output_format")
 }
 
-merge_on_exit <- function(base, overlay) {
+merge_on_exit <- function(base,
+                          overlay) {
+
   function() {
     if (is.function(base)) base()
     if (is.function(overlay)) overlay()
   }
 }
 
-merge_pandoc_options <- function(base, overlay) {
+merge_pandoc_options <- function(base,
+                                 overlay) {
+
   res <- merge_lists(base, overlay, recursive = FALSE)
   res$args <- c(base$args, overlay$args)
   res
@@ -176,7 +184,6 @@ merge_pandoc_options <- function(base, overlay) {
 #' Knitr options for an output format
 #'
 #' Define the knitr options for an R Markdown output format.
-#'
 #' @param opts_knit List of package level knitr options (see
 #'   \code{\link[knitr:opts_knit]{opts_knit}})
 #' @param opts_chunk List of chunk level knitr options (see
@@ -187,18 +194,16 @@ merge_pandoc_options <- function(base, overlay) {
 #'   (see \code{\link[knitr:opts_hooks]{opts_hooks}})
 #' @param opts_template List of templates for chunk level knitr options (see
 #'   \code{\link[knitr:opts_template]{opts_template}})
-#'
-#' @return An list that can be passed as the \code{knitr} argument of the
-#'   \code{\link{output_format}} function.
-#'
+#' @return An list that can be passed as the \code{knitr} argument
+#'   of the \code{\link{output_format}} function.
 #' @seealso \link{output_format}
-#'
 #' @export
 knitr_options <- function(opts_knit = NULL,
                           opts_chunk = NULL,
                           knit_hooks = NULL,
                           opts_hooks = NULL,
                           opts_template = NULL) {
+
   list(opts_knit = opts_knit,
        opts_chunk = opts_chunk,
        knit_hooks = knit_hooks,
@@ -208,18 +213,18 @@ knitr_options <- function(opts_knit = NULL,
 
 #' Knitr options for a PDF output format
 #'
-#' Define knitr options for an R Markdown output format that creates PDF output.
-#'
+#' Define knitr options for an R Markdown output format
+#' that creates PDF output.
 #' @inheritParams html_document
 #' @inheritParams pdf_document
-#'
 #' @return An list that can be passed as the \code{knitr} argument of the
 #'   \code{\link{output_format}} function.
-#'
 #' @seealso \link{knitr_options}, \link{output_format}
-#'
 #' @export
-knitr_options_pdf <- function(fig_width, fig_height, fig_crop, dev = 'pdf') {
+knitr_options_pdf <- function(fig_width,
+                              fig_height,
+                              fig_crop,
+                              dev = 'pdf') {
 
   # default options
   opts_knit <- NULL
@@ -251,6 +256,9 @@ knitr_options_pdf <- function(fig_width, fig_height, fig_crop, dev = 'pdf') {
 #'
 #' Define the pandoc options for an R Markdown output format.
 #'
+#' The \code{from} argument should be used very cautiously as it's
+#' important for users to be able to rely on a stable definition of supported
+#' markdown extensions.
 #' @param to Pandoc format to convert to
 #' @param from Pandoc format to convert from
 #' @param args Character vector of command line arguments to pass to pandoc
@@ -262,16 +270,9 @@ knitr_options_pdf <- function(fig_width, fig_height, fig_crop, dev = 'pdf') {
 #'   chooses default based on \code{to}). This is typically used to force
 #'   the final output of a latex or beamer conversion to be \code{.tex}
 #'   rather than \code{.pdf}.
-#'
 #' @return An list that can be passed as the \code{pandoc} argument of the
 #'   \code{\link{output_format}} function.
-#'
-#' @details The \code{from} argument should be used very cautiously as it's
-#'   important for users to be able to rely on a stable definition of supported
-#'   markdown extensions.
-#'
 #' @seealso \link{output_format}, \link{rmarkdown_format}
-#'
 #' @export
 pandoc_options <- function(to,
                            from = rmarkdown_format(),
@@ -289,17 +290,8 @@ pandoc_options <- function(to,
 
 #' R Markdown input format definition
 #'
-#' Compose a pandoc markdown input definition for R Markdown that can be
-#' passed as the \code{from} argument of \link{pandoc_options}.
-#'
-#'
-#' @param implicit_figures Automatically make figures from images (defaults to \code{TRUE}).
-#' @param extensions Markdown extensions to be added or removed from the
-#' default definition of R Markdown.
-#'
-#' @return Pandoc markdown format specification
-#'
-#' @details
+#' Compose a pandoc markdown input definition for R Markdown
+#' that can be passed as the \code{from} argument of \link{pandoc_options}.
 #'
 #' By default R Markdown is defined as all pandoc markdown extensions with
 #' the following tweaks for backward compatibility with the markdown package
@@ -311,16 +303,17 @@ pandoc_options <- function(to,
 #' \code{+tex_math_single_backslash} \cr
 #' }
 #'
-#'
-#' For more on pandoc markdown see the \href{http://pandoc.org/README.html}{pandoc online documentation}.
-#'
+#' For more on pandoc markdown see the
+#' \href{http://pandoc.org/README.html}{pandoc online documentation}.
+#' @param implicit_figures Automatically make figures from images (defaults to \code{TRUE}).
+#' @param extensions Markdown extensions to be added or removed from the
+#' default definition of R Markdown.
+#' @return Pandoc markdown format specification
 #' @examples
 #' \dontrun{
 #' rmarkdown_format("-implicit_figures")
 #' }
-#'
 #' @seealso \link{output_format}, \link{pandoc_options}
-#'
 #' @export
 rmarkdown_format <- function(extensions = NULL) {
 
@@ -353,22 +346,18 @@ smart_extension <- function(smart, extension) {
 #' document and return the output format that will be generated by
 #' a call to \code{\link{render}}.
 #'
+#' This function is useful for front-end tools that require additional
+#' knowledge of the output to be produced by \code{\link{render}} (e.g. to
+#' customize the preview experience).
 #' @param input Input file (Rmd or plain markdown)
 #' @param encoding The encoding of the input file; see \code{\link{file}}
-#'
 #' @return A named list with a \code{name} value containing the format
 #'   name and an \code{options} value that is a list containing all the options
 #'   for the format and their values. An option's default value will be returned
 #'   if the option isn't set explicitly in the document.
-#'
-#' @details
-#'
-#' This function is useful for front-end tools that require additional
-#' knowledge of the output to be produced by \code{\link{render}} (e.g. to
-#' customize the preview experience).
-#'
 #' @export
-default_output_format <- function(input, encoding = getOption("encoding")) {
+default_output_format <- function(input,
+                                  encoding = getOption("encoding")) {
 
   # execute within the input file's directory (this emulates the way
   # yaml front matter discovery is done within render)
@@ -398,21 +387,16 @@ default_output_format <- function(input, encoding = getOption("encoding")) {
 #' document and return an output format object that can be
 #' passed to the \code{\link{render}} function.
 #'
+#' This function is useful for front-end tools that need to modify
+#' the default behavior of an output format.
 #' @param input Input file (Rmd or plain markdown)
 #' @param output_format Name of output format (or \code{NULL} to use
 #'   the default format for the input file).
 #' @param output_options List of output options that should override the
 #'   options specified in metadata.
-#' @param encoding The encoding of the input file; see \code{\link{file}}
-#'
+#' @param encoding The encoding of the input file; see \code{\link{file}}.
 #' @return An R Markdown output format definition that can be passed to
 #'   \code{\link{render}}.
-#'
-#' @details
-#'
-#' This function is useful for front-end tools that need to modify
-#' the default behavior of an output format.
-#'
 #' @export
 resolve_output_format <- function(input,
                                   output_format = NULL,
@@ -427,10 +411,12 @@ resolve_output_format <- function(input,
     stop("output_format must be a character vector")
 
   # resolve the output format by looking at the yaml
-  output_format <- output_format_from_yaml_front_matter(input_lines,
-                                                        output_options,
-                                                        output_format,
-                                                        encoding = encoding)
+  output_format <-
+    output_format_from_yaml_front_matter(
+      input_lines,
+      output_options,
+      output_format,
+      encoding = encoding)
 
   # return it
   create_output_format(output_format$name, output_format$options)
@@ -443,23 +429,20 @@ resolve_output_format <- function(input,
 #' document and return the output formats that will be generated by
 #' a call to \code{\link{render}}.
 #'
-#' @param input Input file (Rmd or plain markdown)
-#' @param encoding The encoding of the input file; see \code{\link{file}}
-#'
-#' @return A character vector with the names of all output formats.
-#'
-#' @details
-#'
 #' This function is useful for front-end tools that require additional
 #' knowledge of the output to be produced by \code{\link{render}} (e.g. to
 #' customize the preview experience).
-#'
+#' @param input Input file (Rmd or plain markdown)
+#' @param encoding The encoding of the input file; see \code{\link{file}}.
+#' @return A character vector with the names of all output formats.
 #' @export
-all_output_formats <- function(input, encoding = getOption("encoding")) {
-  enumerate_output_formats(input = input,
-                           envir = parent.frame(),
-                           encoding = encoding)
+all_output_formats <- function(input,
+                               encoding = getOption("encoding")) {
 
+  enumerate_output_formats(
+    input = input,
+    envir = parent.frame(),
+    encoding = encoding)
 }
 
 
@@ -471,6 +454,7 @@ output_format_from_yaml_front_matter <- function(input_lines,
                                                  encoding = getOption("encoding")) {
 
   format_name <- output_format_name
+
   # ensure input is the correct data type
   if (!is_null_or_string(format_name)) {
     stop("Unrecognized output format specified", call. = FALSE)
@@ -561,7 +545,8 @@ output_format_from_yaml_front_matter <- function(input_lines,
   list(name = format_name, options = format_options)
 }
 
-create_output_format <- function(name, options) {
+create_output_format <- function(name,
+                                 options) {
 
   # validate the name
   if (is.null(name))
@@ -588,7 +573,9 @@ is_output_format <- function(x) {
   inherits(x, "rmarkdown_output_format")
 }
 
-enumerate_output_formats <- function(input, envir, encoding) {
+enumerate_output_formats <- function(input,
+                                     envir,
+                                     encoding) {
 
   # read the input
   input_lines <- read_lines_utf8(input, encoding)
@@ -632,8 +619,7 @@ enumerate_output_formats <- function(input, envir, encoding) {
     # merge against common _output.yml
     output_format_yaml <- merge_output_options(common_output_format_yaml,
                                                output_format_yaml)
-  }
-  else {
+  } else {
     output_format_yaml <- NULL
   }
 
@@ -648,12 +634,11 @@ enumerate_output_formats <- function(input, envir, encoding) {
 }
 
 #' Parse the YAML front matter from a file
-#'
 #' @inheritParams default_output_format
-#'
 #' @keywords internal
 #' @export
-yaml_front_matter <- function(input, encoding = getOption("encoding")) {
+yaml_front_matter <- function(input,
+                              encoding = getOption("encoding")) {
 
    # read the input file
   input_lines <- read_lines_utf8(input, encoding)
@@ -689,7 +674,6 @@ validate_front_matter <- function(front_matter) {
   if (grepl(":$", front_matter))
     stop("Invalid YAML front matter (ends with ':')", call. = FALSE)
 }
-
 
 
 partition_yaml_front_matter <- function(input_lines) {
@@ -733,7 +717,8 @@ partition_yaml_front_matter <- function(input_lines) {
   }
 }
 
-merge_output_options <- function(base_options, overlay_options) {
+merge_output_options <- function(base_options,
+                                 overlay_options) {
 
   # if either one of these is a character vector then normalize to a named list
   normalize_list <- function(target) {
@@ -753,7 +738,8 @@ is_pandoc_to_html <- function(options) {
   options$to %in% c("html", "html4", "html5")
 }
 
-citeproc_required <- function(yaml_front_matter, input_lines = NULL) {
+citeproc_required <- function(yaml_front_matter,
+                              input_lines = NULL) {
   (
     is.null(yaml_front_matter$citeproc) ||
       yaml_front_matter$citeproc

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -2,6 +2,12 @@
 #'
 #' Convert documents to and from various formats using the pandoc utility.
 #'
+#' Supported input and output formats are described in the
+#' \href{http://johnmacfarlane.net/pandoc/README.html}{pandoc user guide}.
+#'
+#' The system path as well as the version of pandoc shipped with RStudio (if
+#' running under RStudio) are scanned for pandoc and the highest version
+#' available is used.
 #' @param input Character vector containing paths to input files
 #'   (files must be UTF-8 encoded)
 #' @param to Format to convert to (if not specified, you must specify
@@ -9,21 +15,13 @@
 #' @param from Format to convert from (if not specified then the format is
 #'   determined based on the file extension of \code{input}).
 #' @param output Output file (if not specified then determined based on format
-#'   being converted to)
+#'   being converted to).
 #' @param citeproc \code{TRUE} to run the pandoc-citeproc filter (for processing
-#'   citations) as part of the conversion
+#'   citations) as part of the conversion.
 #' @param options Character vector of command line options to pass to pandoc.
 #' @param verbose \code{TRUE} to show the pandoc command line which was executed
 #' @param wd Working directory in which code will be executed. If not
-#'   supplied, defaults to the common base directory of \code{input}
-#'
-#' @details Supported input and output formats are described in the
-#'   \href{http://johnmacfarlane.net/pandoc/README.html}{pandoc user guide}.
-#'
-#'   The system path as well as the version of pandoc shipped with RStudio (if
-#'   running under RStudio) are scanned for pandoc and the highest version
-#'   available is used.
-#'
+#'   supplied, defaults to the common base directory of \code{input}.
 #' @examples
 #' \dontrun{
 #' library(rmarkdown)
@@ -38,7 +36,6 @@
 #' # add some pandoc options
 #' pandoc_convert("input.md", to="pdf", options = c("--listings"))
 #' }
-#'
 #' @export
 pandoc_convert <- function(input,
                            to = NULL,
@@ -56,9 +53,9 @@ pandoc_convert <- function(input,
   if (is.null(wd)) {
     wd <- base_dir(input)
   }
+
   oldwd <- setwd(wd)
   on.exit(setwd(oldwd), add = TRUE)
-
 
   # input file and formats
   args <- c(input)
@@ -69,7 +66,7 @@ pandoc_convert <- function(input,
   if (!is.null(from))
     args <- c(args, "--from", from)
 
-  #  output file
+  # output file
   if (!is.null(output))
     args <- c(args, "--output", output)
 
@@ -111,23 +108,18 @@ pandoc_convert <- function(input,
 #' checking for a specific version or greater). Determine the specific version
 #' of pandoc available.
 #'
-#' @param version Required version of pandoc
-#' @param error Whether to signal an error if pandoc with the required version
-#'   is not found
-#'
-#' @return \code{pandoc_available} returns a logical indicating whether the
-#'   required version of pandoc is available. \code{pandoc_version} returns a
-#'   \code{\link[base]{numeric_version}} with the version of pandoc found.
-#'
-#' @details
-#'
 #' The system environment variable \samp{PATH} as well as the version of pandoc
 #' shipped with RStudio (its location is set via the environment variable
 #' \samp{RSTUDIO_PANDOC} by RStudio products like the RStudio IDE, RStudio
 #' Server, Shiny Server, and RStudio Connect, etc) are scanned for pandoc and
 #' the highest version available is used. Please do not modify the environment
 #' variable \samp{RSTUDIO_PANDOC} unless you know what it means.
-#'
+#' @param version Required version of pandoc
+#' @param error Whether to signal an error if pandoc with the required version
+#'   is not found
+#' @return \code{pandoc_available} returns a logical indicating whether the
+#'   required version of pandoc is available. \code{pandoc_version} returns a
+#'   \code{\link[base]{numeric_version}} with the version of pandoc found.
 #' @examples
 #' \dontrun{
 #' library(rmarkdown)
@@ -139,7 +131,8 @@ pandoc_convert <- function(input,
 #'   cat("required version of pandoc is available!\n")
 #' }
 #' @export
-pandoc_available <- function(version = NULL, error = FALSE) {
+pandoc_available <- function(version = NULL,
+                             error = FALSE) {
 
   # ensure we've scanned for pandoc
   find_pandoc()
@@ -168,10 +161,12 @@ pandoc_version <- function() {
 #'
 #' Functions that assist in creating various types of pandoc command line
 #' arguments (e.g. for templates, table of contents, highlighting, and content
-#' includes)
+#' includes).
 #'
+#' Non-absolute paths for resources referenced from the
+#' \code{in_header}, \code{before_body}, and \code{after_body}
+#' parameters are resolved relative to the directory of the input document.
 #' @inheritParams includes
-#'
 #' @param name Name of template variable to set.
 #' @param value Value of template variable (defaults to \code{true} if missing).
 #' @param toc \code{TRUE} to include a table of contents in the output.
@@ -181,16 +176,9 @@ pandoc_version <- function() {
 #'   "pdflatex", "lualatex", and "xelatex".
 #' @param default The highlighting theme to use if "default"
 #'   is specified.
-#'
-#' @return A character vector with pandoc command line arguments
-#'
-#' @details Non-absolute paths for resources referenced from the
-#'   \code{in_header}, \code{before_body}, and \code{after_body}
-#'   parameters are resolved relative to the directory of the input document.
-#'
+#' @return A character vector with pandoc command line arguments.
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' pandoc_include_args(before_body = "header.htm")
@@ -201,14 +189,15 @@ pandoc_version <- function() {
 #' pandoc_latex_engine_args("pdflatex")
 #'
 #' pandoc_toc_args(toc = TRUE, toc_depth = 2)
-#'
 #' }
 #' @name pandoc_args
 NULL
 
 #' @rdname pandoc_args
 #' @export
-pandoc_variable_arg <- function(name, value) {
+pandoc_variable_arg <- function(name,
+                                value) {
+
   c("--variable", if (missing(value)) name else paste(name, "=", value, sep = ""))
 }
 
@@ -234,7 +223,8 @@ pandoc_include_args <- function(in_header = NULL,
 
 #' @rdname pandoc_args
 #' @export
-pandoc_highlight_args <- function(highlight, default = "tango") {
+pandoc_highlight_args <- function(highlight,
+                                  default = "tango") {
 
   args <- c()
 
@@ -252,6 +242,7 @@ pandoc_highlight_args <- function(highlight, default = "tango") {
 #' @rdname pandoc_args
 #' @export
 pandoc_latex_engine_args <- function(latex_engine) {
+
   c(if (pandoc2.0()) "--pdf-engine" else "--latex-engine",
     find_latex_engine(latex_engine))
 }
@@ -260,6 +251,7 @@ pandoc_latex_engine_args <- function(latex_engine) {
 # of the PATH environment variable by OSX 10.10 Yosemite prevents
 # pandoc from finding the engine in e.g. /usr/texbin
 find_latex_engine <- function(latex_engine) {
+
   # do not need full path if latex_engine is available from PATH
   if (!is_osx() || nzchar(Sys.which(latex_engine))) return(latex_engine)
   # resolve path if it's not already an absolute path
@@ -270,7 +262,8 @@ find_latex_engine <- function(latex_engine) {
 
 #' @rdname pandoc_args
 #' @export
-pandoc_toc_args <- function(toc, toc_depth = 3) {
+pandoc_toc_args <- function(toc,
+                            toc_depth = 3) {
 
   args <- c()
 
@@ -289,16 +282,14 @@ pandoc_toc_args <- function(toc, toc_depth = 3) {
 #' \code{\link[base:path.expand]{path.expand}} on all platforms. On Windows,
 #' transform it to a short path name if it contains spaces, and then convert
 #' forward slashes to back slashes (as required by pandoc for some path
-#' references)
-#'
+#' references).
 #' @param path Path to transform
 #' @param backslash Whether to replace forward slashes in \code{path} with
-#'   backslashes on Windows
-#'
-#' @return Transformed path that can be passed to pandoc on the command line
-#'
+#'   backslashes on Windows.
+#' @return Transformed path that can be passed to pandoc on the command line.
 #' @export
-pandoc_path_arg <- function(path, backslash = TRUE) {
+pandoc_path_arg <- function(path,
+                            backslash = TRUE) {
 
   path <- path.expand(path)
 
@@ -320,14 +311,12 @@ pandoc_path_arg <- function(path, backslash = TRUE) {
 #'
 #' Use the pandoc templating engine to render a text file. Substitutions are
 #' done using the \code{metadata} list passed to the function.
-#'
 #' @param metadata A named list containing metadata to pass to template.
 #' @param template Path to a pandoc template.
 #' @param output Path to save output.
 #' @param verbose \code{TRUE} to show the pandoc command line which was
 #'   executed.
 #' @return (Invisibly) The path of the generated file.
-#'
 #' @export
 pandoc_template <- function(metadata, template, output, verbose = FALSE) {
 
@@ -350,12 +339,9 @@ pandoc_template <- function(metadata, template, output, verbose = FALSE) {
 #'
 #' Create a self-contained HTML document by base64 encoding images,
 #' scripts, and stylesheets referred by the input document.
-#'
 #' @param input Input html file to create self-contained version of.
 #' @param output Path to save output.
-#'
 #' @return (Invisibly) The path of the generated file.
-#'
 #' @export
 pandoc_self_contained_html <- function(input, output) {
 
@@ -400,8 +386,8 @@ pandoc_self_contained_html <- function(input, output) {
 }
 
 
-
 validate_self_contained <- function(mathjax) {
+
   if (identical(mathjax, "local"))
     stop("Local MathJax isn't compatible with self_contained\n",
          "(you should set self_contained to FALSE)", call. = FALSE)
@@ -469,6 +455,7 @@ pandoc_mathjax_local_path <- function() {
 
 
 unix_mathjax_path <- function() {
+
   if (identical(.Platform$OS.type, "unix")) {
     mathjax_path <- "/usr/share/javascript/mathjax"
     if (file.exists(file.path(mathjax_path, "MathJax.js")))
@@ -481,7 +468,8 @@ unix_mathjax_path <- function() {
 }
 
 
-pandoc_html_highlight_args <- function(template, highlight) {
+pandoc_html_highlight_args <- function(template,
+                                       highlight) {
 
   args <- c()
 
@@ -552,6 +540,7 @@ find_pandoc <- function() {
 
 # Get an S3 numeric_version for the pandoc utility at the specified path
 get_pandoc_version <- function(pandoc_dir) {
+
   pandoc_path <- file.path(pandoc_dir, "pandoc")
   if (is_windows()) pandoc_path <- paste0(pandoc_path, ".exe")
   if (!utils::file_test("-x", pandoc_path)) return(numeric_version("0"))
@@ -568,31 +557,39 @@ get_pandoc_version <- function(pandoc_dir) {
 # see: https://github.com/rstudio/rmarkdown/issues/31
 # see: https://ghc.haskell.org/trac/ghc/ticket/7344
 with_pandoc_safe_environment <- function(code) {
+
   lc_all <- Sys.getenv("LC_ALL", unset = NA)
+
   if (!is.na(lc_all)) {
     Sys.unsetenv("LC_ALL")
     on.exit(Sys.setenv(LC_ALL = lc_all), add = TRUE)
   }
+
   lc_ctype <- Sys.getenv("LC_CTYPE", unset = NA)
+
   if (!is.na(lc_ctype)) {
     Sys.unsetenv("LC_CTYPE")
     on.exit(Sys.setenv(LC_CTYPE = lc_ctype), add = TRUE)
   }
+
   if (Sys.info()['sysname'] == "Linux" &&
         is.na(Sys.getenv("HOME", unset = NA))) {
     stop("The 'HOME' environment variable must be set before running Pandoc.")
   }
+
   if (Sys.info()['sysname'] == "Linux" &&
         is.na(Sys.getenv("LANG", unset = NA))) {
     # fill in a the LANG environment variable if it doesn't exist
     Sys.setenv(LANG = detect_generic_lang())
     on.exit(Sys.unsetenv("LANG"), add = TRUE)
   }
+
   if (Sys.info()['sysname'] == "Linux" &&
     identical(Sys.getenv("LANG"), "en_US")) {
     Sys.setenv(LANG = "en_US.UTF-8")
     on.exit(Sys.setenv(LANG = "en_US"), add = TRUE)
   }
+
   force(code)
 }
 
@@ -618,15 +615,17 @@ detect_generic_lang <- function() {
 }
 
 
-
 # get the path to the pandoc binary
 pandoc <- function() {
+
   find_pandoc()
   file.path(.pandoc$dir, "pandoc")
 }
 
+
 # get the path to the pandoc-citeproc binary
 pandoc_citeproc <- function() {
+
   find_pandoc()
   citeproc_path = file.path(.pandoc$dir, "pandoc-citeproc")
   if (file.exists(citeproc_path))
@@ -635,8 +634,10 @@ pandoc_citeproc <- function() {
     "pandoc-citeproc"
 }
 
+
 # quote args if they need it
 quoted <- function(args) {
+
   # some characters are legal in filenames but without quoting are likely to be
   # interpreted by the shell (e.g. redirection, wildcard expansion, etc.) --
   # wrap arguments containing these characters in quotes.
@@ -646,12 +647,15 @@ quoted <- function(args) {
 }
 
 find_pandoc_theme_variable <- function(args) {
+
   range <- length(args) - 1
+
   for (i in 1:range) {
     if (args[[i]] == "--variable" && grepl("^theme:", args[[i + 1]])) {
       return(substring(args[[i + 1]], nchar("theme:") + 1))
     }
   }
+
   # none found, return NULL
   NULL
 }

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -2,37 +2,7 @@
 #'
 #' Formats for converting from R Markdown to a PDF or LaTeX document.
 #'
-#' @inheritParams html_document
-#'
-#' @param fig_crop \code{TRUE} to automatically apply the \code{pdfcrop} utility
-#'   (if available) to pdf figures
-#' @param dev Graphics device to use for figure output (defaults to pdf)
-#' @param highlight Syntax highlighting style. Supported styles include
-#'   "default", "tango", "pygments", "kate", "monochrome", "espresso",
-#'   "zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.
-#' @param keep_tex Keep the intermediate tex file used in the conversion to PDF
-#' @param latex_engine LaTeX engine for producing PDF output. Options are
-#'   "pdflatex", "lualatex", and "xelatex".
-#' @param citation_package The LaTeX package to process citations, \code{natbib}
-#'   or \code{biblatex}. Use \code{none} if neither package is to be used.
-#' @param template Pandoc template to use for rendering. Pass "default" to use
-#'   the rmarkdown package default template; pass \code{NULL} to use pandoc's
-#'   built-in template; pass a path to use a custom template that you've
-#'   created.  See the documentation on
-#'   \href{http://pandoc.org/README.html}{pandoc online documentation}
-#'   for details on creating custom templates.
-#' @param extra_dependencies A LaTeX dependency \code{latex_dependency()}, a
-#'   list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
-#'   \code{c("framed", "hyperref")}), or a named list of LaTeX package options
-#'   with the names being package names (e.g. \code{list(hypreref =
-#'   c("unicode=true", "breaklinks=true"), lmodern = NULL)}). It can be used to
-#'   add custom LaTeX packages to the .tex header.
-#'
-#' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
-#' See the \href{http://rmarkdown.rstudio.com/pdf_document_format.html}{online
+#' See the \href{https://rmarkdown.rstudio.com/pdf_document_format.html}{online
 #' documentation} for additional details on using the \code{pdf_document} format.
 #'
 #' Creating PDF output from R Markdown requires that LaTeX be installed.
@@ -43,7 +13,7 @@
 #'
 #' R Markdown documents also support citations. You can find more information on
 #' the markdown syntax for citations in the
-#' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #' and Citations} article in the online documentation.
 #'
 #' Many aspects of the LaTeX template used to create PDF documents can be
@@ -69,10 +39,33 @@
 #'    \item{\code{linkcolor, urlcolor, citecolor}}{Color for internal, external, and citation links (red, green, magenta, cyan, blue, black)}
 #'    \item{\code{linestretch}}{Options for line spacing (e.g. 1, 1.5, 3)}
 #' }
-#'
+#' @inheritParams html_document
+#' @param fig_crop \code{TRUE} to automatically apply the \code{pdfcrop} utility
+#'   (if available) to pdf figures
+#' @param dev Graphics device to use for figure output (defaults to pdf)
+#' @param highlight Syntax highlighting style. Supported styles include
+#'   "default", "tango", "pygments", "kate", "monochrome", "espresso",
+#'   "zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.
+#' @param keep_tex Keep the intermediate tex file used in the conversion to PDF
+#' @param latex_engine LaTeX engine for producing PDF output. Options are
+#'   "pdflatex", "lualatex", and "xelatex".
+#' @param citation_package The LaTeX package to process citations, \code{natbib}
+#'   or \code{biblatex}. Use \code{none} if neither package is to be used.
+#' @param template Pandoc template to use for rendering. Pass "default" to use
+#'   the rmarkdown package default template; pass \code{NULL} to use pandoc's
+#'   built-in template; pass a path to use a custom template that you've
+#'   created.  See the documentation on
+#'   \href{http://pandoc.org/README.html}{pandoc online documentation}
+#'   for details on creating custom templates.
+#' @param extra_dependencies A LaTeX dependency \code{latex_dependency()}, a
+#'   list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
+#'   \code{c("framed", "hyperref")}), or a named list of LaTeX package options
+#'   with the names being package names (e.g. \code{list(hypreref =
+#'   c("unicode=true", "breaklinks=true"), lmodern = NULL)}). It can be used to
+#'   add custom LaTeX packages to the .tex header.
+#' @return R Markdown output format to pass to \code{\link{render}}
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' # simple invocation
@@ -84,7 +77,6 @@
 #' # add a table of contents and pass an option to pandoc
 #' render("input.Rmd", pdf_document(toc = TRUE, "--listings"))
 #' }
-#'
 #' @export
 pdf_document <- function(toc = FALSE,
                          toc_depth = 2,
@@ -226,6 +218,7 @@ pdf_document <- function(toc = FALSE,
 
 pdf_intermediates_generator <- function(saved_files_dir, original_input,
                                         encoding, intermediates_dir) {
+
   # copy all intermediates (pandoc will need to bundle them in the PDF)
   intermediates <- copy_render_intermediates(original_input, encoding,
                                              intermediates_dir, FALSE)

--- a/R/rtf_document.R
+++ b/R/rtf_document.R
@@ -2,15 +2,7 @@
 #'
 #' Format for converting from R Markdown to an RTF document.
 #'
-#' @inheritParams pdf_document
-#' @inheritParams html_document
-#' @inheritParams word_document
-#'
-#' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
-#' See the \href{http://rmarkdown.rstudio.com/rtf_document_format.html}{online
+#' See the \href{https://rmarkdown.rstudio.com/rtf_document_format.html}{online
 #' documentation} for additional details on using the \code{rtf_document} format.
 #'
 #' R Markdown documents can have optional metadata that is used to generate a
@@ -19,9 +11,12 @@
 #'
 #' R Markdown documents also support citations. You can find more information on
 #' the markdown syntax for citations in the
-#' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #' and Citations} article in the online documentation.
-#'
+#' @inheritParams pdf_document
+#' @inheritParams html_document
+#' @inheritParams word_document
+#' @return R Markdown output format to pass to \code{\link{render}}
 #' @examples
 #' \dontrun{
 #'
@@ -33,7 +28,6 @@
 #' # specify table of contents option
 #' render("input.Rmd", rtf_document(toc = TRUE))
 #' }
-#'
 #' @export
 rtf_document <- function(toc = FALSE,
                          toc_depth = 3,

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -2,6 +2,36 @@
 #'
 #' Start a Shiny server for the given document, and render it for display.
 #'
+#' The \code{run} function runs a Shiny document by starting a Shiny
+#' server associated with the document. The \code{shiny_args} parameter can be
+#' used to configure the server; see the \code{\link[shiny:runApp]{runApp}}
+#' documentation for details.
+#'
+#' Once the server is started, the document will be rendered using
+#' \code{\link{render}}. The server will initiate a render of the document
+#' whenever necessary, so it is not necessary to call \code{run} every time
+#' the document changes: if \code{auto_reload} is \code{TRUE}, saving the
+#' document will trigger a render. You can also manually trigger a render by
+#' reloading the document in a Web browser.
+#'
+#' The server will render any R Markdown (\code{.Rmd}) document in \code{dir};
+#' the \code{file} argument specifies only the initial document to be
+#' rendered and viewed. You can therefore link to other documents in the
+#' directory using standard Markdown syntax, e.g.
+#' \code{[Analysis Page 2](page2.Rmd)}.
+#'
+#' If \code{default_file} is not specified, nor is a file specified on the
+#' URL, then the default document to serve at \code{/} is chosen from (in
+#' order of preference):
+#' \itemize{
+#'   \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
+#'   \item{The file \code{index.Rmd}, if it exists in \code{dir}}
+#'   \item{The file \code{index.html}, if it exists in \code{dir}}
+#' }
+#'
+#' If you wish to share R code between your documents, place it in a file
+#' named \code{global.R} in \code{dir}; it will be sourced into the global
+#' environment.
 #' @param file Path to the R Markdown document to launch in a web browser.
 #'   Defaults to \code{index.Rmd} in the current working directory, but may be
 #'   \code{NULL} to skip launching a browser.
@@ -13,40 +43,7 @@
 #'   Shiny application when the file currently being viewed is changed on disk.
 #' @param shiny_args Additional arguments to \code{\link[shiny:runApp]{runApp}}.
 #' @param render_args Additional arguments to \code{\link{render}}.
-#'
 #' @return Invisible NULL.
-#'
-#' @details The \code{run} function runs a Shiny document by starting a Shiny
-#'   server associated with the document. The \code{shiny_args} parameter can be
-#'   used to configure the server; see the \code{\link[shiny:runApp]{runApp}}
-#'   documentation for details.
-#'
-#'   Once the server is started, the document will be rendered using
-#'   \code{\link{render}}. The server will initiate a render of the document
-#'   whenever necessary, so it is not necessary to call \code{run} every time
-#'   the document changes: if \code{auto_reload} is \code{TRUE}, saving the
-#'   document will trigger a render. You can also manually trigger a render by
-#'   reloading the document in a Web browser.
-#'
-#'   The server will render any R Markdown (\code{.Rmd}) document in \code{dir};
-#'   the \code{file} argument specifies only the initial document to be
-#'   rendered and viewed. You can therefore link to other documents in the
-#'   directory using standard Markdown syntax, e.g.
-#'   \code{[Analysis Page 2](page2.Rmd)}.
-#'
-#'   If \code{default_file} is not specified, nor is a file specified on the
-#'   URL, then the default document to serve at \code{/} is chosen from (in
-#'   order of preference):
-#'   \itemize{
-#'     \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
-#'     \item{The file \code{index.Rmd}, if it exists in \code{dir}}
-#'     \item{The file \code{index.html}, if it exists in \code{dir}}
-#'   }
-#'
-#'   If you wish to share R code between your documents, place it in a file
-#'   named \code{global.R} in \code{dir}; it will be sourced into the global
-#'   environment.
-#'
 #' @note Unlike \code{\link{render}}, \code{run} does not render the document to
 #'   a file on disk. In most cases a Web browser will be started automatically
 #'   to view the document; see \code{launch.browser} in the
@@ -56,20 +53,21 @@
 #'   R Markdown file to view in the URL (e.g.
 #'   \code{http://127.0.0.1:1234/foo.Rmd}). A URL without a filename will show
 #'   the \code{default_file} as described above.
-#'
 #' @examples
 #' \dontrun{
-#'
 #' # Run the Shiny document "index.Rmd" in the current directory
 #' rmarkdown::run()
 #'
 #' # Run the Shiny document "shiny_doc.Rmd" on port 8241
 #' rmarkdown::run("shiny_doc.Rmd", shiny_args = list(port = 8241))
-#'
 #' }
 #' @export
-run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
-                auto_reload = TRUE, shiny_args = NULL, render_args = NULL) {
+run <- function(file = "index.Rmd",
+                dir = dirname(file),
+                default_file = NULL,
+                auto_reload = TRUE,
+                shiny_args = NULL,
+                render_args = NULL) {
 
   # select the document to serve at the root URL if not user-specified. We exclude
   # documents which start with a leading underscore (same pattern is used to
@@ -522,17 +520,14 @@ file.path.ci <- function(dir, name) {
 #' In a Shiny document, evaluate the given expression after the document has
 #' finished rendering, instead of during render.
 #'
+#' This function is useful inside Shiny documents. It delays the
+#' evaluation of its argument until the document has finished its initial
+#' render, so that the document can be viewed before the calculation is
+#' finished.
+#'
+#' Any expression that returns HTML can be wrapped in \code{render_delayed}.
 #' @param expr The expression to evaluate.
-#'
 #' @return An object representing the expression.
-#'
-#' @details This function is useful inside Shiny documents. It delays the
-#'   evaluation of its argument until the document has finished its initial
-#'   render, so that the document can be viewed before the calculation is
-#'   finished.
-#'
-#'   Any expression that returns HTML can be wrapped in \code{render_delayed}.
-#'
 #' @note \code{expr} is evaluated in a \strong{copy} of the environment in which
 #'   the \code{render_delayed} call appears. Consequently, no side effects
 #'   created by \code{expr} are visible in succeeding expressions, nor are
@@ -540,10 +535,8 @@ file.path.ci <- function(dir, name) {
 #'   to \code{expr}.
 #'
 #'   \code{expr} must be an expression that produces HTML.
-#'
 #' @examples
 #' \dontrun{
-#'
 #' # Add the following code to an R Markdown document
 #'
 #' div(Sys.time())
@@ -555,9 +548,9 @@ file.path.ci <- function(dir, name) {
 #'
 #' div(Sys.time())
 #' }
-#'
 #' @export
 render_delayed <- function(expr) {
+
   # take a snapshot of the environment in which the expr should be rendered
   env <- parent.frame()
   env_snapshot <- new.env(parent = parent.env(env))
@@ -593,7 +586,9 @@ is_shiny_prerendered <- function(runtime) {
   identical(runtime, "shiny_prerendered")
 }
 
-write_shiny_deps <- function(files_dir, deps) {
+write_shiny_deps <- function(files_dir,
+                             deps) {
+
   if (!dir_exists(files_dir))
     dir.create(files_dir, recursive = TRUE)
   deps_file <- file.path(files_dir, "dependencies.json")
@@ -613,8 +608,7 @@ read_shiny_deps <- function(files_dir) {
 
     # return
     dependencies
-  }
-  else {
+  } else {
     list()
   }
 }

--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -1,12 +1,16 @@
-
 #' Convert to a slidy presentation
 #'
 #' Format for converting from R Markdown to a slidy presentation.
 #'
+#' See the \href{https://rmarkdown.rstudio.com/slidy_presentation_format.html}{online
+#' documentation} for additional details on using the \code{slidy_presentation}
+#' format.
+#'
+#' For more information on markdown syntax for presentations see the
+#' \href{https://pandoc.org/README.html}{pandoc online documentation}.
 #' @inheritParams pdf_document
 #' @inheritParams html_document
 #' @inheritParams beamer_presentation
-#'
 #' @param duration Duration (in minutes) of the slide deck. This value is used
 #'   to add a countdown timer to the slide footer.
 #' @param footer Footer text (e.g. organization name and/or copyright)
@@ -15,22 +19,9 @@
 #'   using the 'S' (smaller) and 'B' (bigger) keys.
 #' @param ... Additional function arguments to pass to the base R Markdown HTML
 #'   output formatter \code{\link{html_document_base}}
-#'
 #' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
-#' See the
-#' \href{http://rmarkdown.rstudio.com/slidy_presentation_format.html}{online
-#' documentation} for additional details on using the \code{slidy_presentation}
-#' format.
-#'
-#' For more information on markdown syntax for presentations see the
-#' \href{http://pandoc.org/README.html}{pandoc online documentation}.
-#'
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' # simple invocation
@@ -39,7 +30,6 @@
 #' # specify an option for incremental rendering
 #' render("pres.Rmd", slidy_presentation(incremental = TRUE))
 #' }
-#'
 #' @export
 slidy_presentation <- function(incremental = FALSE,
                                duration = NULL,
@@ -150,7 +140,6 @@ slidy_presentation <- function(incremental = FALSE,
                                      ...))
 }
 
-
 html_dependency_slidy <- function() {
   htmlDependency(
     name = "slidy",
@@ -160,4 +149,3 @@ html_dependency_slidy <- function() {
     stylesheet = "styles/slidy.css"
   )
 }
-

--- a/R/tufte_handout.R
+++ b/R/tufte_handout.R
@@ -1,12 +1,9 @@
-
 #' Tufte handout format (PDF)
 #'
 #' Template for creating a handout according to the style of
 #' Edward R. Tufte and Richard Feynman.
-#' @inheritParams pdf_document
-#' @details
-#' See the
-#' \href{https://rmarkdown.rstudio.com/tufte_handout_format.html}{online
+#'
+#' See the \href{https://rmarkdown.rstudio.com/tufte_handout_format.html}{online
 #' documentation} for additional details.
 #'
 #' Creating Tufte handout output from R Markdown requires that LaTeX be installed.
@@ -17,8 +14,9 @@
 #'
 #' R Markdown documents also support citations. You can find more information on
 #' the markdown syntax for citations in the
-#' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #' and Citations} article in the online documentation.
+#' @inheritParams pdf_document
 #' @export
 tufte_handout <- function(fig_width = 4,
                           fig_height = 2.5,

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -2,19 +2,7 @@
 #'
 #' Format for converting from R Markdown to an MS Word document.
 #'
-#' @inheritParams pdf_document
-#' @inheritParams html_document
-#'
-#' @param reference_docx Use the specified file as a style reference in
-#'   producing a docx file. For best results, the reference docx should be a
-#'   modified version of a docx file produced using pandoc. Pass "default"
-#'   to use the rmarkdown default styles.
-#'
-#' @return R Markdown output format to pass to \code{\link{render}}
-#'
-#' @details
-#'
-#' See the \href{http://rmarkdown.rstudio.com/word_document_format.html}{online
+#' See the \href{https://rmarkdown.rstudio.com/word_document_format.html}{online
 #' documentation} for additional details on using the \code{word_document} format.
 #'
 #' R Markdown documents can have optional metadata that is used to generate a
@@ -23,12 +11,17 @@
 #'
 #' R Markdown documents also support citations. You can find more information on
 #' the markdown syntax for citations in the
-#' \href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+#' \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 #' and Citations} article in the online documentation.
-#'
+#' @inheritParams pdf_document
+#' @inheritParams html_document
+#' @param reference_docx Use the specified file as a style reference in
+#'   producing a docx file. For best results, the reference docx should be a
+#'   modified version of a docx file produced using pandoc. Pass "default"
+#'   to use the rmarkdown default styles.
+#' @return R Markdown output format to pass to \code{\link{render}}
 #' @examples
 #' \dontrun{
-#'
 #' library(rmarkdown)
 #'
 #' # simple invocation
@@ -37,7 +30,6 @@
 #' # specify an option for syntax highlighting
 #' render("input.Rmd", word_document(highlight = "zenburn"))
 #' }
-#'
 #' @export
 word_document <- function(toc = FALSE,
                           toc_depth = 3,

--- a/man/all_output_formats.Rd
+++ b/man/all_output_formats.Rd
@@ -9,7 +9,7 @@ all_output_formats(input, encoding = getOption("encoding"))
 \arguments{
 \item{input}{Input file (Rmd or plain markdown)}
 
-\item{encoding}{The encoding of the input file; see \code{\link{file}}}
+\item{encoding}{The encoding of the input file; see \code{\link{file}}.}
 }
 \value{
 A character vector with the names of all output formats.

--- a/man/beamer_presentation.Rd
+++ b/man/beamer_presentation.Rd
@@ -94,8 +94,7 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to a Beamer presentation.
 }
 \details{
-See the
-\href{http://rmarkdown.rstudio.com/beamer_presentation_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/beamer_presentation_format.html}{online
 documentation} for additional details on using the \code{beamer_presentation}
 format.
 
@@ -107,7 +106,7 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }
 \examples{
@@ -121,5 +120,4 @@ render("pres.Rmd", beamer_presentation())
 # specify an option for incremental rendering
 render("pres.Rmd", beamer_presentation(incremental = TRUE))
 }
-
 }

--- a/man/draft.Rd
+++ b/man/draft.Rd
@@ -22,7 +22,7 @@ template).}
 \item{edit}{\code{TRUE} to edit the template immediately}
 }
 \value{
-The file name of the new document (invisibly)
+The file name of the new document (invisibly).
 }
 \description{
 Create (and optionally edit) a draft of an R Markdown document based on a
@@ -30,9 +30,9 @@ template.
 }
 \details{
 The \code{draft} function creates new R Markdown documents based on
-  templates that are either located on the filesystem or within an R package.
-  The template and it's supporting files will be copied to the location
-  specified by \code{file}.
+templates that are either located on the filesystem or within an R package.
+The template and it's supporting files will be copied to the location
+specified by \code{file}.
 }
 \note{
 An R Markdown template consists of a directory that contains a
@@ -67,7 +67,6 @@ An R Markdown template consists of a directory that contains a
 }
 \examples{
 \dontrun{
-
 rmarkdown::draft("Q4Report.Rmd",
                  template="/opt/rmd/templates/quarterly_report")
 

--- a/man/find_external_resources.Rd
+++ b/man/find_external_resources.Rd
@@ -27,18 +27,18 @@ additional files needed in order to render and display the document.
 }
 \details{
 This routine applies heuristics in order to scan a document for
-  possible resource references.
+possible resource references.
 
-  In R Markdown documents, it looks for references to files implicitly
-  referenced in Markdown (e.g. \code{![alt](img.png)}), in the document's
-  YAML header, in raw HTML chunks, and as quoted strings in R code chunks
-  (e.g. \code{read.csv("data.csv")}).
+In R Markdown documents, it looks for references to files implicitly
+referenced in Markdown (e.g. \code{![alt](img.png)}), in the document's
+YAML header, in raw HTML chunks, and as quoted strings in R code chunks
+(e.g. \code{read.csv("data.csv")}).
 
-  Resources specified explicitly in the YAML header for R Markdown documents
-  are also returned. To specify resources in YAML, use the
-  \code{resource_files} key:
+Resources specified explicitly in the YAML header for R Markdown
+documents are also returned. To specify resources in YAML, use the
+\code{resource_files} key:
 
-  \preformatted{---
+\preformatted{---
 title: My Document
 author: My Name
 resource_files:
@@ -46,20 +46,20 @@ resource_files:
  - images/figure.png
 ---}
 
-  Each item in the \code{resource_files} list can refer to:
-  \enumerate{
-  \item A single file, such as \code{images/figure.png}, or
-  \item A directory, such as \code{resources/data}, in which case all of the
-    directory's content will be recursively included, or
-  \item A wildcard pattern, such as \code{data/*.csv}, in which case all of
-    the files matching the pattern will be included. No recursion is done in
-    this case.
-  }
+Each item in the \code{resource_files} list can refer to:
+\enumerate{
+\item A single file, such as \code{images/figure.png}, or
+\item A directory, such as \code{resources/data}, in which case all of the
+  directory's content will be recursively included, or
+\item A wildcard pattern, such as \code{data/*.csv}, in which case all of
+  the files matching the pattern will be included. No recursion is done in
+  this case.
+}
 
-  In HTML files (and raw HTML chunks in R Markdown documents), this routine
-  searches for resources specified in common tag attributes, such as
-  \code{<img src="...">}, \code{<link href="...">}, etc.
+In HTML files (and raw HTML chunks in R Markdown documents), this routine
+searches for resources specified in common tag attributes, such as
+\code{<img src="...">}, \code{<link href="...">}, etc.
 
-  In all cases, only resources that exist on disk and are contained in the
-  document's directory (or a child thereof) are returned.
+In all cases, only resources that exist on disk and are contained in the
+document's directory (or a child thereof) are returned.
 }

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -53,8 +53,7 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to GitHub Flavored Markdown.
 }
 \details{
-See the
-\href{http://rmarkdown.rstudio.com/github_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online
 documentation} for additional details on using the \code{github_document}
 format.
 }

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -234,12 +234,10 @@ and Citations} article in the online documentation.
 
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 render("input.Rmd", html_document())
 
 render("input.Rmd", html_document(toc = TRUE))
 }
-
 }

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -123,7 +123,7 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to an HTML document.
 }
 \details{
-See the \href{http://rmarkdown.rstudio.com/html_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/html_document_format.html}{online
 documentation} for additional details on using the \code{html_document}
 format.
 
@@ -133,7 +133,7 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }
 \section{Navigation Bars}{

--- a/man/html_fragment.Rd
+++ b/man/html_fragment.Rd
@@ -72,7 +72,7 @@ assumes you will include the output into an existing document (e.g. a blog
 post).
 }
 \details{
-See the \href{http://rmarkdown.rstudio.com/html_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/html_document_format.html}{online
 documentation} for additional details on using the \code{html_fragment}
 format.
 }

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -92,6 +92,7 @@ base R Markdown HTML output formatter \code{\link{html_document_base}}}
 Format for converting from R Markdown to an HTML notebook.
 }
 \details{
-For more details on the HTML file format produced by
- \code{html_notebook}, see \href{http://rmarkdown.rstudio.com/r_notebook_format.html}{http://rmarkdown.rstudio.com/r_notebook_format.html}.
+See the \href{https://rmarkdown.rstudio.com/r_notebook_format.html}{online
+documentation} for additional details on using the \code{html_notebook}
+format.
 }

--- a/man/html_notebook_output.Rd
+++ b/man/html_notebook_output.Rd
@@ -47,6 +47,7 @@ through the \code{output_source} function attached to a
 \code{\link{output_format}}.
 }
 \details{
-For more details on the HTML file format produced by
- \code{html_notebook}, see \href{http://rmarkdown.rstudio.com/r_notebook_format.html}{http://rmarkdown.rstudio.com/r_notebook_format.html}.
+See the \href{https://rmarkdown.rstudio.com/r_notebook_format.html}{online
+documentation} for additional details on using the \code{html_notebook}
+format.
 }

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/html_vignette.R
 \name{html_vignette}
 \alias{html_vignette}
-\title{Convert to an HTML vignette.}
+\title{Convert to an HTML vignette}
 \usage{
 html_vignette(fig_width = 3, fig_height = 3, dev = "png",
   df_print = "default", css = NULL, keep_md = FALSE, readme = FALSE,
@@ -57,8 +57,6 @@ Compared to \code{html_document}, it:
   \item uses a custom highlight scheme
  }
 
-
-
-See the \href{http://rmarkdown.rstudio.com/package_vignette_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/package_vignette_format.html}{online
 documentation} for additional details on using the \code{html_vignette} format.
 }

--- a/man/includes.Rd
+++ b/man/includes.Rd
@@ -31,17 +31,15 @@ Specify additional content to be included within an output document.
 }
 \details{
 Non-absolute paths for resources referenced from the
-  \code{in_header}, \code{before_body}, and \code{after_body}
-  parameters are resolved relative to the directory of the input document.
+\code{in_header}, \code{before_body}, and \code{after_body}
+parameters are resolved relative to the directory of the input document.
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 html_document(includes = includes(before_body = "header.htm"))
 
 pdf_document(includes = includes(after_body = "footer.tex"))
-
 }
 }

--- a/man/knitr_options.Rd
+++ b/man/knitr_options.Rd
@@ -24,8 +24,8 @@ knitr_options(opts_knit = NULL, opts_chunk = NULL, knit_hooks = NULL,
 \code{\link[knitr:opts_template]{opts_template}})}
 }
 \value{
-An list that can be passed as the \code{knitr} argument of the
-  \code{\link{output_format}} function.
+An list that can be passed as the \code{knitr} argument
+  of the \code{\link{output_format}} function.
 }
 \description{
 Define the knitr options for an R Markdown output format.

--- a/man/knitr_options_pdf.Rd
+++ b/man/knitr_options_pdf.Rd
@@ -21,7 +21,8 @@ An list that can be passed as the \code{knitr} argument of the
   \code{\link{output_format}} function.
 }
 \description{
-Define knitr options for an R Markdown output format that creates PDF output.
+Define knitr options for an R Markdown output format
+that creates PDF output.
 }
 \seealso{
 \link{knitr_options}, \link{output_format}

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -77,12 +77,10 @@ and Citations} article in the online documentation.
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 render("input.Rmd", md_document())
 
 render("input.Rmd", md_document(variant = "markdown_github"))
 }
-
 }

--- a/man/odt_document.Rd
+++ b/man/odt_document.Rd
@@ -45,7 +45,7 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to an ODT document.
 }
 \details{
-See the \href{http://rmarkdown.rstudio.com/odt_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/odt_document_format.html}{online
 documentation} for additional details on using the \code{odt_document} format.
 
 R Markdown documents can have optional metadata that is used to generate a
@@ -54,12 +54,11 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 # simple invocation
@@ -68,5 +67,4 @@ render("input.Rmd", odt_document())
 # specify an option for syntax highlighting
 render("input.Rmd", odt_document(highlight = "zenburn"))
 }
-
 }

--- a/man/output_format.Rd
+++ b/man/output_format.Rd
@@ -72,15 +72,14 @@ An R Markdown output format definition that can be passed to
   \code{\link{render}}.
 }
 \description{
-Define an R Markdown output format based on a combination of knitr and pandoc
-options.
+Define an R Markdown output format based on a combination of
+knitr and pandoc options.
 }
 \examples{
 \dontrun{
 output_format(knitr = knitr_options(opts_chunk = list(dev = 'png')),
               pandoc = pandoc_options(to = "html"))
 }
-
 }
 \seealso{
 \link{render}, \link{knitr_options}, \link{pandoc_options}

--- a/man/pandoc_args.Rd
+++ b/man/pandoc_args.Rd
@@ -47,21 +47,20 @@ is specified.}
 \item{toc_depth}{Depth of headers to include in table of contents.}
 }
 \value{
-A character vector with pandoc command line arguments
+A character vector with pandoc command line arguments.
 }
 \description{
 Functions that assist in creating various types of pandoc command line
 arguments (e.g. for templates, table of contents, highlighting, and content
-includes)
+includes).
 }
 \details{
 Non-absolute paths for resources referenced from the
-  \code{in_header}, \code{before_body}, and \code{after_body}
-  parameters are resolved relative to the directory of the input document.
+\code{in_header}, \code{before_body}, and \code{after_body}
+parameters are resolved relative to the directory of the input document.
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 pandoc_include_args(before_body = "header.htm")
@@ -72,6 +71,5 @@ pancoc_highlight_args("kate")
 pandoc_latex_engine_args("pdflatex")
 
 pandoc_toc_args(toc = TRUE, toc_depth = 2)
-
 }
 }

--- a/man/pandoc_convert.Rd
+++ b/man/pandoc_convert.Rd
@@ -18,28 +18,28 @@ pandoc_convert(input, to = NULL, from = NULL, output = NULL,
 determined based on the file extension of \code{input}).}
 
 \item{output}{Output file (if not specified then determined based on format
-being converted to)}
+being converted to).}
 
 \item{citeproc}{\code{TRUE} to run the pandoc-citeproc filter (for processing
-citations) as part of the conversion}
+citations) as part of the conversion.}
 
 \item{options}{Character vector of command line options to pass to pandoc.}
 
 \item{verbose}{\code{TRUE} to show the pandoc command line which was executed}
 
 \item{wd}{Working directory in which code will be executed. If not
-supplied, defaults to the common base directory of \code{input}}
+supplied, defaults to the common base directory of \code{input}.}
 }
 \description{
 Convert documents to and from various formats using the pandoc utility.
 }
 \details{
 Supported input and output formats are described in the
-  \href{http://johnmacfarlane.net/pandoc/README.html}{pandoc user guide}.
+\href{http://johnmacfarlane.net/pandoc/README.html}{pandoc user guide}.
 
-  The system path as well as the version of pandoc shipped with RStudio (if
-  running under RStudio) are scanned for pandoc and the highest version
-  available is used.
+The system path as well as the version of pandoc shipped with RStudio (if
+running under RStudio) are scanned for pandoc and the highest version
+available is used.
 }
 \examples{
 \dontrun{
@@ -55,5 +55,4 @@ pandoc_convert("input.md", to = "html", citeproc = TRUE)
 # add some pandoc options
 pandoc_convert("input.md", to="pdf", options = c("--listings"))
 }
-
 }

--- a/man/pandoc_options.Rd
+++ b/man/pandoc_options.Rd
@@ -35,8 +35,8 @@ Define the pandoc options for an R Markdown output format.
 }
 \details{
 The \code{from} argument should be used very cautiously as it's
-  important for users to be able to rely on a stable definition of supported
-  markdown extensions.
+important for users to be able to rely on a stable definition of supported
+markdown extensions.
 }
 \seealso{
 \link{output_format}, \link{rmarkdown_format}

--- a/man/pandoc_path_arg.Rd
+++ b/man/pandoc_path_arg.Rd
@@ -10,15 +10,15 @@ pandoc_path_arg(path, backslash = TRUE)
 \item{path}{Path to transform}
 
 \item{backslash}{Whether to replace forward slashes in \code{path} with
-backslashes on Windows}
+backslashes on Windows.}
 }
 \value{
-Transformed path that can be passed to pandoc on the command line
+Transformed path that can be passed to pandoc on the command line.
 }
 \description{
 Transform a path for passing to pandoc on the command line. Calls
 \code{\link[base:path.expand]{path.expand}} on all platforms. On Windows,
 transform it to a short path name if it contains spaces, and then convert
 forward slashes to back slashes (as required by pandoc for some path
-references)
+references).
 }

--- a/man/parse_html_notebook.Rd
+++ b/man/parse_html_notebook.Rd
@@ -17,6 +17,7 @@ related to generated outputs in the document, as well as the
 original R Markdown source document.
 }
 \details{
-For more details on the HTML file format produced by
- \code{html_notebook}, see \href{http://rmarkdown.rstudio.com/r_notebook_format.html}{http://rmarkdown.rstudio.com/r_notebook_format.html}.
+See the \href{https://rmarkdown.rstudio.com/r_notebook_format.html}{online
+documentation} for additional details on using the \code{html_notebook}
+format.
 }

--- a/man/pdf_document.Rd
+++ b/man/pdf_document.Rd
@@ -91,7 +91,7 @@ R Markdown output format to pass to \code{\link{render}}
 Formats for converting from R Markdown to a PDF or LaTeX document.
 }
 \details{
-See the \href{http://rmarkdown.rstudio.com/pdf_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/pdf_document_format.html}{online
 documentation} for additional details on using the \code{pdf_document} format.
 
 Creating PDF output from R Markdown requires that LaTeX be installed.
@@ -102,7 +102,7 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 
 Many aspects of the LaTeX template used to create PDF documents can be
@@ -131,7 +131,6 @@ Available metadata variables include:
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 # simple invocation
@@ -143,5 +142,4 @@ render("input.Rmd", pdf_document(latex_engine = "lualatex"))
 # add a table of contents and pass an option to pandoc
 render("input.Rmd", pdf_document(toc = TRUE, "--listings"))
 }
-
 }

--- a/man/render_delayed.Rd
+++ b/man/render_delayed.Rd
@@ -18,11 +18,11 @@ finished rendering, instead of during render.
 }
 \details{
 This function is useful inside Shiny documents. It delays the
-  evaluation of its argument until the document has finished its initial
-  render, so that the document can be viewed before the calculation is
-  finished.
+evaluation of its argument until the document has finished its initial
+render, so that the document can be viewed before the calculation is
+finished.
 
-  Any expression that returns HTML can be wrapped in \code{render_delayed}.
+Any expression that returns HTML can be wrapped in \code{render_delayed}.
 }
 \note{
 \code{expr} is evaluated in a \strong{copy} of the environment in which
@@ -35,7 +35,6 @@ This function is useful inside Shiny documents. It delays the
 }
 \examples{
 \dontrun{
-
 # Add the following code to an R Markdown document
 
 div(Sys.time())
@@ -47,5 +46,4 @@ render_delayed({
 
 div(Sys.time())
 }
-
 }

--- a/man/resolve_output_format.Rd
+++ b/man/resolve_output_format.Rd
@@ -16,7 +16,7 @@ the default format for the input file).}
 \item{output_options}{List of output options that should override the
 options specified in metadata.}
 
-\item{encoding}{The encoding of the input file; see \code{\link{file}}}
+\item{encoding}{The encoding of the input file; see \code{\link{file}}.}
 }
 \value{
 An R Markdown output format definition that can be passed to

--- a/man/rmarkdown_format.Rd
+++ b/man/rmarkdown_format.Rd
@@ -19,8 +19,8 @@ default definition of R Markdown.}
 Pandoc markdown format specification
 }
 \description{
-Compose a pandoc markdown input definition for R Markdown that can be
-passed as the \code{from} argument of \link{pandoc_options}.
+Compose a pandoc markdown input definition for R Markdown
+that can be passed as the \code{from} argument of \link{pandoc_options}.
 }
 \details{
 By default R Markdown is defined as all pandoc markdown extensions with
@@ -33,14 +33,13 @@ the following tweaks for backward compatibility with the markdown package
 \code{+tex_math_single_backslash} \cr
 }
 
-
-For more on pandoc markdown see the \href{http://pandoc.org/README.html}{pandoc online documentation}.
+For more on pandoc markdown see the
+\href{http://pandoc.org/README.html}{pandoc online documentation}.
 }
 \examples{
 \dontrun{
 rmarkdown_format("-implicit_figures")
 }
-
 }
 \seealso{
 \link{output_format}, \link{pandoc_options}

--- a/man/rtf_document.Rd
+++ b/man/rtf_document.Rd
@@ -31,7 +31,7 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to an RTF document.
 }
 \details{
-See the \href{http://rmarkdown.rstudio.com/rtf_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/rtf_document_format.html}{online
 documentation} for additional details on using the \code{rtf_document} format.
 
 R Markdown documents can have optional metadata that is used to generate a
@@ -40,7 +40,7 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }
 \examples{
@@ -54,5 +54,4 @@ render("input.Rmd", rtf_document())
 # specify table of contents option
 render("input.Rmd", rtf_document(toc = TRUE))
 }
-
 }

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -33,35 +33,35 @@ Start a Shiny server for the given document, and render it for display.
 }
 \details{
 The \code{run} function runs a Shiny document by starting a Shiny
-  server associated with the document. The \code{shiny_args} parameter can be
-  used to configure the server; see the \code{\link[shiny:runApp]{runApp}}
-  documentation for details.
+server associated with the document. The \code{shiny_args} parameter can be
+used to configure the server; see the \code{\link[shiny:runApp]{runApp}}
+documentation for details.
 
-  Once the server is started, the document will be rendered using
-  \code{\link{render}}. The server will initiate a render of the document
-  whenever necessary, so it is not necessary to call \code{run} every time
-  the document changes: if \code{auto_reload} is \code{TRUE}, saving the
-  document will trigger a render. You can also manually trigger a render by
-  reloading the document in a Web browser.
+Once the server is started, the document will be rendered using
+\code{\link{render}}. The server will initiate a render of the document
+whenever necessary, so it is not necessary to call \code{run} every time
+the document changes: if \code{auto_reload} is \code{TRUE}, saving the
+document will trigger a render. You can also manually trigger a render by
+reloading the document in a Web browser.
 
-  The server will render any R Markdown (\code{.Rmd}) document in \code{dir};
-  the \code{file} argument specifies only the initial document to be
-  rendered and viewed. You can therefore link to other documents in the
-  directory using standard Markdown syntax, e.g.
-  \code{[Analysis Page 2](page2.Rmd)}.
+The server will render any R Markdown (\code{.Rmd}) document in \code{dir};
+the \code{file} argument specifies only the initial document to be
+rendered and viewed. You can therefore link to other documents in the
+directory using standard Markdown syntax, e.g.
+\code{[Analysis Page 2](page2.Rmd)}.
 
-  If \code{default_file} is not specified, nor is a file specified on the
-  URL, then the default document to serve at \code{/} is chosen from (in
-  order of preference):
-  \itemize{
-    \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
-    \item{The file \code{index.Rmd}, if it exists in \code{dir}}
-    \item{The file \code{index.html}, if it exists in \code{dir}}
-  }
+If \code{default_file} is not specified, nor is a file specified on the
+URL, then the default document to serve at \code{/} is chosen from (in
+order of preference):
+\itemize{
+  \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
+  \item{The file \code{index.Rmd}, if it exists in \code{dir}}
+  \item{The file \code{index.html}, if it exists in \code{dir}}
+}
 
-  If you wish to share R code between your documents, place it in a file
-  named \code{global.R} in \code{dir}; it will be sourced into the global
-  environment.
+If you wish to share R code between your documents, place it in a file
+named \code{global.R} in \code{dir}; it will be sourced into the global
+environment.
 }
 \note{
 Unlike \code{\link{render}}, \code{run} does not render the document to
@@ -76,12 +76,10 @@ Unlike \code{\link{render}}, \code{run} does not render the document to
 }
 \examples{
 \dontrun{
-
 # Run the Shiny document "index.Rmd" in the current directory
 rmarkdown::run()
 
 # Run the Shiny document "shiny_doc.Rmd" on port 8241
 rmarkdown::run("shiny_doc.Rmd", shiny_args = list(port = 8241))
-
 }
 }

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -112,17 +112,15 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to a slidy presentation.
 }
 \details{
-See the
-\href{http://rmarkdown.rstudio.com/slidy_presentation_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/slidy_presentation_format.html}{online
 documentation} for additional details on using the \code{slidy_presentation}
 format.
 
 For more information on markdown syntax for presentations see the
-\href{http://pandoc.org/README.html}{pandoc online documentation}.
+\href{https://pandoc.org/README.html}{pandoc online documentation}.
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 # simple invocation
@@ -131,5 +129,4 @@ render("pres.Rmd", slidy_presentation())
 # specify an option for incremental rendering
 render("pres.Rmd", slidy_presentation(incremental = TRUE))
 }
-
 }

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -42,8 +42,7 @@ Template for creating a handout according to the style of
 Edward R. Tufte and Richard Feynman.
 }
 \details{
-See the
-\href{https://rmarkdown.rstudio.com/tufte_handout_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/tufte_handout_format.html}{online
 documentation} for additional details.
 
 Creating Tufte handout output from R Markdown requires that LaTeX be installed.
@@ -54,6 +53,6 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }

--- a/man/word_document.Rd
+++ b/man/word_document.Rd
@@ -59,7 +59,7 @@ R Markdown output format to pass to \code{\link{render}}
 Format for converting from R Markdown to an MS Word document.
 }
 \details{
-See the \href{http://rmarkdown.rstudio.com/word_document_format.html}{online
+See the \href{https://rmarkdown.rstudio.com/word_document_format.html}{online
 documentation} for additional details on using the \code{word_document} format.
 
 R Markdown documents can have optional metadata that is used to generate a
@@ -68,12 +68,11 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
+\href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }
 \examples{
 \dontrun{
-
 library(rmarkdown)
 
 # simple invocation
@@ -82,5 +81,4 @@ render("input.Rmd", word_document())
 # specify an option for syntax highlighting
 render("input.Rmd", word_document(highlight = "zenburn"))
 }
-
 }


### PR DESCRIPTION
Roxygen documentation text from the `@details` section is moved toward the top (becoming the 3rd paragraph). Some line breaks were also added to improve readability within the functions themselves. 