### PR TITLE
handle date/time value parse errors

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -110,7 +110,13 @@ params_value_from_ui <- function(inputControlFn, value, uivalue) {
         # Empty POSIXct
         Sys.time()[-1]
       } else {
-        as.POSIXct(uivalue)
+        tryCatch({
+          as.POSIXct(uivalue)
+        }, error = function(e) {
+          # Unparseable time values produce NULL and float to the default.
+          # This happens most frequently when actively editing a date/time.
+          NULL
+        })
       }
     } else {
       uivalue

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -139,3 +139,23 @@ test_that("params hidden w/o show_default", {
   ui <- params_value_to_ui(function(){}, myobj, FALSE)
   expect_equal(ui, NULL)
 })
+
+test_that("ui value conversion", {
+  skip_on_cran()
+
+  emptydt <- Sys.time()[-1]
+
+  # Sys.time() -> as.character loses sub-second precision
+  nows <- as.character(Sys.time())
+  now <- as.POSIXct(nows)
+  expect_null(params_value_from_ui(shiny::textInput, now, "not-a-datetime"),
+              "produce NULL when datetime cannot be parsed")
+  expect_identical(params_value_from_ui(shiny::textInput, now, nows), now,
+               "produce datetime from valid UI textual value")
+  expect_identical(params_value_from_ui(shiny::textInput, now, ""), emptydt,
+               "produce empty POSIXct on empty input")
+  expect_identical(params_value_from_ui(shiny::textInput, "not-a-datetime", "uivalue"), "uivalue",
+               "textInput unmodified when datetime not involved")
+  expect_identical(params_value_from_ui(shiny::numericInput, 13, 42), 42,
+               "numericInput values pass through")
+})


### PR DESCRIPTION
convert parse errors to NULL; these are often seen while editing date/time
values in a textInput field. if the final value is not valid, we will interpret
that as choosing the default field value.

Sample Rmd:

````
---
title: taking time values
params:
  time: !r Sys.time() # POSIXct
---

time: `r params$time`
````

Running the `knit_params_ask` function:

```
rmarkdown::knit_params_ask('index.Rmd')
```

When the input is provided a valid time value, return a named list containing a `time` element with the parsed time. When the input is left as default or is provided an invalid input, return an empty named list.

Prior to this change, the Shiny application would err:
```
Warning: Error in as.POSIXlt.character: character string is not in a standard unambiguous format
Stack trace (innermost first):
    64: as.POSIXlt.character
    63: as.POSIXlt
    62: as.POSIXct
    61: as.POSIXct.default
    60: as.POSIXct
    59: params_value_from_ui
    58: observerFunc
     3: <Anonymous>
     2: do.call
     1: rmarkdown::knit_params_ask
```