### PR TITLE
include X-UA-Compatible meta header for the default html template

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
+<meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 $if(theme)$
 $else$


### PR DESCRIPTION
The default IE configuration is "Display Intranet site in Compatible View" on some computers. It causes problems when displaying the rendered HTML files. 

The way to solve the issue is to either click off this set-up (as the picture below, but most users don't know) or add a meta header in the HTML file `<meta http-equiv="X-UA-Compatible" content="IE=EDGE" />` (it's preferred since no need extra knowledge from the users). 

Unfortunately, there's no obvious way to add the header. I'm saying this is because the header fragment included using `in_header = "header.html"` will be placed after the `<script>` tags. But this line needs to be placed before that in order to work on IE.

I believe adding this meta header is harmless... and the IE users will be grateful on that.

Thanks!

# The related IE configuration


![image](https://user-images.githubusercontent.com/8368933/60581401-57db2100-9db9-11e9-9d57-da1e0ef47715.png)
