### PR TITLE
Modify link to version 3 of Bootswatch library page

### DIFF
--- a/html_document_format.Rmd
+++ b/html_document_format.Rmd
@@ -124,7 +124,7 @@ install.packages("rmarkdown")
 
 There are several options that control the appearance of HTML documents:
 
-* `theme` specifies the Bootstrap theme to use for the page (themes are drawn from the [Bootswatch](http://bootswatch.com/) theme library). Valid themes include `r paste_and(rmarkdown:::themes())`. Pass null for no theme (in this case you can use the `css` parameter to add your own styles).
+* `theme` specifies the Bootstrap theme to use for the page (themes are drawn from the [Bootswatch](http://bootswatch.com/3/) theme library). Valid themes include `r paste_and(rmarkdown:::themes())`. Pass null for no theme (in this case you can use the `css` parameter to add your own styles).
 
 * `highlight` specifies the syntax highlighting style. Supported styles include `r paste_and(rmarkdown:::html_highlighters())`. Pass null to prevent syntax highlighting.
 

--- a/html_document_format.html
+++ b/html_document_format.html
@@ -370,7 +370,7 @@ output:
 <h2>Appearance and Style</h2>
 <p>There are several options that control the appearance of HTML documents:</p>
 <ul>
-<li><p><code>theme</code> specifies the Bootstrap theme to use for the page (themes are drawn from the <a href="http://bootswatch.com/">Bootswatch</a> theme library). Valid themes include <code>&quot;default&quot;</code>, <code>&quot;cerulean&quot;</code>, <code>&quot;journal&quot;</code>, <code>&quot;flatly&quot;</code>, <code>&quot;readable&quot;</code>, <code>&quot;spacelab&quot;</code>, <code>&quot;united&quot;</code>, <code>&quot;cosmo&quot;</code>, <code>&quot;lumen&quot;</code>, <code>&quot;paper&quot;</code>, <code>&quot;sandstone&quot;</code>, <code>&quot;simplex&quot;</code>, and <code>&quot;yeti&quot;</code>. Pass null for no theme (in this case you can use the <code>css</code> parameter to add your own styles).</p></li>
+<li><p><code>theme</code> specifies the Bootstrap theme to use for the page (themes are drawn from the <a href="http://bootswatch.com/3/">Bootswatch</a> theme library). Valid themes include <code>&quot;default&quot;</code>, <code>&quot;cerulean&quot;</code>, <code>&quot;journal&quot;</code>, <code>&quot;flatly&quot;</code>, <code>&quot;readable&quot;</code>, <code>&quot;spacelab&quot;</code>, <code>&quot;united&quot;</code>, <code>&quot;cosmo&quot;</code>, <code>&quot;lumen&quot;</code>, <code>&quot;paper&quot;</code>, <code>&quot;sandstone&quot;</code>, <code>&quot;simplex&quot;</code>, and <code>&quot;yeti&quot;</code>. Pass null for no theme (in this case you can use the <code>css</code> parameter to add your own styles).</p></li>
 <li><p><code>highlight</code> specifies the syntax highlighting style. Supported styles include <code>&quot;default&quot;</code>, <code>&quot;tango&quot;</code>, <code>&quot;pygments&quot;</code>, <code>&quot;kate&quot;</code>, <code>&quot;monochrome&quot;</code>, <code>&quot;espresso&quot;</code>, <code>&quot;zenburn&quot;</code>, <code>&quot;haddock&quot;</code>, and <code>&quot;textmate&quot;</code>. Pass null to prevent syntax highlighting.</p></li>
 <li><p><code>smart</code> indicates whether to produce typographically correct output, converting straight quotes to curly quotes, <code>---</code> to em-dashes, <code>--</code> to en-dashes, and <code>...</code> to ellipses. Note that <code>smart</code> is enabled by default.</p></li>
 </ul>
@@ -434,10 +434,10 @@ output:
 <div id="data-frame-printing" class="section level2">
 <h2>Data Frame Printing</h2>
 <p>You can enhance the default display of data frames via the <code>df_print</code> option. Valid values include:</p>
-<table style="width:79%;">
+<table>
 <colgroup>
-<col width="18%" />
-<col width="61%" />
+<col width="21%" />
+<col width="78%" />
 </colgroup>
 <thead>
 <tr class="header">
@@ -697,7 +697,7 @@ output: html_fragment
 
 <div id="rStudioFooter" class="band full">
 <div class="bandContent">
-  <div id="copyright">© Copyright 2016 RStudio Inc.</div>
+  <div id="copyright">© Copyright 2016 - 2018 RStudio Inc.</div>
   <div id="logos">
     <a href="https://twitter.com/rstudio" class="footerLogo twitter"></a>
     <a href="https://github.com/rstudio" class="footerLogo gitHub"></a>


### PR DESCRIPTION
This change was from a good suggestion made in issue #1347. The original link to the Bootswatch page led to the most recent version by default. The only change here is the link leading to: `https://bootswatch.com/3/`. This is important because users could see exactly which themes are available to them.