### PR TITLE
fix: apply pandoc div.sourceCode style to pre.sourceCode instead

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -78,7 +78,7 @@ $endif$
       if (rule.type !== rule.STYLE_RULE || rule.selectorText !== "div.sourceCode") continue;
       var style = rule.style.cssText;
       // check if color or background-color is set
-      if (rule.style.color === '' || rule.style.backgroundColor === '') continue;
+      if (rule.style.color === '' && rule.style.backgroundColor === '') continue;
       // replace div.sourceCode by a pre.sourceCode rule
       sheets[i].deleteRule(j);
       sheets[i].insertRule('pre.sourceCode{' + style + '}', j);


### PR DESCRIPTION
This PR is a generalization of a0c0c681f03049a8e017d6ca5295160698cc17a1 (#1471)

Currently, JS converts `background-color` and `color` properties of `div.sourceCode` to `pre.sourceCode` and delete the formers iff the both properties are specified for `div.sourceCode`

Thus, `highlight: tango` with `theme: darkly` clearly shows that `div.source {background: f8f8f8}` is active.
(`tango` only specified `background-color` not `color`)

```
div.sourceCode
  {  background-color: #f8f8f8; }
```

![image](https://user-images.githubusercontent.com/30277794/60762339-7f233e00-a098-11e9-9e4b-a07c0411e78b.png)

By this PR, output becomes

![image](https://user-images.githubusercontent.com/30277794/60762452-f4900e00-a09a-11e9-87e9-3e83f06ab0f2.png)

## Source

````
---
output:
  html_document:
    theme: darkly
    highlight: tango
---

Corners of code block looks like squared due to background colors of `div`.

```r
"Hello, Rmd"
```

Line numbers have background colors because it is within `div.sourceCode`

```{.numberLines}
"Hello, world"
```

Code blocks with no class attributes are unaffected

```
"Hello, world"
```
````



