### PR TITLE
Fix rmarkdown.rstudio.com gallery links

### DIFF
--- a/gallery.Rmd
+++ b/gallery.Rmd
@@ -54,11 +54,6 @@ output:
         <div class="galleryItemDescription">Embed htmlwidgets such as dygraphs and datatables directly into your reports.</div>
       </div>
       <div class="galleryItem">
-        <a href="https://uasnap.shinyapps.io/ex_leaflet/"><img class="galleryItemImage" src="galleryImages/shiny1.png"/></a>
-        <a href="https://uasnap.shinyapps.io/ex_leaflet/" class="galleryItemLabel">Shiny</a>
-        <div class="galleryItemDescription">Add interactive analysis with shiny, which lets your user rerun the actual analysis within your report.</div>
-      </div>
-      <div class="galleryItem">
         <a href="https://bookdown.org/csgillespie/shiny_components/"><img class="galleryItemImage" src="galleryImages/shiny2.png"/></a>
         <a href="https://bookdown.org/csgillespie/shiny_components/" class="galleryItemLabel">Shiny</a>
         <div class="galleryItemDescription">Shiny components and htmlwidgets will work in any HTML based output, such as a file, slide show or dashboard.</div>

--- a/gallery.Rmd
+++ b/gallery.Rmd
@@ -76,11 +76,6 @@ output:
         <div class="galleryItemDescription">Add interactive graphics to a dashboard with htmlwidgets.</div>
       </div>
       <div class="galleryItem">
-        <a href="https://walkerke.shinyapps.io/neighborhood_diversity/"><img class="galleryItemImage" src="galleryImages/dashboard3.png"/></a>
-        <a href="https://walkerke.shinyapps.io/neighborhood_diversity/" class="galleryItemLabel">Dashboard with Shiny</a>
-        <div class="galleryItemDescription">Add interactive analysis to a dashboard with Shiny.</div>
-      </div>
-      <div class="galleryItem">
         <a href="https://beta.rstudioconnect.com/jjallaire/htmlwidgets-showcase-storyboard/"><img class="galleryItemImage" src="galleryImages/dashboard4.png"/></a>
         <a href="https://beta.rstudioconnect.com/jjallaire/htmlwidgets-showcase-storyboard/" class="galleryItemLabel">Dashboard with storyboard</a>
         <div class="galleryItemDescription">Organize dashboards around a storyboard.</div>

--- a/gallery.html
+++ b/gallery.html
@@ -78,9 +78,7 @@ h6 {
 
 <link rel="stylesheet" href="css/rmarkdown.css" type="text/css" />
 
-</head>
 
-<body>
 
 <style type = "text/css">
 .main-container {
@@ -111,8 +109,6 @@ summary {
 </style>
 
 
-
-<div class="container-fluid main-container">
 
 <!-- tabsets -->
 
@@ -184,6 +180,15 @@ $(document).ready(function () {
 
 <!-- code folding -->
 
+
+
+
+</head>
+
+<body>
+
+
+<div class="container-fluid main-container">
 
 
 
@@ -290,11 +295,6 @@ $(".main-container").removeClass("main-container").removeClass("container-fluid"
         <div class="galleryItemDescription">Embed htmlwidgets such as dygraphs and datatables directly into your reports.</div>
       </div>
       <div class="galleryItem">
-        <a href="https://uasnap.shinyapps.io/ex_leaflet/"><img class="galleryItemImage" src="galleryImages/shiny1.png"/></a>
-        <a href="https://uasnap.shinyapps.io/ex_leaflet/" class="galleryItemLabel">Shiny</a>
-        <div class="galleryItemDescription">Add interactive analysis with shiny, which lets your user rerun the actual analysis within your report.</div>
-      </div>
-      <div class="galleryItem">
         <a href="https://bookdown.org/csgillespie/shiny_components/"><img class="galleryItemImage" src="galleryImages/shiny2.png"/></a>
         <a href="https://bookdown.org/csgillespie/shiny_components/" class="galleryItemLabel">Shiny</a>
         <div class="galleryItemDescription">Shiny components and htmlwidgets will work in any HTML based output, such as a file, slide show or dashboard.</div>
@@ -315,11 +315,6 @@ $(".main-container").removeClass("main-container").removeClass("container-fluid"
         <a href="https://beta.rstudioconnect.com/jjallaire/htmlwidgets-highcharter/"><img class="galleryItemImage" src="galleryImages/dashboard2.png"/></a>
         <a href="https://beta.rstudioconnect.com/jjallaire/htmlwidgets-highcharter/" class="galleryItemLabel">Dashboard with htmlwidgets</a>
         <div class="galleryItemDescription">Add interactive graphics to a dashboard with htmlwidgets.</div>
-      </div>
-      <div class="galleryItem">
-        <a href="https://walkerke.shinyapps.io/neighborhood_diversity/"><img class="galleryItemImage" src="galleryImages/dashboard3.png"/></a>
-        <a href="https://walkerke.shinyapps.io/neighborhood_diversity/" class="galleryItemLabel">Dashboard with Shiny</a>
-        <div class="galleryItemDescription">Add interactive analysis to a dashboard with Shiny.</div>
       </div>
       <div class="galleryItem">
         <a href="https://beta.rstudioconnect.com/jjallaire/htmlwidgets-showcase-storyboard/"><img class="galleryItemImage" src="galleryImages/dashboard4.png"/></a>


### PR DESCRIPTION
This PR removes two links in the [gallery](https://rmarkdown.rstudio.com/gallery.html) that were problematic (one produced a 404 error, the other was a Shiny app hosted externally). 

cc @garrettgman @rich-iannone  