### PR TITLE
With an alternate MathJax URL and a custom template, Pandoc argument should be of the form '--mathjax=URL'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ rmarkdown 1.14
 
 - Added a **pkgdown** site for the **rmarkdown** package: https://rmarkdown.rstudio.com/docs/ (thanks, @apreshill, #1574).
 
+- Fixed the bug #1593: in HTML documents, when a MathJax URL is used with `self_contained = FALSE`, the source code of the MathJax library is included in the document. This bug was first declared in **bookdown** (thanks, @topepo for the bug report rstudio/bookdown#683, and @RLesur for the fix #1594).
+
 
 rmarkdown 1.13
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ rmarkdown 1.14
 
 - Added a **pkgdown** site for the **rmarkdown** package: https://rmarkdown.rstudio.com/docs/ (thanks, @apreshill, #1574).
 
-- Fixed the bug #1593: in HTML documents, when a MathJax URL is used with `self_contained = FALSE`, the source code of the MathJax library is included in the document. This bug was first declared in **bookdown** (thanks, @topepo for the bug report rstudio/bookdown#683, and @RLesur for the fix #1594).
+- Fixed the bug #1593: in HTML documents, when a MathJax URL is used with a custom template, the source code of the MathJax library is included in the document. This bug was first declared in **bookdown** (thanks, @topepo for the bug report rstudio/bookdown#683, and @RLesur for the fix #1594).
 
 
 rmarkdown 1.13

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -468,9 +468,7 @@ pandoc_mathjax_args <- function(mathjax,
       args <- c(args, "--mathjax")
       args <- c(args, "--variable", paste0("mathjax-url:", mathjax))
     } else if (!self_contained) {
-      args <- c(args, "--mathjax")
-      if (!is.null(mathjax))
-        args <- c(args, mathjax)
+      args <- c(args, paste(c("--mathjax", mathjax), collapse = "="))
     } else {
       warning("MathJax doesn't work with self_contained when not ",
               "using the rmarkdown \"default\" template.", call. = FALSE)


### PR DESCRIPTION
This PR fixes #1593 and closes rstudio/bookdown#683. 

With HTML documents, when the user uses an alternate MathJax URL and a custom template, the Pandoc CLI argument generated by **rmarkdown** is `--mathjax URL`.
Therefore, the source code of the MathJax library is included in the final document.

In this case, the Pandoc argument should be of the form `--mathjax=URL`.