### PR TITLE
Prevent clash with KOMA-Script classes

### DIFF
--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -176,7 +176,7 @@ pdf_document <- function(toc = FALSE,
 
     # use titling package to change title format to be more compact by default
     if (!has_yaml_parameter(input_test, "compact-title"))
-      args <- c(args, "--variable", "compact-title:no")
+      args <- c(args, "--variable", "compact-title:yes")
 
     if (length(extra_dependencies) || has_latex_dependencies(knit_meta)) {
       extra_dependencies <- latex_dependencies(extra_dependencies)

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -176,7 +176,7 @@ pdf_document <- function(toc = FALSE,
 
     # use titling package to change title format to be more compact by default
     if (!has_yaml_parameter(input_test, "compact-title"))
-      args <- c(args, "--variable", "compact-title:yes")
+      args <- c(args, "--variable", "compact-title:no")
 
     if (length(extra_dependencies) || has_latex_dependencies(knit_meta)) {
       extra_dependencies <- latex_dependencies(extra_dependencies)

--- a/inst/rmd/latex/default-1.14.tex
+++ b/inst/rmd/latex/default-1.14.tex
@@ -144,7 +144,7 @@ $if(compact-title)$
 \usepackage{titling}
 
 % Create subtitle command for use in maketitle
-\newcommand{\subtitle}[1]{
+\providecommand{\subtitle}[1]{
   \posttitle{
     \begin{center}\large#1\end{center}
     }

--- a/inst/rmd/latex/default-1.15.2.tex
+++ b/inst/rmd/latex/default-1.15.2.tex
@@ -177,7 +177,7 @@ $if(compact-title)$
 \usepackage{titling}
 
 % Create subtitle command for use in maketitle
-\newcommand{\subtitle}[1]{
+\providecommand{\subtitle}[1]{
   \posttitle{
     \begin{center}\large#1\end{center}
     }

--- a/inst/rmd/latex/default-1.17.0.2.tex
+++ b/inst/rmd/latex/default-1.17.0.2.tex
@@ -196,7 +196,7 @@ $if(compact-title)$
 \usepackage{titling}
 
 % Create subtitle command for use in maketitle
-\newcommand{\subtitle}[1]{
+\providecommand{\subtitle}[1]{
   \posttitle{
     \begin{center}\large#1\end{center}
     }

--- a/inst/rmd/latex/default.tex
+++ b/inst/rmd/latex/default.tex
@@ -141,7 +141,7 @@ $if(compact-title)$
 \usepackage{titling}
 
 % Create subtitle command for use in maketitle
-\newcommand{\subtitle}[1]{
+\providecommand{\subtitle}[1]{
   \posttitle{
     \begin{center}\large#1\end{center}
     }


### PR DESCRIPTION
This was added in #1284. Setting it by default, however, means that the document cannot be compiled if the document class is set to use KOMA-Script (e.g. `documentclass: scrbook`), or presumably any other class that provides `\subtitle`.