### PR TITLE
Add 20px bottom margin to htmlwidgets

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -139,6 +139,9 @@ img {
 .tabbed-pane {
   padding-top: 12px;
 }
+.html-widget {
+  margin-bottom: 20px;
+}
 button.code-folding-btn:focus {
   outline: none;
 }


### PR DESCRIPTION
This matches the amount of padding/margin after `<pre>` tags. R plots normally have some internal margin and in addition are enclosed in `<p>` which has a bottom margin of 1em.