### PR TITLE
Fix regressions in html_document with Shiny runtime

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Authors@R: c(
   person("Frederik", "Aust", role = "ctb", email = "frederik.aust@uni-koeln.de", comment = c(ORCID = "0000-0003-4900-788X")),
   person("Christophe", "Dervieux", role = "ctb"),
   person("Malcolm", "Barrett", role = "ctb"),
+  person("Romain", "Lesur", role = "ctb"),
   person(family = "RStudio, Inc.", role = "cph"),
   person(family = "jQuery Foundation", role = "cph",
          comment = "jQuery library"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 1.14
 
 - Fixed a regression in `ioslides_presentation` that background colors via the `data-background` attribute on slides stopped working (thanks, @ShKlinkenberg, #1265).
 
+- Fixed the bug #1577 introduced in **rmarkdown** v1.12: tabsets, floating TOC, and code folding in the `html_document` format no longer work with the `shiny` runtime (thanks, @RLesur for the fix #1587, and @fawda123 @ColinChisholm @JasonAizkalns for the bug report).
+
 - For `render()`, if the input filename contains special characters such as spaces or question marks (as defined in `rmarkdown:::.shell_chars_regex`), the file will be temporarily renamed with the special characters replaced by `-` (dash) instead of `_` (underscore, as in previous versions of **rmarkdown**). This change will affect users who render such files with caching (cache will be invalidated and regenerated). The change is due to the fact that `-` is generally a safer character than `_`, especially for LaTeX output (#1396).
 
 

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -354,16 +354,6 @@ $if(code_menu)$
 <style type="text/css">
 .code-folding-btn { margin-bottom: 4px; }
 </style>
-<script>
-$$(document).ready(function () {
-$if(source_embed)$
-  window.initializeSourceEmbed("$source_embed$");
-$endif$
-$if(code_folding)$
-  window.initializeCodeFolding("$code_folding$" === "show");
-$endif$
-});
-</script>
 $endif$
 
 
@@ -595,6 +585,20 @@ $$(document).ready(function () {
   });
 });
 </script>
+
+<!-- code folding -->
+$if(code_menu)$
+<script>
+$$(document).ready(function () {
+$if(source_embed)$
+  window.initializeSourceEmbed("$source_embed$");
+$endif$
+$if(code_folding)$
+  window.initializeCodeFolding("$code_folding$" === "show");
+$endif$
+});
+</script>
+$endif$
 
 $if(toc_float)$
 <script>

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -369,41 +369,6 @@ $endif$
 
 $if(toc_float)$
 
-<script>
-$$(document).ready(function ()  {
-
-    // move toc-ignore selectors from section div to header
-    $$('div.section.toc-ignore')
-        .removeClass('toc-ignore')
-        .children('h1,h2,h3,h4,h5').addClass('toc-ignore');
-
-    // establish options
-    var options = {
-      selectors: "$toc_selectors$",
-      theme: "bootstrap3",
-      context: '.toc-content',
-      hashGenerator: function (text) {
-        return text.replace(/[.\\/?&!#<>]/g, '').replace(/\s/g, '_').toLowerCase();
-      },
-      ignoreSelector: ".toc-ignore",
-      scrollTo: 0
-    };
-$if(toc_collapsed)$
-    options.showAndHide = true;
-$else$
-    options.showAndHide = false;
-$endif$
-$if(toc_smooth_scroll)$
-    options.smoothScroll = true;
-$else$
-    options.smoothScroll = false;
-$endif$
-
-    // tocify
-    var toc = $$("#$idprefix$TOC").tocify(options).data("toc-tocify");
-});
-</script>
-
 <style type="text/css">
 
 #$idprefix$TOC {
@@ -630,6 +595,43 @@ $$(document).ready(function () {
   });
 });
 </script>
+
+$if(toc_float)$
+<script>
+$$(document).ready(function ()  {
+
+    // move toc-ignore selectors from section div to header
+    $$('div.section.toc-ignore')
+        .removeClass('toc-ignore')
+        .children('h1,h2,h3,h4,h5').addClass('toc-ignore');
+
+    // establish options
+    var options = {
+      selectors: "$toc_selectors$",
+      theme: "bootstrap3",
+      context: '.toc-content',
+      hashGenerator: function (text) {
+        return text.replace(/[.\\/?&!#<>]/g, '').replace(/\s/g, '_').toLowerCase();
+      },
+      ignoreSelector: ".toc-ignore",
+      scrollTo: 0
+    };
+$if(toc_collapsed)$
+    options.showAndHide = true;
+$else$
+    options.showAndHide = false;
+$endif$
+$if(toc_smooth_scroll)$
+    options.smoothScroll = true;
+$else$
+    options.smoothScroll = false;
+$endif$
+
+    // tocify
+    var toc = $$("#$idprefix$TOC").tocify(options).data("toc-tocify");
+});
+</script>
+$endif$
 
 $if(mathjax-url)$
 <!-- dynamically load mathjax for compatibility with self-contained -->

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -349,18 +349,6 @@ $endif$
 }
 </style>
 
-<script>
-$$(document).ready(function () {
-  window.buildTabsets("$idprefix$TOC");
-});
-
-$$(document).ready(function () {
-  $$('.tabset-dropdown > .nav-tabs > li').click(function () {
-    $$(this).parent().toggleClass('nav-tabs-open')
-  });
-});
-</script>
-
 <!-- code folding -->
 $if(code_menu)$
 <style type="text/css">
@@ -628,6 +616,20 @@ $endif$
 
 </script>
 $endif$
+
+<!-- tabsets -->
+
+<script>
+$$(document).ready(function () {
+  window.buildTabsets("$idprefix$TOC");
+});
+
+$$(document).ready(function () {
+  $$('.tabset-dropdown > .nav-tabs > li').click(function () {
+    $$(this).parent().toggleClass('nav-tabs-open')
+  });
+});
+</script>
 
 $if(mathjax-url)$
 <!-- dynamically load mathjax for compatibility with self-contained -->


### PR DESCRIPTION
The aim of this PR is to fix #1577.

Some regressions appear in **rmarkdown 1.12** using the `html_document` format with the Shiny runtime:
- tabsets
- floating TOC
- code folding

These regressions were introduced by #1547. The goal of #1547 was to move style declarations from the `body` element to the `head` element. However, some scripts were also moved by #1547 from `body` to `head`. That has led to the regressions detailed in #1577.

There are four scripts involved. I have checked them. Three of them are about tabsets, floating TOC and code folding and need to be moved in the `body`. The fourth script is this one:
https://github.com/rstudio/rmarkdown/blob/d1b9935d982547f1d116b32d74795331689cfba5/inst/rmd/h/default.html#L277-L293

I have not found any trouble with this one.

With the current PR, the three scripts in trouble are moved back in the `body` element.

#### Test files

Here are the Rmd files I used to perform tests. I copy them here for the record.

##### Tabsets

```markdown
---
output:
  html_document:
    template:
    # test with the template before #1547
    #- https://raw.githubusercontent.com/rstudio/rmarkdown/3a502fa8e85425aa7af723c1b4d2eecda9d7c632/inst/rmd/h/default.html
    # test with the template modified by #1547
    #- https://raw.githubusercontent.com/rstudio/rmarkdown/c6d06159c4860d45d0cfb09b79b39ade5f8a215b/inst/rmd/h/default.html
    # test with the current PR
    - https://raw.githubusercontent.com/RLesur/rmarkdown/bugfix/issue-1577/inst/rmd/h/default.html
runtime: shiny
---

## Title {.tabset .tabset-fade}
Content above tabbed region.

### Tab 1 
Tab 1 content

### Tab 2
Tab 2 content
```

##### Floating TOC

```markdown
---
title: "Habits"
output:
  html_document:
    toc: true
    toc_float:
      collapsed: false
    template:
    # test with the template before #1547
    #- https://raw.githubusercontent.com/rstudio/rmarkdown/3a502fa8e85425aa7af723c1b4d2eecda9d7c632/inst/rmd/h/default.html
    # test with the template modified by #1547
    #- https://raw.githubusercontent.com/rstudio/rmarkdown/c6d06159c4860d45d0cfb09b79b39ade5f8a215b/inst/rmd/h/default.html
    # test with the current PR
    - https://raw.githubusercontent.com/RLesur/rmarkdown/bugfix/issue-1577/inst/rmd/h/default.html
runtime: shiny
---

# First Section

Some text in the first section.

# Second section

Some text in the second section.
```

##### Code folding

    ---
    title: "Habits"
    output:
      html_document:
        code_folding: hide
        template:
        # test with the template before #1547
        #- https://raw.githubusercontent.com/rstudio/rmarkdown/3a502fa8e85425aa7af723c1b4d2eecda9d7c632/inst/rmd/h/default.html
        # test with the template modified by #1547
        #- https://raw.githubusercontent.com/rstudio/rmarkdown/c6d06159c4860d45d0cfb09b79b39ade5f8a215b/inst/rmd/h/default.html
        # test with the current PR
        - https://raw.githubusercontent.com/RLesur/rmarkdown/bugfix/issue-1577/inst/rmd/h/default.html
    runtime: shiny
    ---
    
    ```{r}
    summary(cars)
    ```
