### PR TITLE
Added check to make sure params exists before attempting to call unlockBinding

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -604,7 +604,7 @@ render <- function(input,
       assign("params", params, envir = envir)
       lockBinding("params", envir)
       on.exit({
-        if ('params' %in% ls(envir = envir)) {
+        if (exists("params", envir = envir, inherits = FALSE)) {
             do.call("unlockBinding", list("params", envir))
           if (hasParams)
             assign("params", envirParams, envir = envir)

--- a/R/render.R
+++ b/R/render.R
@@ -604,11 +604,13 @@ render <- function(input,
       assign("params", params, envir = envir)
       lockBinding("params", envir)
       on.exit({
-        do.call("unlockBinding", list("params", envir))
-        if (hasParams)
-          assign("params", envirParams, envir = envir)
-        else
-          remove("params", envir = envir)
+        if ('params' %in% ls(envir = envir)) {
+            do.call("unlockBinding", list("params", envir))
+          if (hasParams)
+            assign("params", envirParams, envir = envir)
+          else
+            remove("params", envir = envir)
+        }
       }, add = TRUE)
     }
 


### PR DESCRIPTION
This PR fixes an issue whereby if a user has explicitly deleted the `params` in an Rmarkdown file, render throws the error:

```
Error in unlockBinding("params", <environment>) : no binding for "params"
Calls: <Anonymous> -> do.call -> unlockBinding
```

This may be done, for example, to free up memory (`rm(list = ls())`) prior to having pandoc render a large file.
