### PR TITLE
Replace special chars with dashes instead of underscores in filenames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.13.2
+Version: 1.13.3
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 1.14
 
 - Fixed a regression in `ioslides_presentation` that background colors via the `data-background` attribute on slides stopped working (thanks, @ShKlinkenberg, #1265).
 
+- For `render()`, if the input filename contains special characters such as spaces or question marks (as defined in `rmarkdown:::.shell_chars_regex`), the file will be temporarily renamed with the special characters replaced by `-` (dash) instead of `_` (underscore, as in previous versions of **rmarkdown**). This change will affect users who render such files with caching (cache will be invalidated and regenerated). The change is due to the fact that `-` is generally a safer character than `_`, especially for LaTeX output (#1396).
+
 
 rmarkdown 1.13
 ================================================================================

--- a/R/util.R
+++ b/R/util.R
@@ -92,7 +92,7 @@ yaml_load <- function(...) yaml::yaml.load(..., eval.expr = TRUE)
 yaml_load_file <- function(input, ...) yaml_load(read_utf8(input), ...)
 
 file_name_without_shell_chars <- function(file) {
-  name <- gsub(.shell_chars_regex, '_', basename(file))
+  name <- gsub(.shell_chars_regex, '-', basename(file))
   dir <- dirname(file)
   if (nzchar(dir) && !identical(dir, "."))
     file.path(dir, name)


### PR DESCRIPTION
Because underscores are usually problematic in LaTeX (you may or may not have to escape them; it is hard to tell). [Dashes are much safer.](https://yihui.name/en/2018/03/space-pain/)

This fixes the four-year old bug rstudio/rticles#9.