### PR TITLE
Overwrite summary bootstrap style in HTML templates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 1.11 (unreleased)
 ================================================================================
 
+* Fixed #1483, which prevented the triangle to be displayed in Firefox when `<details><summary>...</summary></details>` was used (#1485, @bisaloo)
+
 * Provided `rmarkdown.pandoc.args` as a **knitr** package option in `knitr::opts_knit` (#1468, @noamross).
 
 * Added the exported function `pandoc_exec()`, which returns the path of the pandoc binary used by the package (#1465, #1466 @noamross).

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -153,6 +153,9 @@ img {
 button.code-folding-btn:focus {
   outline: none;
 }
+summary {
+  display: list-item
+}
 </style>
 
 $if(kable-scroll)$

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -154,7 +154,7 @@ button.code-folding-btn:focus {
   outline: none;
 }
 summary {
-  display: list-item
+  display: list-item;
 }
 </style>
 

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -71,6 +71,10 @@ $endfor$
       font-style: italic;
     }
 
+    summary {
+      display: list-item;
+    }
+
     slides > slide {
       -webkit-transition: all $transition$s ease-in-out;
       -moz-transition: all $transition$s ease-in-out;


### PR DESCRIPTION
For future reference, this is a temporary fix for a bug in bootstrap which has now been fixed upstream. This means that this commit can safely be reverted once rmarkdown bootstrap version is updated.

Fix #1483.

This was tested locally for every rmarkdown HTML output formats.

Please let me know if anything needs to be adjusted before this is ready to be merged.