### PR TITLE
Stop `render()` early when duplicate chunk names found

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -330,6 +330,13 @@ render <- function(input,
   # read the input file
   input_lines <- read_lines_utf8(knit_input, encoding)
 
+  # Terminate the render process early if there are document
+  # chunk names found in `input_lines`
+  if (any_duplicate_chunk_names(input_lines = input_lines)) {
+    stop("Duplicate chunk names were found in the input document. ",
+         "Please correct this and `render()` again", call. = FALSE)
+  }
+
   # read the yaml front matter
   yaml_front_matter <- parse_yaml_front_matter(input_lines)
 

--- a/R/util.R
+++ b/R/util.R
@@ -69,6 +69,25 @@ read_lines_utf8 <- function(file, encoding) {
   to_utf8(lines, encoding)
 }
 
+# Determine if there are duplicate chunk names in the document's
+# `input_lines`; this allows the render process to terminate early
+# for any long-running rendering tasks
+any_duplicate_chunk_names <- function(input_lines) {
+
+  # Get only the lines related to chunk headers
+  chunk_headers <- input_lines[which(grepl("^```\\{\\w+?", input_lines))]
+
+  # Remove any components not related to the chunk names
+  chunk_names <-
+    gsub("^```\\{[a-zA-Z]+?\\s*\\}$|```\\{[a-zA-Z]+?\\s+?|\\}$|,.*|[a-zA-Z0-9 ]*?\\s*=\\s*.*|\\s*\\}", "",
+         chunk_headers, perl = TRUE)
+
+  # Remove remaining whitespace
+  chunk_names <- gsub("^\\s*", "\\s*$", chunk_names)
+
+  # Determine if there are duplicate chunk names
+  anyDuplicated(chunk_names[chunk_names != ""]) != 0
+}
 
 to_utf8 <- function(x, encoding) {
   # normalize encoding to iconv compatible form


### PR DESCRIPTION
These changes will stop the render process early when two or more chunks have the same name. It adds a utility function to parse the lines of the input file, yielding `TRUE` if any duplicate chunk names are detected. This function is called in `render()` just after reading the input file. This will save this user time when rendering any long-running input files where chunk names are not carefully checked for duplicates (e.g., ad-hoc analyses with DBs, etc.).

If duplicate chunk names are detected, `stop()` is called with an informative error message.

Fixes #1276 