### PR TITLE
Use slidy slide number to find element and trigger 'shown' event

### DIFF
--- a/inst/rmd/slidy/slidy_shiny.js
+++ b/inst/rmd/slidy/slidy_shiny.js
@@ -3,7 +3,8 @@
   if (!window.Shiny) return;
   if (!window.$) return;
   // whenever a slide changes, tell shiny to recalculate what is displayed
-  window.w3c_slidy.add_observer(function () {
-    $(document.body).children().first().trigger("shown");
+  window.w3c_slidy.add_observer(function (slide_num) {
+    // slide_num starts at position 1
+    $(w3c_slidy.slides[slide_num - 1]).trigger("shown");
   });
 })()


### PR DESCRIPTION
Followup to #1717 

From feedback in https://github.com/rstudio/shiny/pull/2718 with @wch , we determined it would be good to find a slide element and trigger the `shown` method directly on the slide element.

Retrieving the slide value using `w3c_slidy.slides[slide_num - 1]` comes directly from https://github.com/rstudio/rmarkdown/blob/3d648d3c60ac887cf29bd75e431dadae0d2b2b74/inst/rmd/slidy/Slidy2/scripts/slidy.js#L1301 reversing the `+1` added in 
https://github.com/rstudio/rmarkdown/blob/3d648d3c60ac887cf29bd75e431dadae0d2b2b74/inst/rmd/slidy/Slidy2/scripts/slidy.js#L1304