### PR TITLE
explicitly call print when df_print: default (fixes #1614)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ rmarkdown 2.1
 
 - Removed the jQuery dependency in `html_document_base()` (#1723). To avoid bugs like #1723, Pandoc 2.8 users have to upgrade to Pandoc 2.9+.
 
-- Fixed data frames not being printend when `render()` is called interactively (thanks, @atusy, #1750)
+- Fixed data frames not being printed when `render()` is called interactively (thanks, @atusy, #1750)
 
 
 rmarkdown 2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ rmarkdown 2.1
 
 - Removed the jQuery dependency in `html_document_base()` (#1723). To avoid bugs like #1723, Pandoc 2.8 users have to upgrade to Pandoc 2.9+.
 
+- Fixed data frames not being printend when `render()` is called interactively (thanks, @atusy, #1750)
+
 
 rmarkdown 2.0
 ================================================================================

--- a/R/knit_print.R
+++ b/R/knit_print.R
@@ -21,6 +21,8 @@ knit_print.data.frame <- function(x, ...) {
     if (identical(context$df_print, knitr::kable)) {
       res <- one_string(c('<div class="kable-table">', '', knitr::kable(x), '', '</div>'))
       knitr::asis_output(res)
+    } else if (identical(context$df_print, print)) {
+      print(x)
     } else {
       context$df_print(x)
     }


### PR DESCRIPTION
This PR fixes #1614 .
Though I do not see why, `knit_print.data.frame` must call `print` explicitly when interactively rendering Rmd files and `df_print` is default.
