### PR TITLE
Partial match of 'package' to 'packages' when rendering shiny-prerendered documents

### DIFF
--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -230,7 +230,7 @@ shiny_prerendered_prerender <- function(
   # check for execution package version differences
   execution_json <- shiny_prerendered_extract_context(html_lines, "execution_dependencies")
   execution_info <- jsonlite::unserializeJSON(execution_json)
-  execution_pkg_names <- execution_info$packages$package
+  execution_pkg_names <- execution_info$packages$packages
   execution_pkg_versions <- execution_info$packages$version
   for (i in seq_along(execution_pkg_names)) {
     if (!identical(


### PR DESCRIPTION
Following the trail, it corresponds to https://github.com/rstudio/rmarkdown/blob/26ffc0c5507674e3ae283de10eff65e1d1733ef8/R/util.R#L518

in 

https://github.com/rstudio/rmarkdown/blob/26ffc0c5507674e3ae283de10eff65e1d1733ef8/R/util.R#L511-L522

being stored in 

https://github.com/rstudio/rmarkdown/blob/26ffc0c5507674e3ae283de10eff65e1d1733ef8/R/render.R#L449-L456

