### PR TITLE
Do not check for shiny_prerender href dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 1.13
 ================================================================================
 
+- Fixed [rstudio/shiny#2307](https://github.com/rstudio/shiny/issues/2307) where the second execution of a shiny_prerendred document with href dependencies would cause a prerender check error. (#1562, @schloerke)
+
 - For `pdf_document()`, do not override margins to 1 inch when a custom document class or geometry settings are specified in the YAML front matter (thanks, @adunning, #1550)
 
 - The default value of the `encoding` argument in all functions in this package (such as `render()` and `render_site()`) has been changed from `getOption("encoding")` to `UTF-8`. We have been hoping to support UTF-8 only in **rmarkdown**, **knitr**, and other related packages in the future. For more info, you may read https://yihui.name/en/2018/11/biggest-regret-knitr/.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 rmarkdown 1.13
 ================================================================================
 
-- Fixed [rstudio/shiny#2307](https://github.com/rstudio/shiny/issues/2307) where the second execution of a shiny_prerendred document with href dependencies would cause a prerender check error. (#1562, @schloerke)
-
 - For `pdf_document()`, do not override margins to 1 inch when a custom document class or geometry settings are specified in the YAML front matter (thanks, @adunning, #1550)
 
 - The default value of the `encoding` argument in all functions in this package (such as `render()` and `render_site()`) has been changed from `getOption("encoding")` to `UTF-8`. We have been hoping to support UTF-8 only in **rmarkdown**, **knitr**, and other related packages in the future. For more info, you may read https://yihui.name/en/2018/11/biggest-regret-knitr/.
@@ -12,6 +10,8 @@ rmarkdown 1.13
 - For the `output_file` argument of `render()`, a file extension will be automatically added if the filename does not contain an extension (e.g., `render('foo.Rmd', 'html_document', output_file = 'bar')` will generate `bar.html`); see the help page `?rmarkdown::render` for details (thanks, @apreshill, #1551).
 
 - TOC items are not correctly indented when `toc_float` is enabled for the `html_document` format (thanks, @carolynwclayton #1235 and @RLesur #1243).
+
+- Fixed rstudio/shiny#2307 where the second execution of a `shiny_prerendred` document with `href` dependencies would cause a prerender check error (thanks, @schloerke, #1562).
 
 
 rmarkdown 1.12

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -191,12 +191,17 @@ shiny_prerendered_prerender <- function(
   pkgsSeen <- list()
   for (dep in dependencies) {
     if (is.null(dep$package)) {
-      # if the file doesn't exist at all, render again
-      if (!file.exists(dep$src$file)) {
-        # might create a missing file compile-time error,
-        #   but that's better than a missing file prerendered error
-        return(TRUE)
+      src_file <- dep$src$file
+      if (!is.null(src_file)) {
+        if (!file.exists(src_file)) {
+          # might create a missing file compile-time error,
+          #   but that's better than a missing file prerendered error
+          return(TRUE)
+        }
       }
+      # if there is a dep$src$href but no dep$package,
+      # then we can't determine where the file came from.
+      # Ignore checking for the href files for now, as pkg versions are checked below
     } else {
       depPkg <- dep$package
       depVer <- dep$pkgVersion


### PR DESCRIPTION
Fixes https://github.com/rstudio/shiny/issues/2307

Steps to reproduce error: 

```r
remotes::install_github("rstudio/learnr")
install.packages("rmarkdown")
remotes::install_github("ScPoEcon/ScPoEconometrics")
ScPoEconometrics::runTutorial("chapter2") # prerender + run
# close tutorial
ScPoEconometrics::runTutorial("chapter2") # errors in prerender check
#> Error in file.exists(dep$src$file) : invalid 'file' argument

```
