### PR TITLE
Preserve the toc_float text formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ rmarkdown 1.13
 
 - The default value of the `encoding` argument in all functions in this package (such as `render()` and `render_site()`) has been changed from `getOption("encoding")` to `UTF-8`. We have been hoping to support UTF-8 only in **rmarkdown**, **knitr**, and other related packages in the future. For more info, you may read https://yihui.name/en/2018/11/biggest-regret-knitr/.
 
+- The `toc_float = yes` now preserves the text formatting (@codetrainee, #1548).
 
 rmarkdown 1.12
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ rmarkdown 1.13
 
 - The default value of the `encoding` argument in all functions in this package (such as `render()` and `render_site()`) has been changed from `getOption("encoding")` to `UTF-8`. We have been hoping to support UTF-8 only in **rmarkdown**, **knitr**, and other related packages in the future. For more info, you may read https://yihui.name/en/2018/11/biggest-regret-knitr/.
 
-- The `toc_float = yes` now preserves the text formatting (@codetrainee, #1548).
+- The option `toc_float: true` for `html_document` now preserves the text formatting (thanks, @codetrainee, #1548).
 
 rmarkdown 1.12
 ================================================================================

--- a/inst/rmd/h/tocify/jquery.tocify.js
+++ b/inst/rmd/h/tocify/jquery.tocify.js
@@ -386,13 +386,13 @@
 
           item.append($("<a/>", {
 
-            "text": self.text()
+            "html": self.html()
 
           }));
 
         } else {
 
-          item.text(self.text());
+          item.html(self.html());
 
         }
 


### PR DESCRIPTION
This fixes #1548 to keep the `toc_float` text formatting.

Before applying the fix.

![image](https://user-images.githubusercontent.com/8357863/54356933-eb74ce80-46b0-11e9-9cbc-7e25bc0e1c4d.png)

After applying the fix.

![image](https://user-images.githubusercontent.com/8357863/54470098-8925e600-47f6-11e9-884d-584670296e6b.png)