### PR TITLE
use --metadata-file to not override pagetitle inside document

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -402,7 +402,7 @@ copy_render_intermediates <- function(original_input, encoding, intermediates_di
   dest_dir <- normalize_path(intermediates_dir)
   source_dir <- dirname(normalize_path(original_input))
 
-  # process each returned reosurce
+  # process each returned resource
   by(resources, seq_len(nrow(resources)), function(res) {
     # skip web resources if requested
     if (skip_web && res$web) return()


### PR DESCRIPTION
This is a PR to illustrate one of the fix suggested in #1607 

It uses `--metadata-file` instead of `--metadata` in pandoc command line to define `pagetitle` and not override one that would be provided in the document. 

With this fix, this now works
````
---
output: 
  flexdashboard::flex_dashboard
---

```{r setup, include=FALSE}
my_title <- "I am the title"
```

---
pagetitle: `r my_title`
---

Test R Markdown flexdashboard

```` 

`pagetitle` is used here because it is the one variable used in flexdashboard. see rstudio/flexdashboard#226

However, in this case 
````
---
output: 
  html_document
---

```{r setup, include=FALSE}
my_title <- "I am the title"
```

---
title: `r my_title`
---

Test R Markdown
````
`pagetitle` is still set by rmarkdown to the utf8filename
![image](https://user-images.githubusercontent.com/6791940/61968755-1402c280-afd9-11e9-9a4b-116ee7713d14.png)
unless this is done (possible with this fix)
````
---
output: 
  html_document
---

```{r setup, include=FALSE}
my_title <- "I am the title"
```

---
title: `r my_title`
pagetitle: `r my_title`
---

Test R Markdown
````

is this an interesting fix? 

If so, there still needs a bullet in NEWS and maybe some tests ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/rmarkdown/1608)
<!-- Reviewable:end -->
