### PR TITLE
Made `rmarkdown:::list_template_dirs()` a little bit faster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Authors@R: c(
   person("Christophe", "Dervieux", role = "ctb"),
   person("Frederik", "Aust", role = "ctb", email = "frederik.aust@uni-koeln.de", comment = c(ORCID = "0000-0003-4900-788X")),
   person("Jeff", "Allen", role = "ctb", email = "jeff@rstudio.com"),
+  person("JooYoung", "Seo", role="ctb", comment = c(ORCID = "0000-0002-4064-6012")),
   person("Malcolm", "Barrett", role = "ctb"),
   person("Rob", "Hyndman", role = "ctb", email = "Rob.Hyndman@monash.edu"),
   person("Romain", "Lesur", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ rmarkdown 1.18
 
 - Removed the `xmlns` attribute in the `<html>` tag in the default HTML template (thanks, @grady #1640, @spgarbet #995).
 
+- Made `rmarkdown:::list_template_dirs()` a little bit faster.
+
 
 rmarkdown 1.17
 ================================================================================

--- a/R/draft.R
+++ b/R/draft.R
@@ -141,13 +141,13 @@ list_template_dirs <- function() {
 
     # check to see if the package includes a template folder
     template_folder <- system.file("rmarkdown", "templates", package = pkg)
-    if (dir_exists(template_folder)) {
+    if (fs::dir_exists(template_folder)) {
 
       # it does; list each template directory within the template folder
       template_dirs <- list.dirs(path = template_folder, recursive = FALSE)
-      for (dir in template_dirs) {
+      lapply(template_dirs, function(dir) {
         cat(pkg, "|", dir, "\n", sep = "")
-      }
+      })
     }
   }
 }


### PR DESCRIPTION
* Replaced `for` loop with `lapply()`, which gives a little bit faster performance.