### PR TITLE
Force a render when user pkgs don't match the pkgs used in a rendered, shiny-prerendered document

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@ rmarkdown 1.11 (unreleased)
 
 * Fixed a regression that caused scrollbars on code blocks when the syntax highlighting theme is not the default (#654, #1399).
 
+* Added checks for shiny-prerendered documents to find all html dependencies, match all execution packages, and match the major R version (#1420).
+
+
 rmarkdown 1.10
 ================================================================================
 
@@ -543,4 +546,3 @@ rmarkdown 0.3.11
 ================================================================================
 
 Initial release to CRAN
-

--- a/R/render.R
+++ b/R/render.R
@@ -362,8 +362,7 @@ render <- function(input,
     output_options$dependency_resolver <- function(deps) {
       shiny_prerendered_dependencies <<- list(
         deps = deps,
-        packages = get_loaded_packages(),
-        rMajorVersion = R.version$major
+        packages = get_loaded_packages()
       )
       list()
     }

--- a/R/render.R
+++ b/R/render.R
@@ -360,7 +360,11 @@ render <- function(input,
     # force various output options
     output_options$self_contained <- FALSE
     output_options$dependency_resolver <- function(deps) {
-      shiny_prerendered_dependencies <<- deps
+      shiny_prerendered_dependencies <<- list(
+        deps = deps,
+        packages = get_loaded_packages(),
+        rMajorVersion = R.version$major
+      )
       list()
     }
   }

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -183,7 +183,6 @@ shiny_prerendered_prerender <- function(
     return(TRUE)
   }
 
-  message("look at packages used in dependencies")
   html_lines <- readLines(rendered_html, encoding = "UTF-8", warn = FALSE)
   dependencies_json <- shiny_prerendered_extract_context(html_lines, "dependencies")
   dependencies <- jsonlite::unserializeJSON(dependencies_json)
@@ -193,6 +192,8 @@ shiny_prerendered_prerender <- function(
     if (is.null(dep$package)) {
       # if the file doesn't exist at all, render again
       if (!file.exists(dep$src$file)) {
+        # might create a missing file compile-time error,
+        #   but that's better than a missing file prerendered error
         return(TRUE)
       }
     } else {
@@ -202,6 +203,7 @@ shiny_prerendered_prerender <- function(
         # has not seen pkg
 
         # depVer could be NULL, producing a logical(0)
+        #   means old prerender version, render again
         if (!isTRUE(packageVersion(depPkg) == depVer)) {
           # was not rendered with the same R package. must render again
           return (TRUE)

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -216,20 +216,18 @@ shiny_prerendered_prerender <- function(
   }
   # all html dependencies are accounted for
 
+  # check for execution package version differences
   execution_json <- shiny_prerendered_extract_context(html_lines, "execution_dependencies")
   execution_info <- jsonlite::unserializeJSON(execution_json)
-
-  # check for execution package version differences
-  execution_pkgs <- execution_info$packages
-  versions_dont_match <- unlist(Map(
-    execution_pkgs$package,
-    execution_pkgs$version,
-    f = function(package, version) {
-      !identical(get_package_version_string(package), version)
+  execution_pkg_names <- execution_info$packages$package
+  execution_pkg_versions <- execution_info$packages$version
+  for (i in seq_len(nrow(execution_pkgs))) {
+    if (!identical(
+      get_package_version_string(execution_pkg_names[i]),
+      execution_pkg_versions[i]
+    )) {
+      return(TRUE)
     }
-  ))
-  if (any(versions_dont_match)) {
-    return(TRUE)
   }
   # all execution packages match
 

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -219,11 +219,6 @@ shiny_prerendered_prerender <- function(
   execution_json <- shiny_prerendered_extract_context(html_lines, "execution_dependencies")
   execution_info <- jsonlite::unserializeJSON(execution_json)
 
-  # check that the major R versions match
-  if (!identical(R.version$major, execution_info$rMajorVersion)) {
-    return(TRUE)
-  }
-
   # check for execution package version differences
   execution_pkgs <- execution_info$packages
   versions_dont_match <- unlist(Map(
@@ -298,7 +293,8 @@ shiny_prerendered_append_dependencies <- function(input, # always UTF-8
 
   # write r major version and execution package dependencies
   execution_json <- jsonlite::serializeJSON(
-    shiny_prerendered_dependencies[c("rMajorVersion", "packages")],
+    # visibly display what is being stored
+    shiny_prerendered_dependencies[c("packages")],
     pretty = FALSE
   )
   shiny_prerendered_append_context(con, "execution_dependencies", execution_json)

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -324,7 +324,7 @@ shiny_prerendered_option_hook <- function(input, encoding) {
                                                     options$cache > 0)
       data_file <- to_utf8(data_file, encoding)
       data_dir <- shiny_prerendered_data_dir(input, create = TRUE)
-      index_file <- shiny_prerendred_data_chunks_index(data_dir)
+      index_file <- shiny_prerendered_data_chunks_index(data_dir)
       conn <- file(index_file, open = "ab", encoding = "UTF-8")
       on.exit(close(conn), add = TRUE)
       write(data_file, file = conn, append = TRUE)
@@ -406,7 +406,7 @@ shiny_prerendered_evaluate_hook <- function(input) {
 shiny_prerendered_remove_uncached_data <- function(input) {
   data_dir <- shiny_prerendered_data_dir(input)
   if (dir_exists(data_dir)) {
-    index_file <- shiny_prerendred_data_chunks_index(data_dir)
+    index_file <- shiny_prerendered_data_chunks_index(data_dir)
     if (file.exists(index_file))
       unlink(index_file)
     rdata_files <- list.files(data_dir, pattern = utils::glob2rx("*.RData"))
@@ -562,7 +562,7 @@ shiny_prerendered_data_load <- function(input_rmd, server_envir) {
   data_dir <- shiny_prerendered_data_dir(input_rmd)
   if (dir_exists(data_dir)) {
     # read index of data files
-    index_file <- shiny_prerendred_data_chunks_index(data_dir)
+    index_file <- shiny_prerendered_data_chunks_index(data_dir)
     if (file.exists(index_file)) {
       rdata_files <- readLines(index_file, encoding = "UTF-8")
       # load each of the files in the index
@@ -576,7 +576,7 @@ shiny_prerendered_data_load <- function(input_rmd, server_envir) {
 }
 
 # File used to store names of chunks which had cache=TRUE during the last render
-shiny_prerendred_data_chunks_index <- function(data_dir) {
+shiny_prerendered_data_chunks_index <- function(data_dir) {
   file.path(data_dir, "data_chunks_index.txt")
 }
 

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -292,7 +292,7 @@ shiny_prerendered_append_dependencies <- function(input, # always UTF-8
   # write r major version and execution package dependencies
   execution_json <- jsonlite::serializeJSON(
     # visibly display what is being stored
-    shiny_prerendered_dependencies[c("packages")],
+    shiny_prerendered_dependencies["packages"],
     pretty = FALSE
   )
   shiny_prerendered_append_context(con, "execution_dependencies", execution_json)

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -190,18 +190,24 @@ shiny_prerendered_prerender <- function(
 
   pkgsSeen <- list()
   for (dep in dependencies) {
-    if (is.null(dep$package)) next
-    depPkg <- dep$package
-    depVer <- dep$pkgVersion
-    if (is.null(pkgsSeen[[depPkg]])) {
-      # has not seen pkg
-
-      # depVer could be NULL, producing a logical(0)
-      if (!isTRUE(packageVersion(depPkg) == depVer)) {
-        # was not rendered with the same R package. must render again
-        return (TRUE)
+    if (is.null(dep$package)) {
+      # if the file doesn't exist at all, render again
+      if (!file.exists(dep$src$file)) {
+        return(TRUE)
       }
-      pkgsSeen[[depPkg]] <- depVer
+    } else {
+      depPkg <- dep$package
+      depVer <- dep$pkgVersion
+      if (is.null(pkgsSeen[[depPkg]])) {
+        # has not seen pkg
+
+        # depVer could be NULL, producing a logical(0)
+        if (!isTRUE(packageVersion(depPkg) == depVer)) {
+          # was not rendered with the same R package. must render again
+          return (TRUE)
+        }
+        pkgsSeen[[depPkg]] <- depVer
+      }
     }
   }
 

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -199,6 +199,7 @@ shiny_prerendered_append_dependencies <- function(input, # always UTF-8
         package_desc <- read.dcf(file.path(package_dir, "DESCRIPTION"),
                                  all = TRUE)
         dependency$package <- package_desc$Package
+        dependency$pkgVersion <- package_desc$Version
         dependency$src$file <- normalized_relative_to(package_dir,
                                                       dependency$src$file)
       }

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -221,7 +221,7 @@ shiny_prerendered_prerender <- function(
   execution_info <- jsonlite::unserializeJSON(execution_json)
   execution_pkg_names <- execution_info$packages$package
   execution_pkg_versions <- execution_info$packages$version
-  for (i in seq_len(nrow(execution_pkgs))) {
+  for (i in seq_along(execution_pkg_names)) {
     if (!identical(
       get_package_version_string(execution_pkg_names[i]),
       execution_pkg_versions[i]

--- a/R/util.R
+++ b/R/util.R
@@ -528,7 +528,7 @@ get_package_version_string <- function(package) {
 # find all loaded packages.
 # May contain extra packages, but will contain all packages used while knitting
 get_loaded_packages <- function() {
-  packages <- sort(loadedNamespaces()
+  packages <- sort(loadedNamespaces())
   version <- vapply(packages, get_package_version_string, character(1))
 
   data.frame(

--- a/R/util.R
+++ b/R/util.R
@@ -513,3 +513,34 @@ package_root <- function(path) {
       length(grep('^Package: ', readLines(desc))) == 0) return(package_root(dir))
   dir
 }
+
+
+# retrieve package version without fear of error
+# loading namespace is ok as these packages have been or will be used
+get_package_version_string <- function(package) {
+  tryCatch(
+    as.character(getNamespaceVersion(package)),
+    error = function(e) {
+      NULL
+    }
+  )
+}
+# find all loaded packages.
+# May contain extra packages, but contains all packages used while knitting
+get_loaded_packages <- function() {
+  base_r_packages <- c(
+    "base", "compiler", "datasets", "graphics", "grDevices",
+    "grid", "methods", "parallel", "splines",
+    "stats", "stats4", "tcltk", "tools", "utils"
+  )
+
+  packages <- sort(setdiff(loadedNamespaces(), base_r_packages))
+  version <- vapply(packages, get_package_version_string, character(1))
+  attached <- paste0("package:", packages) %in% search()
+
+  data.frame(
+    packages = packages[attached],
+    version = version[attached],
+    row.names = NULL, stringsAsFactors = FALSE
+  )
+}

--- a/R/util.R
+++ b/R/util.R
@@ -526,17 +526,14 @@ get_package_version_string <- function(package) {
   )
 }
 # find all loaded packages.
-# May contain extra packages, but contains all packages used while knitting
+# May contain extra packages, but will contain all packages used while knitting
 get_loaded_packages <- function() {
-  base_r_packages <- rownames(installed.packages(priority = 'base'))
-
-  packages <- sort(setdiff(loadedNamespaces(), base_r_packages))
+  packages <- sort(loadedNamespaces()
   version <- vapply(packages, get_package_version_string, character(1))
-  attached <- paste0("package:", packages) %in% search()
 
   data.frame(
-    packages = packages[attached],
-    version = version[attached],
+    packages = packages,
+    version = version,
     row.names = NULL, stringsAsFactors = FALSE
   )
 }

--- a/R/util.R
+++ b/R/util.R
@@ -528,11 +528,7 @@ get_package_version_string <- function(package) {
 # find all loaded packages.
 # May contain extra packages, but contains all packages used while knitting
 get_loaded_packages <- function() {
-  base_r_packages <- c(
-    "base", "compiler", "datasets", "graphics", "grDevices",
-    "grid", "methods", "parallel", "splines",
-    "stats", "stats4", "tcltk", "tools", "utils"
-  )
+  base_r_packages <- rownames(installed.packages(priority = 'base'))
 
   packages <- sort(setdiff(loadedNamespaces(), base_r_packages))
   version <- vapply(packages, get_package_version_string, character(1))


### PR DESCRIPTION
Address: https://github.com/rstudio/learnr/issues/169

By keeping track of the package version, we can force a new render if the user does not have the same package versions as the pre-rendered document.  

This solves the error where a pre-rendered resource can not be mounted (because it doesn't exist!).

- [x] NEWS item
- [ ] test?
- [x] when in Shiny Server and RSC env set in learnr
