### PR TITLE
Remove unnecessary directory check

### DIFF
--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -75,10 +75,6 @@ reference_intermediates_generator <- function(
 ) {
   res <- general_intermediates_generator(saved_files_dir,  original_input, encoding, intermediates_dir)
   if (is.null(reference_doc) || identical(reference_doc, 'default')) return(res)
-  if (dirname(reference_doc) != '.') stop(
-    'The reference document ', reference_doc, 'must be under the directory ', getwd(),
-    ' and its path must be ', basename(reference_doc)
-  )
   file.copy(reference_doc, intermediates_dir)
   c(res, file.path(intermediates_dir, basename(reference_doc)))
 }


### PR DESCRIPTION
In `reference_intermediates_generator`, this directory check precludes using `system.file` to refer to templates included in packages (as we do in psychmeta https://github.com/psychmeta/psychmeta/blob/2447d1891bf41d6fa3aa34bd88adee91d9cc8ed2/R/output.R#L810) or otherwise to files located somewhere else on the user's system. This is really limiting. This check isn't necessary, I don't believe—`file.copy` works fine with `reference_doc` located in another directory.