### PR TITLE
[ioslides] add a few hints in the stylesheet for print

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@ rmarkdown 1.19
 
 - Added `ext` argument to `md_document()`. Its default value is ".md". This argument is intended to be used together with `variant` argument (e.g., `variant = "context"` and `ext = ".pdf"`) (thanks, @atusy, #1715).
 
+- `ioslides_presentation()` stylesheet is updated for printing. Browsers are notified that the presentation should preferentially be printed in landscape orientation and without margin (thanks, @RLesur, #1718).
+
 rmarkdown 1.18
 ================================================================================
 

--- a/inst/rmd/ioslides/ioslides-13.5.1/theme/css/default.css
+++ b/inst/rmd/ioslides/ioslides-13.5.1/theme/css/default.css
@@ -1414,6 +1414,12 @@ slides > slide {
 }
 
 @media print {
+  /* Additions for printing with Chrome, e.g. pagedown::chrome_print() */
+  @page {
+    size: landscape;
+    margin: 0;
+  }
+
   /* line 978, ../scss/default.scss */
   slides slide {
     display: block !important;

--- a/inst/rmd/ioslides/ioslides-13.5.1/theme/css/default.css
+++ b/inst/rmd/ioslides/ioslides-13.5.1/theme/css/default.css
@@ -1414,7 +1414,7 @@ slides > slide {
 }
 
 @media print {
-  /* Additions for printing with Chrome, e.g. pagedown::chrome_print() */
+  /* Additions for printing with Headless Chrome using pagedown::chrome_print() */
   @page {
     size: landscape;
     margin: 0;


### PR DESCRIPTION
I tried to print an ioslides presentation with `pagedown::chrome_print()` (with default parameters): the result is [here](https://github.com/rstudio/rmarkdown/files/3918792/io_master.pdf).  

Since there is no at-page rule in ioslides stylesheets, Chrome use its default settings for printing.

I propose to add two at-page CSS declarations for print: orientation (landscape) and margin (0).  
The result of this PR is [here](https://github.com/rstudio/rmarkdown/files/3918803/io_PR.pdf)

