### PR TITLE
add ext argument to md_document

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ rmarkdown 1.19
 
 - `render_site()` can render R scripts in addition to Rmd files if you set `autospin: true` in `_site.yml` (thanks, @zeehio, #1564).
 
-- Added `ext` argument to `md_document()`. Its default value is ".md". This argument is intended to be used together with `variant` argument (e.g., `variant = "context"` and `ext = ".pdf"`).
+- Added `ext` argument to `md_document()`. Its default value is ".md". This argument is intended to be used together with `variant` argument (e.g., `variant = "context"` and `ext = ".pdf"`) (thanks, @atusy, #1715).
 
 rmarkdown 1.18
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ rmarkdown 1.19
 
 - `render_site()` can render R scripts in addition to Rmd files if you set `autospin: true` in `_site.yml` (thanks, @zeehio, #1564).
 
+- Added `ext` argument to `md_document()`. Its default value is ".md". This argument is intended to be used together with `variant` argument (e.g., `variant = "context"` and `ext = ".pdf"`).
 
 rmarkdown 1.18
 ================================================================================

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -22,6 +22,7 @@
 #'   widely used retina displays, but will also result in the output of
 #'   \code{<img>} tags rather than markdown images due to the need to set the
 #'   width of the image explicitly.
+#' @param ext Extention of the output document (defaults to ".md").
 #' @return R Markdown output format to pass to \code{\link{render}}
 #' @examples
 #' \dontrun{
@@ -43,7 +44,8 @@ md_document <- function(variant = "markdown_strict",
                         df_print = "default",
                         includes = NULL,
                         md_extensions = NULL,
-                        pandoc_args = NULL) {
+                        pandoc_args = NULL,
+                        ext = ".md") {
 
   # base pandoc options for all markdown output
   args <- c(if (variant != "markdown" || preserve_yaml) "--standalone")
@@ -76,7 +78,7 @@ md_document <- function(variant = "markdown_strict",
     pandoc = pandoc_options(to = variant,
                             from = from_rmarkdown(extensions = md_extensions),
                             args = args,
-                            ext = '.md'),
+                            ext = ext),
     clean_supporting = FALSE,
     df_print = df_print,
     post_processor = post_processor

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -16,7 +16,8 @@ md_document(
   df_print = "default",
   includes = NULL,
   md_extensions = NULL,
-  pandoc_args = NULL
+  pandoc_args = NULL,
+  ext = ".md"
 )
 }
 \arguments{
@@ -64,6 +65,8 @@ default definition or R Markdown. See the \code{\link{rmarkdown_format}} for
 additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
+
+\item{ext}{Extention of the output document (defaults to ".md").}
 }
 \value{
 R Markdown output format to pass to \code{\link{render}}


### PR DESCRIPTION
This PR generalizes `md_document` by adding ext argument, so that we can generate a wide variety of formats.
Below is an example YAML frontmatter to generate pdf with ConTeXt.

```yaml
---
output:
  md_document:
    variant: context
    ext: ".pdf"
---
```