### PR TITLE
In html_vignette, do not clean when self_contained is FALSE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ rmarkdown 1.16
 
 - Added `self_contained` argument to `html_vignette` to keep intermediate directory if `self_contained = FALSE` (thanks, @cderv, #1641)
 
-- It is now possible to add pagebreak in html, word, latex and odt documents using `\newpage` or `\pagebreak` command in a Rmd file. This is possible thanks to [_pandoc's pagebreak lua filter_](https://github.com/pandoc/lua-filters/tree/master/pagebreak). See `vignette("pagebreak", package = "rmarkdown")`
+- It is now possible to add pagebreak in html, word, latex and odt documents using `\newpage` or `\pagebreak` command in a Rmd file. This is possible thanks to [_pandoc's pagebreak lua filter_](https://github.com/pandoc/lua-filters/tree/master/pagebreak). See `vignette("pagebreak", package = "rmarkdown")` (thanks, @cderv, #1626)
 
 - Output formats can be configured by arbitrary YAML files, which used to be restricted to `_output.yml` or `_output.yaml`. They can be specified via the `output_yaml` argument of `render()` or the `output_yaml` top-level parameter of YAML front matter, and the first existing one will be used. If `output_yaml` is specified both for `render()` and YAML front matter, then `render()` has the priority. If none are found, then `_output.yml` or `_output.yaml` will be used if they exist (thanks, @atusy, #1634).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 1.16
 ================================================================================
 
+- Added `self_contained` argument to `html_vignette` to keep intermediate directory if `self_contained = FALSE` (thanks, @cderv, #1641)
+
 - It is now possible to add pagebreak in html, word, latex and odt documents using `\newpage` or `\pagebreak` command in a Rmd file. This is possible thanks to [_pandoc's pagebreak lua filter_](https://github.com/pandoc/lua-filters/tree/master/pagebreak). See `vignette("pagebreak", package = "rmarkdown")`
 
 - Output formats can be configured by arbitrary YAML files, which used to be restricted to `_output.yml` or `_output.yaml`. They can be specified via the `output_yaml` argument of `render()` or the `output_yaml` top-level parameter of YAML front matter, and the first existing one will be used. If `output_yaml` is specified both for `render()` and YAML front matter, then `render()` has the priority. If none are found, then `_output.yml` or `_output.yaml` will be used if they exist (thanks, @atusy, #1634).

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -32,6 +32,7 @@ html_vignette <- function(fig_width = 3,
                           css = NULL,
                           keep_md = FALSE,
                           readme = FALSE,
+                          self_contained = TRUE,
                           ...) {
 
   if (is.null(css)) {
@@ -56,6 +57,7 @@ html_vignette <- function(fig_width = 3,
     df_print = df_print,
     pre_knit = pre_knit,
     keep_md = keep_md,
+    clean_supporting = self_contained,
     base_format = html_document(fig_width = fig_width,
                                 fig_height = fig_height,
                                 dev = dev,

--- a/man/html_vignette.Rd
+++ b/man/html_vignette.Rd
@@ -6,7 +6,7 @@
 \usage{
 html_vignette(fig_width = 3, fig_height = 3, dev = "png",
   df_print = "default", css = NULL, keep_md = FALSE,
-  readme = FALSE, ...)
+  readme = FALSE, self_contained = TRUE, ...)
 }
 \arguments{
 \item{fig_width}{Default width (in inches) for figures}
@@ -33,6 +33,12 @@ by setting the option \code{rmarkdown.df_print} to \code{FALSE}.}
 \item{readme}{Use this vignette as the package README.md file (i.e. render
 it as README.md to the package root). Note that if there are image files
 within your vignette you should be sure to add README_files to .Rbuildignore}
+
+\item{self_contained}{Produce a standalone HTML file with no external
+dependencies, using data: URIs to incorporate the contents of linked
+scripts, stylesheets, images, and videos. Note that even for self contained
+documents MathJax is still loaded externally (this is necessary because of
+its size).}
 
 \item{...}{Additional arguments passed to \code{\link{html_document}}. Please
 note that \code{theme}, \code{fig_retina} and \code{highlight} are hard


### PR DESCRIPTION
This PR closes #1639 by adding a `self_contained` argument explicitly to `html_vignette` to pass to `clean_supporting`. 

This will prevent cleaning directory if `self_contained = FALSE` as it was reported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/rmarkdown/1641)
<!-- Reviewable:end -->
