### PR TITLE
Allow `run()` to work if `file = NULL` and multiple .Rmd files are present

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ rmarkdown 1.11 (unreleased)
 
 * The icons in `flexdashboard::valueBox()` are not of the full sizes due to the upgrade of FontAwesome in #1340 in the previous version (#1388, rstudio/flexdashboard#189).
 
+* Fix for `run()` to work if `file = NULL` and multiple .Rmd files are present in the search
+path (#1406).
+
 rmarkdown 1.10
 --------------------------------------------------------------------------------
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -108,6 +108,13 @@ run <- function(file = "index.Rmd",
     }
   }
 
+  # If no `default_file` yet chosen but multiple .Rmd
+  # files exist in the directory, choose the first based
+  # on an alpha sort
+  if (is.null(default_file) && length(allRmds) > 1) {
+    default_file <- sort(allRmds)[1]
+  }
+
   # form and test locations
   dir <- normalize_path(dir)
   if (!dir_exists(dir))

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -25,8 +25,10 @@
 #' order of preference):
 #' \itemize{
 #'   \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
-#'   \item{The file \code{index.Rmd}, if it exists in \code{dir}}
-#'   \item{The file \code{index.html}, if it exists in \code{dir}}
+#'   \item{The file \code{index.Rmd}, if it exists in \code{dir}.}
+#'   \item{The file \code{index.html}, if it exists in \code{dir}.}
+#'   \item{The first (based on alphabetical order) \code{Rmd} if multiple
+#'   \code{Rmd} files are present in \code{dir}.}
 #' }
 #'
 #' If you wish to share R code between your documents, place it in a file
@@ -106,6 +108,13 @@ run <- function(file = "index.Rmd",
     if (length(indexHtml) > 0) {
       default_file <- indexHtml[1]
     }
+  }
+
+  # If no `default_file` yet chosen but multiple .Rmd
+  # files exist in the directory, choose the first based
+  # on an alpha sort
+  if (is.null(default_file) && length(allRmds) > 1) {
+    default_file <- sort(allRmds)[1]
   }
 
   # If no `default_file` yet chosen but multiple .Rmd

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -117,13 +117,6 @@ run <- function(file = "index.Rmd",
     default_file <- sort(allRmds)[1]
   }
 
-  # If no `default_file` yet chosen but multiple .Rmd
-  # files exist in the directory, choose the first based
-  # on an alpha sort
-  if (is.null(default_file) && length(allRmds) > 1) {
-    default_file <- sort(allRmds)[1]
-  }
-
   # form and test locations
   dir <- normalize_path(dir)
   if (!dir_exists(dir))

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -55,10 +55,8 @@ URL, then the default document to serve at \code{/} is chosen from (in
 order of preference):
 \itemize{
   \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
-  \item{The file \code{index.Rmd}, if it exists in \code{dir}.}
-  \item{The file \code{index.html}, if it exists in \code{dir}.}
-  \item{The first (based on alphabetical order) \code{Rmd} if multiple
-  \code{Rmd} files are present in \code{dir}.}
+  \item{The file \code{index.Rmd}, if it exists in \code{dir}}
+  \item{The file \code{index.html}, if it exists in \code{dir}}
 }
 
 If you wish to share R code between your documents, place it in a file

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -55,8 +55,10 @@ URL, then the default document to serve at \code{/} is chosen from (in
 order of preference):
 \itemize{
   \item{If \code{dir} contains only one \code{Rmd}, that \code{Rmd}.}
-  \item{The file \code{index.Rmd}, if it exists in \code{dir}}
-  \item{The file \code{index.html}, if it exists in \code{dir}}
+  \item{The file \code{index.Rmd}, if it exists in \code{dir}.}
+  \item{The file \code{index.html}, if it exists in \code{dir}.}
+  \item{The first (based on alphabetical order) \code{Rmd} if multiple
+  \code{Rmd} files are present in \code{dir}.}
 }
 
 If you wish to share R code between your documents, place it in a file


### PR DESCRIPTION
This allows `run()` to work if `file = NULL` and multiple .Rmd files are present. This selects the first .Rmd file based on alphabetical order. The function documentation has been amended to make this clear. This fixes #906 