### PR TITLE
Notify shiny when slidy slides change

### DIFF
--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -65,8 +65,10 @@ slidy_presentation <- function(incremental = FALSE,
     args <- c(args, "--template", pandoc_path_arg(template))
 
   # html dependency for slidy
-  extra_dependencies <- append(extra_dependencies,
-                               list(html_dependency_slidy()))
+  extra_dependencies <- append(
+    extra_dependencies,
+    list(html_dependency_slidy(),
+         html_dependency_slidy_shiny()))
 
   # incremental
   if (incremental)
@@ -145,5 +147,15 @@ html_dependency_slidy <- function() {
     src = pkg_file("rmd/slidy/Slidy2"),
     script = "scripts/slidy.js",
     stylesheet = "styles/slidy.css"
+  )
+}
+
+html_dependency_slidy_shiny <- function() {
+  htmlDependency(
+    name = "slidy_shiny",
+    version = "1",
+    src = pkg_file("rmd/slidy/"),
+    script = "slidy_shiny.js",
+    all_files = FALSE
   )
 }

--- a/inst/rmd/slidy/slidy_shiny.js
+++ b/inst/rmd/slidy/slidy_shiny.js
@@ -1,0 +1,9 @@
+(function() {
+  if (!window.w3c_slidy) return;
+  if (!window.Shiny) return;
+  if (!window.$) return;
+  // whenever a slide changes, tell shiny to recalculate what is displayed
+  window.w3c_slidy.add_observer(function () {
+    $(document.body).children().first().trigger("shown");
+  });
+})()


### PR DESCRIPTION
Fixes rstudio/learnr#308

When slides not initially displayed are displayed, Shiny still believes they are hidden.  By attaching to slidy's add_observer, we can notify Shiny to re-check what is "shown".