### PR TITLE
Add intermediates generator function for the Powerpoint format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.10.16
+Version: 1.10.17
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ rmarkdown 1.11 (unreleased)
 
 * Fixed #1407: reactive expressions can break the section headers of Shiny R Markdown documents.
 
+# Fixed #1431: using the `intermediates_dir` with the Powerpoint output results in an error.
+
 * Fixed the website navbar not being able to display submenus properly (#721, #1426).
 
 * Added checks for shiny-prerendered documents to find all html dependencies, match all execution packages, and match the major R version (#1420).

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ rmarkdown 1.11 (unreleased)
 
 * Fixed #1407: reactive expressions can break the section headers of Shiny R Markdown documents.
 
-# Fixed #1431: using the `intermediates_dir` with the Powerpoint output results in an error.
+# Fixed #1431: `render()` with the `intermediates_dir` argument when the output format is `powerpoint_presentation` with a custom `reference_doc` fails to find the reference document.
 
 * Fixed the website navbar not being able to display submenus properly (#721, #1426).
 

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -139,10 +139,8 @@ beamer_presentation <- function(toc = FALSE,
   }
 
   # generate intermediates (required to make resources available for publish)
-  intermediates_generator <- function(original_input, encoding,
-                                      intermediates_dir) {
-    return(pdf_intermediates_generator(saved_files_dir, original_input,
-                                        encoding, intermediates_dir))
+  intermediates_generator <- function(...) {
+    general_intermediates_generator(saved_files_dir, ...)
   }
 
   # return format

--- a/R/odt_document.R
+++ b/R/odt_document.R
@@ -60,9 +60,7 @@ odt_document <- function(fig_width = 5,
   args <- c(args, includes_to_pandoc_args(includes))
 
   # reference odt
-  if (!is.null(reference_odt) && !identical(reference_odt, "default")) {
-    args <- c(args, reference_doc_arg("odt"), pandoc_path_arg(reference_odt))
-  }
+  args <- c(args, reference_doc_args("odt", reference_odt))
 
   # pandoc args
   args <- c(args, pandoc_args)

--- a/R/odt_document.R
+++ b/R/odt_document.R
@@ -65,12 +65,24 @@ odt_document <- function(fig_width = 5,
   # pandoc args
   args <- c(args, pandoc_args)
 
+  saved_files_dir <- NULL
+  pre_processor <- function(metadata, input_file, runtime, knit_meta, files_dir, output_dir) {
+    saved_files_dir <<- files_dir
+    NULL
+  }
+
+  intermediates_generator <- function(...) {
+    reference_intermediates_generator(saved_files_dir, ..., reference_odt)
+  }
+
   # return output format
   output_format(
     knitr = knitr,
     pandoc = pandoc_options(to = "odt",
                             from = from_rmarkdown(fig_caption, md_extensions),
                             args = args),
-    keep_md = keep_md
+    keep_md = keep_md,
+    pre_processor = pre_processor,
+    intermediates_generator = intermediates_generator
   )
 }

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -204,10 +204,8 @@ pdf_document <- function(toc = FALSE,
       invisible(NULL)
   }
 
-  intermediates_generator <- function(original_input, encoding,
-                                      intermediates_dir) {
-    return(pdf_intermediates_generator(saved_files_dir, original_input,
-                                        encoding, intermediates_dir))
+  intermediates_generator <- function(...) {
+    general_intermediates_generator(saved_files_dir, ...)
   }
 
   # return format
@@ -225,12 +223,10 @@ pdf_document <- function(toc = FALSE,
   )
 }
 
-pdf_intermediates_generator <- function(saved_files_dir, original_input,
-                                        encoding, intermediates_dir) {
+general_intermediates_generator <- function(saved_files_dir, ..., intermediates_dir) {
 
   # copy all intermediates (pandoc will need to bundle them in the PDF)
-  intermediates <- copy_render_intermediates(original_input, encoding,
-                                             intermediates_dir, FALSE)
+  intermediates <- copy_render_intermediates(..., intermediates_dir, FALSE)
 
   # we need figures from the supporting files dir to be available during
   # render as well; if we have a files directory, copy its contents

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -223,10 +223,12 @@ pdf_document <- function(toc = FALSE,
   )
 }
 
-general_intermediates_generator <- function(saved_files_dir, ..., intermediates_dir) {
+general_intermediates_generator <- function(
+  saved_files_dir, original_input, encoding, intermediates_dir
+) {
 
   # copy all intermediates (pandoc will need to bundle them in the PDF)
-  intermediates <- copy_render_intermediates(..., intermediates_dir, FALSE)
+  intermediates <- copy_render_intermediates(original_input, encoding, intermediates_dir, FALSE)
 
   # we need figures from the supporting files dir to be available during
   # render as well; if we have a files directory, copy its contents

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -47,10 +47,13 @@ powerpoint_presentation <- function(
 
   saved_files_dir <- NULL
 
-  intermediates_generator <- function(original_input, encoding,
-                                      intermediates_dir) {
-    return(powerpoint_intermediates_generator(saved_files_dir, original_input,
-                                              encoding, intermediates_dir))
+  pre_processor <- function(...) {
+    saved_files_dir <<- files_dir
+    NULL
+  }
+
+  intermediates_generator <- function(...) {
+    general_intermediates_generator(saved_files_dir, ...)
   }
 
   # return output format
@@ -63,26 +66,7 @@ powerpoint_presentation <- function(
     ),
     keep_md = keep_md,
     df_print = df_print,
+    pre_processor = pre_processor,
     intermediates_generator = intermediates_generator
   )
-}
-
-powerpoint_intermediates_generator <- function(saved_files_dir,
-                                               original_input,
-                                               encoding, intermediates_dir) {
-
-  # copy all intermediates (pandoc will need to bundle them in the Powerpoint)
-  intermediates <- copy_render_intermediates(original_input, encoding,
-                                             intermediates_dir, FALSE)
-
-  # we need figures from the supporting files dir to be available during
-  # render as well; if we have a files directory, copy its contents
-  if (!is.null(saved_files_dir) && dir_exists(saved_files_dir)) {
-    file.copy(saved_files_dir, intermediates_dir, recursive = TRUE)
-    intermediates <- c(intermediates, list.files(
-      path = file.path(intermediates_dir, basename(saved_files_dir)),
-      all.files = TRUE, recursive = TRUE, full.names = TRUE))
-  }
-
-  intermediates
 }

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -45,7 +45,7 @@ powerpoint_presentation <- function(
 
   saved_files_dir <- NULL
 
-  pre_processor <- function(...) {
+  pre_processor <- function(metadata, input_file, runtime, knit_meta, files_dir, output_dir) {
     saved_files_dir <<- files_dir
     NULL
   }

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -51,7 +51,7 @@ powerpoint_presentation <- function(
   }
 
   intermediates_generator <- function(...) {
-    general_intermediates_generator(saved_files_dir, ...)
+    reference_intermediates_generator(saved_files_dir, ..., reference_doc)
   }
 
   # return output format
@@ -67,4 +67,18 @@ powerpoint_presentation <- function(
     pre_processor = pre_processor,
     intermediates_generator = intermediates_generator
   )
+}
+
+# copy the reference doc to the intermediate dir when the dir is specified
+reference_intermediates_generator <- function(
+  saved_files_dir, original_input, encoding, intermediates_dir, reference_doc
+) {
+  res <- general_intermediates_generator(saved_files_dir,  original_input, encoding, intermediates_dir)
+  if (is.null(reference_doc) || identical(reference_doc, 'default')) return(res)
+  if (dirname(reference_doc) != '.') stop(
+    'The reference document ', reference_doc, 'must be under the directory ', getwd(),
+    ' and its path must be ', basename(reference_doc)
+  )
+  file.copy(reference_doc, intermediates_dir)
+  c(res, file.path(intermediates_dir, basename(reference_doc)))
 }

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -32,9 +32,7 @@ powerpoint_presentation <- function(
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
   # ppt template
-  if (!is.null(reference_doc) && !identical(reference_doc, 'default')) {
-    args <- c(args, '--reference-doc', pandoc_path_arg(reference_doc))
-  }
+  args <- c(args, reference_doc_args("doc", reference_doc))
 
   # slide level
   if (!is.null(slide_level))

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -79,6 +79,16 @@ word_document <- function(toc = FALSE,
   # pandoc args
   args <- c(args, pandoc_args)
 
+  saved_files_dir <- NULL
+  pre_processor <- function(metadata, input_file, runtime, knit_meta, files_dir, output_dir) {
+    saved_files_dir <<- files_dir
+    NULL
+  }
+
+  intermediates_generator <- function(...) {
+    reference_intermediates_generator(saved_files_dir, ..., reference_docx)
+  }
+
   # return output format
   output_format(
     knitr = knitr,
@@ -86,7 +96,9 @@ word_document <- function(toc = FALSE,
                             from = from_rmarkdown(fig_caption, md_extensions),
                             args = args),
     keep_md = keep_md,
-    df_print = df_print
+    df_print = df_print,
+    pre_processor = pre_processor,
+    intermediates_generator = intermediates_generator
   )
 }
 

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -74,9 +74,7 @@ word_document <- function(toc = FALSE,
   args <- c(args, pandoc_highlight_args(highlight))
 
   # reference docx
-  if (!is.null(reference_docx) && !identical(reference_docx, "default")) {
-    args <- c(args, reference_doc_arg("docx"), pandoc_path_arg(reference_docx))
-  }
+  args <- c(args, reference_doc_args("docx", reference_docx))
 
   # pandoc args
   args <- c(args, pandoc_args)
@@ -92,9 +90,10 @@ word_document <- function(toc = FALSE,
   )
 }
 
-reference_doc_arg <- function(type) {
-  paste0("--reference-", if (pandoc2.0()) "doc" else {
-    match.arg(type, c("docx", "odt"))
-  })
+reference_doc_args <- function(type, doc) {
+  if (!is.null(doc) && !identical(doc, "default")) return()
+  c(paste0("--reference-", if (pandoc2.0()) "doc" else {
+    match.arg(type, c("docx", "odt", "doc"))
+  }), pandoc_path_arg(doc))
 }
 

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -91,7 +91,7 @@ word_document <- function(toc = FALSE,
 }
 
 reference_doc_args <- function(type, doc) {
-  if (!is.null(doc) && !identical(doc, "default")) return()
+  if (is.null(doc) || identical(doc, "default")) return()
   c(paste0("--reference-", if (pandoc2.0()) "doc" else {
     match.arg(type, c("docx", "odt", "doc"))
   }), pandoc_path_arg(doc))


### PR DESCRIPTION
This allows for supporting input files to be collected and moved to the intermediates directory when `intermediates_dir` is specified. Fixes#1431