### PR TITLE
Allow selection/use of the "darkly" theme (issue#889)

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -48,9 +48,9 @@
 #'  documents MathJax is still loaded externally (this is necessary because of
 #'  its size).
 #'@param theme Visual theme ("default", "cerulean", "journal", "flatly",
-#'  "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone",
-#'  "simplex", or "yeti"). Pass \code{NULL} for no theme (in this case you can
-#'  use the \code{css} parameter to add your own styles).
+#'  "darkly", "readable", "spacelab", "united", "cosmo", "lumen", "paper",
+#'  "sandstone", "simplex", or "yeti"). Pass \code{NULL} for no theme (in this
+#'  case you can use the \code{css} parameter to add your own styles).
 #'@param highlight Syntax highlighting style. Supported styles include
 #'  "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",
 #'  "haddock", and "textmate". Pass \code{NULL} to prevent syntax highlighting.
@@ -484,6 +484,7 @@ themes <- function() {
     "cerulean",
     "journal",
     "flatly",
+    "darkly",
     "readable",
     "spacelab",
     "united",
@@ -515,6 +516,7 @@ pandoc_body_padding_variable_args <- function(theme) {
                      "cerulean" = 51,
                      "journal" = 61 ,
                      "flatly" = 60,
+                     "darkly" = 60,
                      "readable" = 66,
                      "spacelab" = 52,
                      "united" = 51,

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -76,9 +76,9 @@ documents MathJax is still loaded externally (this is necessary because of
 its size).}
 
 \item{theme}{Visual theme ("default", "cerulean", "journal", "flatly",
-"readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone",
-"simplex", or "yeti"). Pass \code{NULL} for no theme (in this case you can
-use the \code{css} parameter to add your own styles).}
+"darkly", "readable", "spacelab", "united", "cosmo", "lumen", "paper",
+"sandstone", "simplex", or "yeti"). Pass \code{NULL} for no theme (in this
+case you can use the \code{css} parameter to add your own styles).}
 
 \item{highlight}{Syntax highlighting style. Supported styles include
 "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -16,9 +16,9 @@ quotes to curly quotes, --- to em-dashes, -- to en-dashes, and ... to
 ellipses.}
 
 \item{theme}{Visual theme ("default", "cerulean", "journal", "flatly",
-"readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone",
-"simplex", or "yeti"). Pass \code{NULL} for no theme (in this case you can
-use the \code{css} parameter to add your own styles).}
+"darkly", "readable", "spacelab", "united", "cosmo", "lumen", "paper",
+"sandstone", "simplex", or "yeti"). Pass \code{NULL} for no theme (in this
+case you can use the \code{css} parameter to add your own styles).}
 
 \item{self_contained}{Produce a standalone HTML file with no external
 dependencies, using data: URIs to incorporate the contents of linked

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -48,9 +48,9 @@ quotes to curly quotes, --- to em-dashes, -- to en-dashes, and ... to
 ellipses.}
 
 \item{theme}{Visual theme ("default", "cerulean", "journal", "flatly",
-"readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone",
-"simplex", or "yeti"). Pass \code{NULL} for no theme (in this case you can
-use the \code{css} parameter to add your own styles).}
+"darkly", "readable", "spacelab", "united", "cosmo", "lumen", "paper",
+"sandstone", "simplex", or "yeti"). Pass \code{NULL} for no theme (in this
+case you can use the \code{css} parameter to add your own styles).}
 
 \item{highlight}{Syntax highlighting style. Supported styles include
 "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",


### PR DESCRIPTION
This allows for the selection and use of the "darkly" theme. This is a dark variation of the "flatly" theme. The minified CSS file for this theme was recently added to the `rstudio/htmldeps` package. Documentation in the package has been amended based on this theme addition.

When using `theme: darkly` the sample .Rmd renders as such:

<img width="1680" alt="darkly" src="https://user-images.githubusercontent.com/5612024/42903402-93dce982-8a86-11e8-956e-087387f56145.png">
