### PR TITLE
Fix overlapping content while printing on Firefox with a TOC.

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -383,6 +383,8 @@ $endif$
 .toc-content {
   padding-left: 30px;
   padding-right: 40px;
+  /* For printing, see https://github.com/w3c/csswg-drafts/issues/4434 */
+  float: right;
 }
 
 div.main-container {

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -371,20 +371,22 @@ $if(toc_float)$
 }
 }
 
+@media print {
 $if(toc_print)$
 $else$
-@media print {
 #$idprefix$TOC {
   display: none !important;
 }
-}
 $endif$
+.toc-content {
+  /* see https://github.com/w3c/csswg-drafts/issues/4434 */
+  float: right;
+}
+}
 
 .toc-content {
   padding-left: 30px;
   padding-right: 40px;
-  /* For printing, see https://github.com/w3c/csswg-drafts/issues/4434 */
-  float: right;
 }
 
 div.main-container {


### PR DESCRIPTION
Since there's only one empty left-float, only one page gets pushed to the right.

This is a deeper issue which as far as I can tell is not defined in the
specification, see https://github.com/w3c/csswg-drafts/issues/4434 for an
example with multicol.

This fixes the print issue on Firefox by floating the content to the right,
which produces the desired layout and prevents overlapping the table of
contents.