### PR TITLE
Set alternative sourceCode overflow-x value

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -55,6 +55,10 @@ $if(code_folding)$
 div.sourceCode {
   overflow-x: visible;
 }
+$else$
+div.sourceCode {
+  overflow-x: auto;
+}
 $endif$
 </style>
 $if(theme)$


### PR DESCRIPTION
This addresses #654 by providing an `overflow-x` value for `div.sourceCode` when `code_folding` is not true.