### PR TITLE
Fix default metadata addition for pandoc 2.8 change of behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ rmarkdown 2.2
 
 - `pdf_document()` should not specify the `geometry` variable when the `documentclass` variable is passed to Pandoc (thanks, @jpcirrus, #1782).
 
+- `render()` now respects the YAML metadata in the R script when rendering the script with Pandoc 2.8 or later (thanks, @nsoranzo #1740, @cderv #1741).
+
 
 rmarkdown 2.1
 ================================================================================

--- a/R/render.R
+++ b/R/render.R
@@ -398,17 +398,17 @@ render <- function(input,
                             format = "Rmd")
     intermediates <- c(intermediates, spin_rmd)
     knit_input <- spin_rmd
-    # append default metadata (this will be ignored if there is user
-    # metadata elsewhere in the file)
-    metadata <- paste('\n',
-      '---\n',
-      'title: "', input, '"\n',
-      'author: "', Sys.info()[["user"]], '"\n',
-      'date: "', Sys.Date(), '"\n',
-      '---\n'
-    , sep = "")
-    input_lines <- read_utf8(knit_input)
-    write_utf8(c(input_lines, metadata), knit_input)
+    # append default metadata unless the field exists in YAML
+    meta1 <- yaml_front_matter(knit_input)
+    meta2 <- list(
+      title = input, author = Sys.info()[["user"]],
+      date = as.character(Sys.Date())
+    )
+    for (i in names(meta2)) if (!is.null(meta1[[i]])) meta2[[i]] <- NULL
+    if (length(meta2)) {
+      input_lines <- read_utf8(knit_input)
+      write_utf8(c(input_lines, '\n\n---', yaml::as.yaml(meta2), '---'), knit_input)
+    }
   }
 
   # read the input file

--- a/tests/testthat/test-spin.R
+++ b/tests/testthat/test-spin.R
@@ -1,0 +1,40 @@
+context("spin")
+
+test_that("default metadata are included if no metadata is provided", {
+  content <- c(
+    "#' # Header 1",
+    "print('Hello World!')"
+  )
+  input_file <- tempfile(fileext = ".R")
+  on.exit(unlink(input_file), add = TRUE)
+  xfun::write_utf8(content, input_file)
+  output_file <- tempfile(fileext = ".html")
+  on.exit(unlink(output_file), add = TRUE)
+  res <- render(input_file,
+                output_format = "html_document",
+                output_file = output_file,
+                quiet = TRUE)
+  output <- xfun::read_utf8(res)
+  expect_match(grep("<title>", output, value = TRUE),
+               paste0("<title>", basename(input_file), "</title>"))
+})
+
+test_that("included YAML metadata are respected", {
+  content <- c(
+    "#' ---",
+    "#' title: Test title",
+    "#' ---",
+    "print('Hello World!')"
+  )
+  input_file <- tempfile(fileext = ".R")
+  on.exit(unlink(input_file), add = TRUE)
+  xfun::write_utf8(content, input_file)
+  output_file <- tempfile(fileext = ".html")
+  on.exit(unlink(output_file), add = TRUE)
+  res <- render(input_file,
+                output_format = "html_document",
+                output_file = output_file,
+                quiet = TRUE)
+  output <- xfun::read_utf8(res)
+  expect_match(grep("<title>", output, value = TRUE), "<title>Test title</title>")
+})


### PR DESCRIPTION
This fixes #1740 

I began with the easy way, just prepending if pandoc  >= 2.8
This seem to work well

@yihui what do you prefer ? 
This sort of simple way to deal with this or the use of `--metadata-file` ? 

In fact, I tried the later, but at [these lines](https://github.com/rstudio/rmarkdown/blob/7660bc08ebec10f39241972339de5f0145ef9af6/R/render.R#L401-L411) in render.R, where R file is spinned, it does not seems that we can access yet the output format to add some pandoc args directly. We can add it later like `post_knit_handler` or just add it anywhere if a temporary yaml file has been created I guess. Even if it seems the way to go, it seems maybe to complicated to implement (more lines and logic to add)

What do you think ?
I'll modify or complete this PR based on your input. 