### PR TITLE
attempt to fix ioslides table rendering for pandoc 2

### DIFF
--- a/inst/rmd/ioslides/ioslides_presentation.lua
+++ b/inst/rmd/ioslides/ioslides_presentation.lua
@@ -447,7 +447,7 @@ function Table(caption, aligns, widths, headers, rows)
   end
   if widths and widths[1] ~= 0 then
     for _, w in pairs(widths) do
-      add('<col width="' .. string.format("%d%%", w * 100) .. '" />')
+      add('<col width="' .. string.format("%f%%", w * 100) .. '" />')
     end
   end
   local header_row = {}


### PR DESCRIPTION
Seeing this error for some tables:

```
pandoc: PandocLuaException "[string \"local fig_caption = true...\"]:456: bad argument #2 to 'format' (number has no integer representation)"
Error: pandoc document conversion failed with error 1
Execution halted
```

Likely related to not being able to coerce certain width values to integer. This change formats table widths as floats (which should still be HTML compatible)