### PR TITLE
add keep_html option for github_document (closes #1648)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ rmarkdown 1.16
 
 - Added a Pandoc lua filter to convert fenced Divs to LaTeX environments when the output format is `latex` or `beamer`. Basically a fenced Div `::: {.NAME data-latex="[OPTIONS]"}` is converted to `\begin{NAME}[OPTIONS] \end{NAME}` in LaTeX. The attribute `data-latex` must be provided, even if it is an empty string (meaning that the LaTeX environment does not have any optional arguments). For example, `::: {.verbatim data-latex=""}` generates a `verbatim` environment, and `::: {.minipage data-latex="{.5\textwidth}"}` generates `\begin{minipage}{.5\textwidth}`. This lua filter was originally written by @RLesur at https://github.com/yihui/bookdown-crc/issues/1. It will allow users to create custom blocks that work for both HTML and LaTeX output (e.g., info boxes or warning boxes).
 
+- Added `keep_html` argument to `github_document` so to save a preview HTML file in a working directory (thanks, @atusy, #1650).
 
 rmarkdown 1.15
 ================================================================================

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -12,6 +12,8 @@
 #'   newline to represent a line break (as opposed to two-spaces and a newline).
 #' @param html_preview \code{TRUE} to also generate an HTML file for the purpose of
 #'   locally previewing what the document will look like on GitHub.
+#' @param keep_html \code{TRUE} to keep the preview HTML file in the working
+#'   directory. Default is \code{FALSE}.
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @export
 github_document <- function(toc = FALSE,
@@ -24,7 +26,8 @@ github_document <- function(toc = FALSE,
                             md_extensions = NULL,
                             hard_line_breaks = TRUE,
                             pandoc_args = NULL,
-                            html_preview = TRUE) {
+                            html_preview = TRUE,
+                            keep_html = FALSE) {
 
   # add special markdown rendering template to ensure we include the title fields
   pandoc_args <- c(
@@ -75,12 +78,14 @@ github_document <- function(toc = FALSE,
       )
 
       # move the preview to the preview_dir if specified
-      preview_dir <- Sys.getenv("RMARKDOWN_PREVIEW_DIR", unset = NA)
-      if (!is.na(preview_dir)) {
-        relocated_preview_file <- tempfile("preview-", preview_dir, ".html")
-        file.copy(preview_file, relocated_preview_file)
-        file.remove(preview_file)
-        preview_file <- relocated_preview_file
+      if (!keep_html) {
+        preview_dir <- Sys.getenv("RMARKDOWN_PREVIEW_DIR", unset = NA)
+        if (!is.na(preview_dir)) {
+          relocated_preview_file <- tempfile("preview-", preview_dir, ".html")
+          file.copy(preview_file, relocated_preview_file)
+          file.remove(preview_file)
+          preview_file <- relocated_preview_file
+        }
       }
 
       if (verbose) message("\nPreview created: ", preview_file)

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -7,7 +7,7 @@
 github_document(toc = FALSE, toc_depth = 3, fig_width = 7,
   fig_height = 5, dev = "png", df_print = "default",
   includes = NULL, md_extensions = NULL, hard_line_breaks = TRUE,
-  pandoc_args = NULL, html_preview = TRUE)
+  pandoc_args = NULL, html_preview = TRUE, keep_html = FALSE)
 }
 \arguments{
 \item{toc}{\code{TRUE} to include a table of contents in the output}
@@ -45,6 +45,9 @@ newline to represent a line break (as opposed to two-spaces and a newline).}
 
 \item{html_preview}{\code{TRUE} to also generate an HTML file for the purpose of
 locally previewing what the document will look like on GitHub.}
+
+\item{keep_html}{\code{TRUE} to keep the preview HTML file in the working
+directory. Default is \code{FALSE}.}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}


### PR DESCRIPTION
This PR adds `keep_html` argument to `github_document` so to save a preview HTML file in a working directory.
See https://github.com/rstudio/rmarkdown/issues/1648 for the use case.