### PR TITLE
Prevent rmarkdown::run from failing when file is NULL and dir is set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ rmarkdown 1.18
 
 - `find_external_resources()` can find external resources specified in the output format's `reference_doc` or `reference_docx` option now (thanks, @jmcphers, #1696).
 
+- `rmarkdown::run(file = NULL, dir = "foo/")` failed to run Rmd files under the `foo/` directory (thanks, @jenzopr, #1703).
+
 
 rmarkdown 1.17
 ================================================================================

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -73,19 +73,19 @@ run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
     allRmds <- list.files(path = dir, pattern = "^[^_].*\\.[Rr][Mm][Dd]$")
     if (length(allRmds) == 1) {
       # just one R Markdown document
-      default_file <- allRmds
+      default_file <- file.path(dir, allRmds)
     } else {
       # more than one: look for an index
       index <- which(tolower(allRmds) == "index.rmd")
       if (length(index) > 0) {
-        default_file <- allRmds[index[1]]
+        default_file <- file.path(dir, allRmds[index[1]])
       } else {
         # look for first one that has runtime: shiny
         for (rmd in allRmds) {
           encoding <- render_args$encoding %||% "UTF-8"
           runtime <- yaml_front_matter(file.path(dir, rmd), encoding)$runtime
           if (is_shiny(runtime)) {
-            default_file <- rmd
+            default_file <- file.path(dir, rmd)
             break
           }
         }
@@ -96,7 +96,7 @@ run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
   if (is.null(default_file)) {
     # no R Markdown default found; how about an HTML?
     indexHtml <- list.files(dir, "index.html?", ignore.case = TRUE)
-    if (length(indexHtml) > 0) default_file <- indexHtml[1]
+    if (length(indexHtml) > 0) default_file <- file.path(dir, indexHtml[1])
   }
 
   # form and test locations


### PR DESCRIPTION
Hi Yihui,

I prefixed all occurrences of `default_file` with values from `dir` in case it was `NULL`. This allows the user to give a full path for `default_file` as well. 

Xref: #1700 

Best,
Jens