### PR TITLE
update documentation of df_print

### DIFF
--- a/R/output_format.R
+++ b/R/output_format.R
@@ -13,7 +13,8 @@
 #'   \code{\link{render_supporting_files}}
 #' @param df_print Method to be used for printing data frames. Valid values
 #'   include "default", "kable", "tibble", and "paged". The "default" method
-#'   uses \code{print.data.frame}. The "kable" method uses the
+#'   uses a corresponding S3 method of \code{print}, typically
+#'   \code{print.data.frame}. The "kable" method uses the
 #'   \code{\link[knitr:kable]{knitr::kable}} function. The "tibble" method uses
 #'   the \pkg{tibble} package to print a summary of the data frame. The "paged"
 #'   method creates a paginated HTML table (note that this method is only valid

--- a/man/output_format.Rd
+++ b/man/output_format.Rd
@@ -35,7 +35,8 @@ this is \code{TRUE} then \code{clean_supporting} will always be
 
 \item{df_print}{Method to be used for printing data frames. Valid values
 include "default", "kable", "tibble", and "paged". The "default" method
-uses \code{print.data.frame}. The "kable" method uses the
+uses a corresponding S3 method of \code{print}, typically
+\code{print.data.frame}. The "kable" method uses the
 \code{\link[knitr:kable]{knitr::kable}} function. The "tibble" method uses
 the \pkg{tibble} package to print a summary of the data frame. The "paged"
 method creates a paginated HTML table (note that this method is only valid


### PR DESCRIPTION
This PR updates the documentation of the `df_print` parameter because a printing method for data frames are chosen based on their classes rather than fixed to `print.data.frame` as currently described in the doc.

For example, `print.tbl_df` is used for a tibble because `rmarkdown:::knit_print.data.frame` calls `print` rather than `print.data.frame`.

https://github.com/rstudio/rmarkdown/blob/7f51e232c98b2f7db40b40cd593385fe76b3189b/R/knit_print.R#L28

````
---
output:
  html_document:
    df_print: default
---

```{r}
tibble::as_tibble(head(iris))
```
````