### PR TITLE
unspecify img's heigth in css

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -161,7 +161,6 @@ code {
 }
 img {
   max-width:100%;
-  height: auto;
 }
 .tabbed-pane {
   padding-top: 12px;


### PR DESCRIPTION
This PR modifies CSS in the template of `html_document`.

``` css
img {
  max-width:100%;
  height: auto;
}
```

becomes

``` css
img {
  max-width:100%;
}
```

The fixes the `out.height`  chunk option being ignored on browser.
It is ignored because `out.height` specifies the `img` tag's `height` attribute, which has less priority than CSS's `height` property.

Even if `height: auto;` is removed, resizing images works fine without breaking aspect ratios of raw images.