### PR TITLE
Fixed #1663: empty h2 tag for empty subtitle in ioslides_presentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Authors@R: c(
   person("Christophe", "Dervieux", role = "ctb"),
   person("Frederik", "Aust", role = "ctb", email = "frederik.aust@uni-koeln.de", comment = c(ORCID = "0000-0003-4900-788X")),
   person("Jeff", "Allen", role = "ctb", email = "jeff@rstudio.com"),
+  person("JooYoung", "Seo", role="ctb", comment = c(ORCID = "0000-0002-4064-6012")),
   person("Malcolm", "Barrett", role = "ctb"),
   person("Rob", "Hyndman", role = "ctb", email = "Rob.Hyndman@monash.edu"),
   person("Romain", "Lesur", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.1
 ================================================================================
 
-- `ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML.
+- `ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML (thanks, @jooyoungseo #1735, @cgrudz #1663).
 
 
 rmarkdown 2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.1
 ================================================================================
 
+- `ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML.
 
 
 rmarkdown 2.0

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -139,7 +139,7 @@ $else$
     <!-- The content of this hgroup is replaced programmatically through the slide_config.json. -->
     <hgroup class="auto-fadein">
       <h1 data-config-title><!-- populated from slide_config.json --></h1>
-      <h2 data-config-subtitle><!-- populated from slide_config.json --></h2>
+              $if(subtitle)$<h2 data-config-subtitle><!-- populated from slide_config.json --></h2>$endif$
       <p data-config-presenter><!-- populated from slide_config.json --></p>
       $if(date)$
       <p style="margin-top: 6px; margin-left: -2px;">$date$</p>

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -139,7 +139,7 @@ $else$
     <!-- The content of this hgroup is replaced programmatically through the slide_config.json. -->
     <hgroup class="auto-fadein">
       <h1 data-config-title><!-- populated from slide_config.json --></h1>
-              $if(subtitle)$<h2 data-config-subtitle><!-- populated from slide_config.json --></h2>$endif$
+      $if(subtitle)$<h2 data-config-subtitle><!-- populated from slide_config.json --></h2>$endif$
       <p data-config-presenter><!-- populated from slide_config.json --></p>
       $if(date)$
       <p style="margin-top: 6px; margin-left: -2px;">$date$</p>


### PR DESCRIPTION
This PR addresses #1663.

`ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML.