### PR TITLE
Modify pagedtable even background color

### DIFF
--- a/inst/rmd/h/pagedtable-1.1/css/pagedtable.css
+++ b/inst/rmd/h/pagedtable-1.1/css/pagedtable.css
@@ -33,7 +33,8 @@
 }
 
 .pagedtable .even {
-  background-color: #fcfcfc;
+  background-color: #8b8b8b;
+  background-color: rgba(140, 140, 140, 0.1);
 }
 
 .pagedtable-padding-col {


### PR DESCRIPTION
This fixes #1413. The issue is that the even-row cell background is a solid white, which doesn't work with themes that have a dark background and light fonts (only dark theme currently is the Bootswatch `darkly` theme).

This change modifies the CSS rule for the paged table `even` rows:

```
.pagedtable .even {
  background-color: #8b8b8b;
  background-color: rgba(140, 140, 140, 0.1);
}
```

By specifying a medium gray (RGB 140, 140, 140) and a very low value for opacity (0.1) we can achieve a tint that is still subtle and works with dark and light background and font colors (i.e., high contrast). I specified a static color in the line before for IE 8 and before (they don't support rgba).

Here are screenshots with the change applied for both the darkly and flatly themes:

<img width="991" alt="darkly_change" src="https://user-images.githubusercontent.com/5612024/43157418-d68af6fc-8f31-11e8-8895-477dd5323b35.png">

<img width="981" alt="flatly_change" src="https://user-images.githubusercontent.com/5612024/43157426-dc9f2df6-8f31-11e8-9bbe-f277c3975b36.png">


