### PR TITLE
pass self_contained argument value to base format too

### DIFF
--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -65,6 +65,7 @@ html_vignette <- function(fig_width = 3,
                                 css = css,
                                 theme = NULL,
                                 highlight = "pygments",
+                                self_contained = self_contained,
                                 ...)
   )
 }


### PR DESCRIPTION
This fixes #1667 

Bug was introduced in https://github.com/rstudio/rmarkdown/pull/1641 where a new `self_contained` argument has been added to `html_vignette`. 

The value must be passed to _base _format_ too and this was not the case. It seems it was creating confict. Just adding it seems to fix the issue. 

# Reprex I tested with

```r
dir.create(temp_dir <- tempfile())
download.file("https://github.com/rstudio/rmarkdown/files/3713183/image_not_found.zip", 
              destfile = file.path(temp_dir, "test.zip"), mode = "wb")
unzip(file.path(temp_dir, "test.zip"), exdir = temp_dir)
list.files(temp_dir)

# to execute inside `rmarkdown.Rproj` directory
devtools::load_all()
old <- setwd(temp_dir)
render("test.Rmd")
render("test.Rmd", intermediates_dir = tempdir())
setwd(old)
unlink(temp_dir, recursive = TRUE)
```