### PR TITLE
add natbiboptions pandoc variable

### DIFF
--- a/inst/rmd/latex/default-1.17.0.2.tex
+++ b/inst/rmd/latex/default-1.17.0.2.tex
@@ -93,7 +93,7 @@ $endfor$
 \fi
 $endif$
 $if(natbib)$
-\usepackage{natbib}
+\usepackage$if(natbiboptions)$[$for(natbiboptions)$$natbiboptions$$sep$,$endfor$]$endif${natbib}
 \bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$


### PR DESCRIPTION
There is no current way to achieve:

```latex
\usepackage[numbers,sort&compress]{natbib}
```

I changed the template to expose the [`natbiboptions`](https://pandoc.org/MANUAL.html#variables-for-latex) pandoc latex variable. Now it optionally allows 1 or more `natbiboptions` to be passed via `pandoc_args`.

in `_output.yml`:
```yaml
rmarkdown::pdf_document:
  citation_package: natbib
  pandoc_args: [
      "--variable", "natbiboptions=numbers",
      "--variable", "natbiboptions=sort&compress"
    ]
```
