### PR TITLE
knit metadata from yaml that could contains R code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 1.18.3
+Version: 1.18.4
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 1.19
 
 - For the output format `pdf_document()`, we no longer adjust the vertical spacing of the title area. This means there will be a larger spacing above the document title in PDF. If you prefers the old (smaller) spacing, please download https://github.com/rstudio/rmarkdown/blob/f6961af/inst/rmd/latex/compact-title.tex and include it to the preamble via the `includes` option of `pdf_document`. However, please note that this means you won't be able to have multiple authors in the `author` field of the YAML frontmatter, unless you use a custom LaTeX template. With the default LaTeX template, you will run into the error in #1716. Besides, the `compact-title` option in YAML is no longer supported.
 
+- R code in the `header-includes` field in the YAML frontmatter stopped working in the previous version of **rmarkdown**. The code should be evaluated before passing to Pandoc (thanks, @mcol #1709, @cderv #1710).
+
 - The `encoding` argument is no longer passed to the `intermediates_generator` of R Markdown output formats. The `intermediates_generator` function can only accept arguments `input_file` and `intermediates_dir` now (see `?rmarkdown::output_format`). This is a breaking change to developers. If you are an output format developer, you have to remove the `encoding` argument in your `intermediates_generator` if your output format uses this function.
 
 - The `encoding` argument is no longer passed to the `render` element of the site generator (see `?rmarkdown::render_site`).

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -108,7 +108,11 @@ pdf_document <- function(toc = FALSE,
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
-  append_in_header <- function(text, file = as_tmpfile(text)) {
+  append_in_header <- function(text, file = as_tmpfile(text), knit = FALSE) {
+    if (knit) {
+      # if text contains R inline code
+      knitr::knit(text = xfun::read_utf8(file), output = file, quiet = TRUE)
+    }
     includes_to_pandoc_args(includes(in_header = file))
   }
 
@@ -156,7 +160,7 @@ pdf_document <- function(toc = FALSE,
     # make sure --include-in-header from command line will not completely
     # override header-includes in metadata but give the latter lower precedence:
     # https://github.com/rstudio/rmarkdown/issues/1359
-    args <- append_in_header(metadata[["header-includes"]])
+    args <- append_in_header(metadata[["header-includes"]], knit = TRUE)
 
     # use a geometry filter when we are using the "default" template
     if (identical(template, "default")) {

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -108,11 +108,7 @@ pdf_document <- function(toc = FALSE,
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
-  append_in_header <- function(text, file = as_tmpfile(text), knit = FALSE) {
-    if (knit && !is.null(file)) {
-      # Rmd yaml header can contains some R code to be knitted
-      knitr::knit(text = xfun::read_utf8(file), output = file, quiet = TRUE)
-    }
+  append_in_header <- function(text, file = as_tmpfile(text)) {
     includes_to_pandoc_args(includes(in_header = file))
   }
 
@@ -160,7 +156,10 @@ pdf_document <- function(toc = FALSE,
     # make sure --include-in-header from command line will not completely
     # override header-includes in metadata but give the latter lower precedence:
     # https://github.com/rstudio/rmarkdown/issues/1359
-    args <- append_in_header(metadata[["header-includes"]], knit = TRUE)
+    # be sure to get the knitted metadata as it will be passed to pandoc as-is:
+    # https://github.com/rstudio/rmarkdown/issues/1709
+    knitted_metadata <- yaml_front_matter(input_file)
+    args <- append_in_header(knitted_metadata[["header-includes"]])
 
     # use a geometry filter when we are using the "default" template
     if (identical(template, "default")) {

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -109,8 +109,7 @@ pdf_document <- function(toc = FALSE,
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
   append_in_header <- function(text, file = as_tmpfile(text), knit = FALSE) {
-    if (knit) {
-      # if text contains R inline code
+    if (!is.null(file) && knit) {
       knitr::knit(text = xfun::read_utf8(file), output = file, quiet = TRUE)
     }
     includes_to_pandoc_args(includes(in_header = file))

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -156,10 +156,7 @@ pdf_document <- function(toc = FALSE,
     # make sure --include-in-header from command line will not completely
     # override header-includes in metadata but give the latter lower precedence:
     # https://github.com/rstudio/rmarkdown/issues/1359
-    # be sure to get the knitted metadata as it will be passed to pandoc as-is:
-    # https://github.com/rstudio/rmarkdown/issues/1709
-    knitted_metadata <- yaml_front_matter(input_file)
-    args <- append_in_header(knitted_metadata[["header-includes"]])
+    args <- append_in_header(metadata[["header-includes"]])
 
     # use a geometry filter when we are using the "default" template
     if (identical(template, "default")) {

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -109,7 +109,8 @@ pdf_document <- function(toc = FALSE,
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
   append_in_header <- function(text, file = as_tmpfile(text), knit = FALSE) {
-    if (!is.null(file) && knit) {
+    if (knit && !is.null(file)) {
+      # Rmd yaml header can contains some R code to be knitted
       knitr::knit(text = xfun::read_utf8(file), output = file, quiet = TRUE)
     }
     includes_to_pandoc_args(includes(in_header = file))

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -108,7 +108,11 @@ pdf_document <- function(toc = FALSE,
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
-  append_in_header <- function(text, file = as_tmpfile(text)) {
+  append_in_header <- function(text, file = as_tmpfile(text), knit = FALSE) {
+    if (knit) {
+      # if text contains R inline code
+      knitr::knit(text = xfun::read_utf8(file), output = file, quiet = TRUE)
+    }
     includes_to_pandoc_args(includes(in_header = file))
   }
 
@@ -156,9 +160,7 @@ pdf_document <- function(toc = FALSE,
     # make sure --include-in-header from command line will not completely
     # override header-includes in metadata but give the latter lower precedence:
     # https://github.com/rstudio/rmarkdown/issues/1359
-    args <- append_in_header(
-      knitr::knit(text = metadata[["header-includes"]], quiet = TRUE)
-    )
+    args <- append_in_header(metadata[["header-includes"]], knit = TRUE)
 
     # use a geometry filter when we are using the "default" template
     if (identical(template, "default")) {

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -108,11 +108,7 @@ pdf_document <- function(toc = FALSE,
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
-  append_in_header <- function(text, file = as_tmpfile(text), knit = FALSE) {
-    if (knit) {
-      # if text contains R inline code
-      knitr::knit(text = xfun::read_utf8(file), output = file, quiet = TRUE)
-    }
+  append_in_header <- function(text, file = as_tmpfile(text)) {
     includes_to_pandoc_args(includes(in_header = file))
   }
 
@@ -160,7 +156,9 @@ pdf_document <- function(toc = FALSE,
     # make sure --include-in-header from command line will not completely
     # override header-includes in metadata but give the latter lower precedence:
     # https://github.com/rstudio/rmarkdown/issues/1359
-    args <- append_in_header(metadata[["header-includes"]], knit = TRUE)
+    args <- append_in_header(
+      knitr::knit(text = metadata[["header-includes"]], quiet = TRUE)
+    )
 
     # use a geometry filter when we are using the "default" template
     if (identical(template, "default")) {

--- a/R/render.R
+++ b/R/render.R
@@ -738,6 +738,8 @@ render <- function(input,
 
     perf_timer_stop("knitr")
 
+    yaml_front_matter <- yaml_front_matter(input)
+
     # call post_knit handler
     output_format$pandoc$args <- call_post_knit_handler()
 

--- a/tests/rmd/yaml-r-code.Rmd
+++ b/tests/rmd/yaml-r-code.Rmd
@@ -1,0 +1,8 @@
+---
+title: "Inline R code in YAML"
+output: pdf_document
+header-includes:
+  - \usepackage{`r "ae"`}
+---
+
+R code in YAML should be evaluated before YAML is passed to Pandoc: https://github.com/rstudio/rmarkdown/issues/1709

--- a/tests/testrmd.R
+++ b/tests/testrmd.R
@@ -26,4 +26,8 @@ if (.Platform$OS.type == 'unix' && !is.na(Sys.getenv('CI', NA))) {
   # the default LaTeX template should work with multiple authors:
   # https://github.com/rstudio/rmarkdown/issues/1716
   rmarkdown::render('rmd/two-authors.Rmd')
+
+  # R code in YAML should be evaluated before YAML is passed to Pandoc:
+  # https://github.com/rstudio/rmarkdown/issues/1709
+  rmarkdown::render('rmd/yaml-r-code.Rmd')
 }


### PR DESCRIPTION
Previously before #1359 `header-includes` was passed to pandoc through yaml header. If Rmd yaml header contains R code, md yaml header will not as it has been knit already. And `header-includes` is used in pandoc. 

The conflict between `in_header` and `header-include` is a pandoc issue really. The fix in https://github.com/rstudio/rmarkdown/commit/5499ec63dbf4b15eb8769e4a0c59843ac53abfd2 has the effect of using `--include-in-header` no matter what now. This means that if `header-includes` contains R code it will no more be knitted and pass as is to pandoc. That causes issue for people using it. 

@yihui This PR is a draft as it is more to illustrate the issue and a possible fix that closes #1709. It shows metadata could be knitted before being passed to pandoc. 

Here is way to do it by knitting the file content and replacing it. 
Another way would be to knit the header metadata before passing it to new `append_in_header`
```r
    args <- append_in_header(
         knitr::knit(text = metadata[["header-includes"]], quiet = TRUE)
   )
```

I think there is other places that uses information from the yaml _as-is_ and where inline r expression in yaml won't be taken into account. (for `includes` for example). This is also a draft as I am not sure if we want to support this everywhere or fix bugs as they come. 

This is WIP as this needs more thoughts and some special caseS handling. 

I wonder if metadata to pass to pandoc should be retrieve from knitted output rather Rmd file. Could be a way to handle all this. 