### PR TITLE
fix for windows 10 xelatex no image render

### DIFF
--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -114,6 +114,9 @@ pdf_document <- function(toc = FALSE,
     pandoc_available(error = TRUE)
     # choose the right template
     version <- pandoc_version()
+    if (latex_engine == "xelatex")
+      latex_template <- "default.tex"
+    else
     if (version >= "1.17.0.2")
       latex_template <- "default-1.17.0.2.tex"
     else if (version >= "1.15.2")


### PR DESCRIPTION
After a recent update I have found that png, jpg, etc. images no longer render with \includegraphics under xelatex on Windows 10 with the latest updates and formats to MikTex (pdf do render). Images all render correctly under pdflatex and luatex, but not using xelatex. Apparently the conflict is in the line `\usepackage{graphicx,grffile}` triggered by higher pandoc versions as opposed to `\usepackage{graphicx}` as the default. This pull request invokes `default.tex` ahead of other template considerations when latex_engine == 'xelatex'. This resolves the issues for my purposes and may be of value to other Windows users who experience the same problem. A more thoughtful integration of this change to the alternate pandoc version templates may be worthy of consideration.

Cross posting this here in case this is of value to others...

https://github.com/MiKTeX/miktex-packaging/issues/131#issuecomment-552168956