### PR TITLE
feat: individually select folding when code_folding: hide

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Authors@R: c(
   person("Richard", "Iannone", role = "aut", email = "rich@rstudio.com", comment = c(ORCID = "0000-0003-3925-190X")),
   #
   # Contributors, ordered alphabetically by first name
+  person("Atsushi", "Yasumoto", role = "ctb", comment = c(ORCID = "0000-0002-8335-495X")),
   person("Barret", "Schloerke", role = "ctb"),
   person("Christophe", "Dervieux", role = "ctb"),
   person("Frederik", "Aust", role = "ctb", email = "frederik.aust@uni-koeln.de", comment = c(ORCID = "0000-0003-4900-788X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ rmarkdown 1.15
 
 - Exclude README.R?md from files processed by render site 
 
-- `html_document` with `code_folding: hide` supports showing specific source codes if they have `fold-show` class (e.g., `class.source="fold-show"` in chunk options) (thanks, @atusy, #1602).
+- `html_document` with `code_folding: hide` supports showing individual source code chunks if they are assigned the `fold-show` class via the chunk option `class.source="fold-show"` (thanks, @atusy, #1602).
 
 rmarkdown 1.14
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 1.15
 ================================================================================
 
-
+- `html_document` with `code_folding: hide` supports showing specific source codes if they have `fold-show` class (e.g., `class.source="fold-show"` in chunk options) (thanks, @atusy, #1602).
 
 rmarkdown 1.14
 ================================================================================

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -22,7 +22,7 @@ window.initializeCodeFolding = function(show) {
 
     // create a collapsable div to wrap the code in
     var div = $('<div class="collapse r-code-collapse"></div>');
-    if (show)
+    if (show || $(this)[0].classList.contains('fold-show'))
       div.addClass('in');
     var id = 'rcode-643E0F36' + currentIndex++;
     div.attr('id', id);


### PR DESCRIPTION
This PR enables code_folding for a specific chunk and closes #664.

This works by hiding all source codes as default except for sources that have 'fold-show' class.

- specifying `code_folding: hide` in YAML front matter
- specifying `class.source='fold-show'`

````
---
output:
  html_document:
    code_folding: hide
---

```{r class.source = 'fold-show'}
1
```

```{r class.source = 'fold-show'}
2
```

```{r}
# This source is hidden
```
````

If anyone wants to default to show all and hide specific ones, try

````
---
output:
  html_document:
    code_folding: hide
---

```{r}
knitr::opts_chunk$set(class.source='fold-show')
```

```{r}
'Shown by default'
```

```{r class.source = NULL}
'Hidden manually'
```
````

Maybe we can consider more for better class name?
