### PR TITLE
Correct Pandoc citeproc binary on windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 1.16
 ================================================================================
 
+- Pandoc and Pandoc citeproc binaries are now found correctly on Windows. This fixes an issue with `pandoc_citeproc_convert()` (thanks @cderv, #1651).
+
 - Added `self_contained` argument to `html_vignette` to keep intermediate directory if `self_contained = FALSE` (thanks, @cderv, #1641)
 
 - It is now possible to add pagebreak in HTML, Word, LaTeX, and ODT documents using the `\newpage` or `\pagebreak` command in an Rmd file. This is possible thanks to the [Pandoc's pagebreak lua filter](https://github.com/pandoc/lua-filters/tree/master/pagebreak). See `vignette("lua-filters", package = "rmarkdown")` (thanks, @cderv, #1626).

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -664,13 +664,13 @@ pandoc <- function() {
 
 # get the path to the pandoc-citeproc binary
 pandoc_citeproc <- function() {
-
   find_pandoc()
-  citeproc_path = file.path(.pandoc$dir, "pandoc-citeproc")
+  bin = xfun::with_ext("pandoc-citeproc", if (xfun::is_windows()) "exe")
+  citeproc_path = file.path(.pandoc$dir, bin)
   if (file.exists(citeproc_path))
     citeproc_path
   else
-    "pandoc-citeproc"
+    bin
 }
 
 pandoc_lua_filters <- function(...) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -665,8 +665,8 @@ pandoc <- function() {
 # get the path to the pandoc-citeproc binary
 pandoc_citeproc <- function() {
   find_pandoc()
-  bin = xfun::with_ext("pandoc-citeproc", if (xfun::is_windows()) "exe")
-  citeproc_path = file.path(.pandoc$dir, bin)
+  bin <- xfun::with_ext("pandoc-citeproc", if (xfun::is_windows()) "exe")
+  citeproc_path <- file.path(.pandoc$dir, bin)
   if (file.exists(citeproc_path))
     citeproc_path
   else

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -657,20 +657,17 @@ detect_generic_lang <- function() {
 # get the path to the pandoc binary
 pandoc <- function() {
   find_pandoc()
-  bin <- xfun::with_ext("pandoc", if (xfun::is_windows()) "exe")
-  file.path(.pandoc$dir, bin)
+  file.path(.pandoc$dir, "pandoc")
 }
 
 
 # get the path to the pandoc-citeproc binary
 pandoc_citeproc <- function() {
   find_pandoc()
-  bin <- xfun::with_ext("pandoc-citeproc", if (xfun::is_windows()) "exe")
-  citeproc_path <- file.path(.pandoc$dir, bin)
-  if (file.exists(citeproc_path))
-    citeproc_path
-  else
-    bin
+  bin <- "pandoc-citeproc"
+  p <- file.path(.pandoc$dir, bin)
+  if (xfun::is_windows()) p <- xfun::with_ext(p, "exe")
+  if (file.exists(p)) p else bin
 }
 
 pandoc_lua_filters <- function(...) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -656,9 +656,9 @@ detect_generic_lang <- function() {
 
 # get the path to the pandoc binary
 pandoc <- function() {
-
   find_pandoc()
-  file.path(.pandoc$dir, "pandoc")
+  bin <- xfun::with_ext("pandoc", if (xfun::is_windows()) "exe")
+  file.path(.pandoc$dir, bin)
 }
 
 


### PR DESCRIPTION
This fixes #1651 and also shoud fix https://github.com/rstudio/distill/issues/103

`pandoc_citeproc()` will now look on windows for a `pandoc-citeproc.exe` in pandoc directory, or if not found, default to a local directory binary. 

`pandoc` works a bit differently but was also returning a path with the`.exe`. It was working because `pandoc()` was not checking for existence of the binary, and calling a binary without `.exe` works on windows. However, I also integrated the `.exe` extension. 

Is this clever or should we only change `pandoc_citeproc.exe` as the issue is currently only with `pandoc_citeproc_convert()` ? 

It is easy to revert commit if required.

I wanted to add tests, but rmarkdown as a few test only and not sure what is expected in this package. Locally, tests passes on my computer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/rmarkdown/1653)
<!-- Reviewable:end -->
