### PR TITLE
Avoid pagetitle warning from pandoc2.0 when title is missing.

### DIFF
--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -108,6 +108,10 @@ html_document_base <- function(smart = TRUE,
 
     preserved_chunks <<- extract_preserve_chunks(input_file)
 
+    # Avoid pagetitle warning from pandoc2.0 when title is missing
+    if (pandoc2.0() && is.null(metadata$title))
+      args <- c(args, "--metadata", paste0("pagetitle=", input_file))
+
     args
   }
 

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -377,8 +377,7 @@ discover_rmd_resources <- function(rmd_file,
   html_file <- render(input = md_file, output_file = html_file,
                       output_format = override_output_format,
                       output_options = list(
-                        self_contained = FALSE,
-                        pandoc_args = c("--metadata", "pagetitle=PREVIEW")),
+                        self_contained = FALSE),
                       quiet = TRUE,
                       encoding = "UTF-8")
 


### PR DESCRIPTION
I noticed the warning produced by pandoc 2+ when the R Markdown file does not have a title in the YAML header. This is the same warning as demonstrated for `find_external_resources` in #1290. The fix in #1298 removes the warning only for `find_external_resources`.

This PR makes the change to the pre_processor function of `html_document_base`, and thus it removes the warning for anything that inherits from this function (including `find_external_resources`).

I also made two other minor improvements:

1. Don't specify `pagetitle` if there is a `title` specified in the YAML header. This keeps the text displayed in the browser tab the same as the document title (which is the same behavior as pandoc 1.0)
1. Instead of using `"PREVIEW"`, use the basename of the input file. This will make it easier to identify the browser tab. Also, this is similar to pandoc's fallback option.

cc @rich-iannone

I tested this with R 3.3.3, pandoc 2.2.1, and macOS 10.10.5. I'm happy to test this on other operating systems if there is interest in merging this PR.

I've previously signed the individual contributor agreement.