### PR TITLE
Add the missing slash in the html meta data

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -10,7 +10,7 @@
 
 $if(theme)$
 $else$
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 $endif$
 
 $for(author-meta)$


### PR DESCRIPTION
Add the missing "/" in the meta data in generated html. 
There should be no problem for most users but it do cause some issue in my use case.