### PR TITLE
Allow the user to remove default/base html dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.15.1
+Version: 1.15.1.9000
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -78,6 +78,8 @@
 #'  default definition or R Markdown. See the \code{\link{rmarkdown_format}} for
 #'  additional details.
 #'@param pandoc_args Additional command line options to pass to pandoc
+#'@param include_base_dependencies Include the base dependencies added by
+#'rmarkdown (currently jquery, jqueryui, tocify, and navigation)
 #'@param extra_dependencies,... Additional function arguments to pass to the
 #'  base R Markdown HTML output formatter \code{\link{html_document_base}}
 #'@return R Markdown output format to pass to \code{\link{render}}
@@ -198,6 +200,7 @@ html_document <- function(toc = FALSE,
                           highlight = "default",
                           mathjax = "default",
                           template = "default",
+                          include_base_dependencies = TRUE,
                           extra_dependencies = NULL,
                           css = NULL,
                           includes = NULL,
@@ -324,6 +327,10 @@ html_document <- function(toc = FALSE,
                                  list(html_dependency_pagedtable()))
   }
 
+  if (!include_base_dependencies){
+    extra_dependencies <- list()
+  }
+
   # pre-processor for arguments that may depend on the name of the
   # the input file AND which need to inject html dependencies
   # (otherwise we could just call the pre_processor)
@@ -445,6 +452,7 @@ html_document <- function(toc = FALSE,
                                      lib_dir = lib_dir, mathjax = mathjax,
                                      template = template,
                                      pandoc_args = pandoc_args,
+                                     include_base_dependencies = include_base_dependencies,
                                      extra_dependencies = extra_dependencies,
                                      ...)
   )

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -23,6 +23,7 @@ html_document_base <- function(smart = TRUE,
                                template = "default",
                                dependency_resolver = NULL,
                                copy_resources = FALSE,
+                               include_base_dependencies = TRUE,
                                extra_dependencies = NULL,
                                bootstrap_compatible = FALSE,
                                ...) {
@@ -83,14 +84,16 @@ html_document_base <- function(smart = TRUE,
     # resolve and inject extras, including dependencies specified by the format
     # and dependencies specified by the user (via extra_dependencies)
     format_deps <- list()
-    if (!is.null(theme)) {
-      format_deps <- append(format_deps, list(html_dependency_jquery(),
-                                              html_dependency_bootstrap(theme)))
-    }
-    else if (isTRUE(bootstrap_compatible) && is_shiny(runtime)) {
-      # If we can add bootstrap for Shiny, do it
-      format_deps <- append(format_deps,
-                            list(html_dependency_bootstrap("bootstrap")))
+    if (include_base_dependencies){
+      if (!is.null(theme)) {
+        format_deps <- append(format_deps, list(html_dependency_jquery(),
+                                                html_dependency_bootstrap(theme)))
+      }
+      else if (isTRUE(bootstrap_compatible) && is_shiny(runtime)) {
+        # If we can add bootstrap for Shiny, do it
+        format_deps <- append(format_deps,
+                              list(html_dependency_bootstrap("bootstrap")))
+      }
     }
     format_deps <- append(format_deps, extra_dependencies)
 

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -10,9 +10,10 @@ html_document(toc = FALSE, toc_depth = 3, toc_float = FALSE,
   df_print = "default", code_folding = c("none", "show", "hide"),
   code_download = FALSE, smart = TRUE, self_contained = TRUE,
   theme = "default", highlight = "default", mathjax = "default",
-  template = "default", extra_dependencies = NULL, css = NULL,
-  includes = NULL, keep_md = FALSE, lib_dir = NULL,
-  md_extensions = NULL, pandoc_args = NULL, ...)
+  template = "default", include_base_dependencies = TRUE,
+  extra_dependencies = NULL, css = NULL, includes = NULL,
+  keep_md = FALSE, lib_dir = NULL, md_extensions = NULL,
+  pandoc_args = NULL, ...)
 }
 \arguments{
 \item{toc}{\code{TRUE} to include a table of contents in the output}
@@ -95,6 +96,9 @@ built-in template; pass a path to use a custom template that you've created.
 Note that if you don't use the "default" template then some features of
 \code{html_document} won't be available (see the Templates section below for
 more details).}
+
+\item{include_base_dependencies}{Include the base dependencies added by
+rmarkdown (currently jquery, jqueryui, tocify, and navigation)}
 
 \item{extra_dependencies, ...}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link{html_document_base}}}

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -7,8 +7,8 @@
 html_document_base(smart = TRUE, theme = NULL, self_contained = TRUE,
   lib_dir = NULL, mathjax = "default", pandoc_args = NULL,
   template = "default", dependency_resolver = NULL,
-  copy_resources = FALSE, extra_dependencies = NULL,
-  bootstrap_compatible = FALSE, ...)
+  copy_resources = FALSE, include_base_dependencies = TRUE,
+  extra_dependencies = NULL, bootstrap_compatible = FALSE, ...)
 }
 \arguments{
 \item{smart}{Produce typographically correct output, converting straight
@@ -47,6 +47,9 @@ more details).}
 \item{dependency_resolver}{A dependency resolver}
 
 \item{copy_resources}{Copy resources}
+
+\item{include_base_dependencies}{Include the base dependencies added by
+rmarkdown (currently jquery, jqueryui, tocify, and navigation)}
 
 \item{extra_dependencies}{Extra dependencies}
 


### PR DESCRIPTION
I've currently got a specific use case where I have a bunch of automated reports that will all be pushed to a website.
They all have a similar structure and therefore have many similar dependencies. As a result, instead of making many seperate HTML files that each have their own local references to the required libraries (that also get produced each time each file is rendered), I added the references that will be required when the files are live on the website within the RMarkdown files themselves.

This led to the issue of duplicated library references, where the head would contain references to the default libraries (jquery, navigation, etc.) that were included when the file was rendered, and the body containing the references that I added myself that pointed to the libraries on the website server.

To rectify this, I added a `include_base_dependencies` parameter to the `html_document()` function. When set to TRUE, the default libraries are added as usual. When set to FALSE, no extra dependencies are added in the head of the HTML file.

This required minimal changes to the `html_document()` and `html_document_base()` functions to only add the dependencies if `include_base_dependencies` is TRUE.

I understand that this use-case is quite specific and the changes that it required may not be conducive to the philisophy and approach of the package. But I thought I'd create the pull request anyway in case the ability to remove all dependencies from an HTML file is useful to anyone else.