### PR TITLE
Use `--quiet` arg to squelch warnings from Pandoc 2.0+

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -77,6 +77,9 @@ pandoc_convert <- function(input,
   # additional command line options
   args <- c(args, options)
 
+  # Use `--quiet` arg to squelch warnings from 2.0+ Pandoc
+  if (pandoc2.0()) args <- c(args, "--quiet")
+
   # citeproc filter if requested
   if (citeproc) {
     args <- c(args, "--filter", pandoc_citeproc())


### PR DESCRIPTION
Addresses issue #1290. Checks for Pandoc with version 2.0 or greater and simply adds the `--quiet` arg. (This removes all Pandoc warnings.)