### PR TITLE
Use a more descriptive resource prefix in shiny_prerendered runtime

### DIFF
--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -100,8 +100,10 @@ shiny_prerendered_html <- function(input_rmd, encoding, render_args) {
 
   # add some resource paths
   add_resource_path <- function(path) {
-    if (dir_exists(path))
-      shiny::addResourcePath(basename(path), path)
+    if (dir_exists(path)) {
+      prefix <- paste0("shiny_prerendered_", basename(path))
+      shiny::addResourcePath(prefix, path)
+    }
   }
   files_dir <- knitr_files_dir(rendered_html)
   add_resource_path(files_dir)


### PR DESCRIPTION
Due to new fallthrough behavior in Shiny 1.3.0, these paths could cause problems if a shiny prerendered document with a `js` or `css` subdir is run via `rmarkdown::run()`, and then later a regular Shiny app with a `www/js` or `www/css` directory is run.  See https://github.com/rstudio/shiny-examples/pull/144 for a reproducible example of the problem