### PR TITLE
Use metadata variable `pagetitle` for Pandoc 2.0+

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -376,7 +376,9 @@ discover_rmd_resources <- function(rmd_file,
 
   html_file <- render(input = md_file, output_file = html_file,
                       output_format = override_output_format,
-                      output_options = list(self_contained = FALSE),
+                      output_options = list(
+                        self_contained = FALSE,
+                        pandoc_args = c("--metadata", "pagetitle=PREVIEW")),
                       quiet = TRUE,
                       encoding = "UTF-8")
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -77,6 +77,9 @@ pandoc_convert <- function(input,
   # additional command line options
   args <- c(args, options)
 
+  # Use metadata variable `pagetitle` to satisfy a Pandoc 2.0+ requirement
+  if (pandoc2.0()) args <- c(args, c("--metadata", "pagetitle=PREVIEW"))
+
   # citeproc filter if requested
   if (citeproc) {
     args <- c(args, "--filter", pandoc_citeproc())

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -77,9 +77,6 @@ pandoc_convert <- function(input,
   # additional command line options
   args <- c(args, options)
 
-  # Use metadata variable `pagetitle` to satisfy a Pandoc 2.0+ requirement
-  if (pandoc2.0()) args <- c(args, c("--metadata", "pagetitle=PREVIEW"))
-
   # citeproc filter if requested
   if (citeproc) {
     args <- c(args, "--filter", pandoc_citeproc())


### PR DESCRIPTION
When using Pandoc 2.0+, this changes addresses a requirement for a page title in the input document. Closes #1290