### PR TITLE
Enable breezedark syntax highlighting

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -173,7 +173,8 @@ highlighters <- function() {
     "monochrome",
     "espresso",
     "zenburn",
-    "haddock")
+    "haddock",
+    "breezedark")
 }
 
 merge_lists <- function(base_list, overlay_list, recursive = TRUE) {


### PR DESCRIPTION
Highlighting style `breezedark` has been available in pandoc since version [`1.19.2`](https://github.com/jgm/pandoc/releases/tag/1.19.2).

```bash
$ pandoc --list-highlight-styles
pygments
tango
espresso
zenburn
kate
monochrome
breezedark
haddock
```
<img width="270" alt="Screen Shot 2019-08-15 at 7 30 08 PM" src="https://user-images.githubusercontent.com/6521018/63092113-2ac28680-bf93-11e9-915b-0714c7064676.png">

Given `1.19.2` was released in Jan 2017 and the pandoc I got with RStudio is `2.3.1` I guess it's safe to enable this. Just that it's stated in many places that the minimum version is `1.12.3`.
