### PR TITLE
change default date to Sys.Date

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -319,7 +319,7 @@ render <- function(input,
       '---\n',
       'title: "', input, '"\n',
       'author: "', Sys.info()[["user"]], '"\n',
-      'date: "', date(), '"\n',
+      'date: "', Sys.Date(), '"\n',
       '---\n'
     , sep = "")
     if (!identical(encoding, "native.enc"))


### PR DESCRIPTION
`render()` [sets a date](https://github.com/rstudio/rmarkdown/blob/3901a9ddb27fd959ff41f4c4b6270bf170dcf52b/R/render.R#L322) if no date is provided in the yaml. Currently it uses the `date()` function to provide this date. `date()`'s format is quite obscure, however, and not standardized (apart from originating from the similarly obscure ctime() function). 

I propose to change the date to the one provided by `Sys.Date()`. 

Obviously this is highly opinionated, but `Sys.Date()` is also used in the `html_vignette` [skeleton](https://github.com/rstudio/rmarkdown/blob/3901a9ddb27fd959ff41f4c4b6270bf170dcf52b/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd#L4). 😃 