### PR TITLE
Avoid changing margins with custom document class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 1.13
 ================================================================================
 
-- Do not override margins to 1 inch when a custom document class or geometry settings are specified in the YAML front matter (Andrew Dunning, #1550)
+- For `pdf_document()`, do not override margins to 1 inch when a custom document class or geometry settings are specified in the YAML front matter (thanks, @adunning, #1550)
 
 - The default value of the `encoding` argument in all functions in this package (such as `render()` and `render_site()`) has been changed from `getOption("encoding")` to `UTF-8`. We have been hoping to support UTF-8 only in **rmarkdown**, **knitr**, and other related packages in the future. For more info, you may read https://yihui.name/en/2018/11/biggest-regret-knitr/.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 1.13
 ================================================================================
 
+- Do not override margins to 1 inch when a custom document class or geometry settings are specified in the YAML front matter (Andrew Dunning, #1550)
+
 - The default value of the `encoding` argument in all functions in this package (such as `render()` and `render_site()`) has been changed from `getOption("encoding")` to `UTF-8`. We have been hoping to support UTF-8 only in **rmarkdown**, **knitr**, and other related packages in the future. For more info, you may read https://yihui.name/en/2018/11/biggest-regret-knitr/.
 
 

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -171,7 +171,7 @@ pdf_document <- function(toc = FALSE,
     input_test <- read_utf8(input_file)
 
     # set the margin to 1 inch if no geometry options or document class specified
-    if (!has_yaml_parameter(input_test, "geometry") || !has_yaml_parameter(input_test, "documentclass"))
+    if (!has_yaml_parameter(input_test, "(geometry|documentclass)"))
       args <- c(args, "--variable", "geometry:margin=1in")
 
     # use titling package to change title format to be more compact by default

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -170,8 +170,8 @@ pdf_document <- function(toc = FALSE,
 
     input_test <- read_utf8(input_file)
 
-    # set the margin to 1 inch if no other geometry options specified
-    if (!has_yaml_parameter(input_test, "geometry"))
+    # set the margin to 1 inch if no geometry options or document class specified
+    if (!has_yaml_parameter(input_test, "geometry") || !has_yaml_parameter(input_test, "documentclass"))
       args <- c(args, "--variable", "geometry:margin=1in")
 
     # use titling package to change title format to be more compact by default


### PR DESCRIPTION
Detect `documentclass` alongside `geometry` in determining whether to change the margins: avoids conflicts when not using the `article` class. Closes #1549.