### PR TITLE
Using knit field in YAML when rendering (closes #1711)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ rmarkdown 2.1
 
 - Removed the jQuery dependency in `html_document_base()` (#1723). To avoid bugs like #1723, Pandoc 2.8 users have to upgrade to Pandoc 2.9+.
 
+- Enable `render()` to use `knit` field in the YAML front matter (thanks, @atusy, #1711).
 
 rmarkdown 2.0
 ================================================================================

--- a/R/render.R
+++ b/R/render.R
@@ -211,7 +211,8 @@ NULL
 #' @param quiet An option to suppress printing of the pandoc command line.
 #' @param encoding Ignored. The encoding is always assumed to be UTF-8.
 #' @param customize Render input by a function defined by the \code{knit}
-#' field at the top level of the YAML front matter of the input.
+#' field at the top level of the YAML front matter of the input. Default to
+#' \code{FALSE}.
 #' @return
 #'   When \code{run_pandoc = TRUE}, the compiled document is written into
 #'   the output file, and the path of the output file is returned. When
@@ -252,7 +253,7 @@ render <- function(input,
                    run_pandoc = TRUE,
                    quiet = FALSE,
                    encoding = "UTF-8",
-                   customize = interactive()) {
+                   customize = FALSE) {
 
   yaml_knit <- yaml_front_matter(input)[["knit"]]
   if (!is.null(yaml_knit)) {

--- a/R/render.R
+++ b/R/render.R
@@ -212,7 +212,8 @@ NULL
 #' @param encoding Ignored. The encoding is always assumed to be UTF-8.
 #' @param customize Render input by a function defined by the \code{knit}
 #' field at the top level of the YAML front matter of the input. Default to
-#' \code{FALSE}.
+#' \code{FALSE}. If \code{TRUE}, then only the \code{input} argument is passed
+#' to the rendering function, and the others are ignored.
 #' @return
 #'   When \code{run_pandoc = TRUE}, the compiled document is written into
 #'   the output file, and the path of the output file is returned. When
@@ -257,16 +258,7 @@ render <- function(input,
 
   if (customize) {
     yaml_knit <- yaml_front_matter(input)[["knit"]]
-    if (!is.null(yaml_knit)) {
-      return(eval(parse(text = yaml_knit))(
-        input = input, output_file = output_file, output_dir = output_dir,
-        output_options = output_options, output_yaml = output_yaml,
-        intermediates_dir = intermediates_dir, knit_root_dir = knit_root_dir,
-        runtime = runtime, clean = clean, knit_meta = knit_meta, envir = envir,
-        run_pandoc = run_pandoc, quiet = quiet, encoding = encoding,
-        customize = FALSE
-      ))
-    }
+    if (!is.null(yaml_knit)) return(eval(parse(text = yaml_knit))(input))
   }
 
   perf_timer_start("render")

--- a/R/render.R
+++ b/R/render.R
@@ -210,6 +210,8 @@ NULL
 #' output.
 #' @param quiet An option to suppress printing of the pandoc command line.
 #' @param encoding Ignored. The encoding is always assumed to be UTF-8.
+#' @param customize Render input by a function defined by the \code{knit}
+#' field at the top level of the YAML front matter of the input.
 #' @return
 #'   When \code{run_pandoc = TRUE}, the compiled document is written into
 #'   the output file, and the path of the output file is returned. When
@@ -249,7 +251,20 @@ render <- function(input,
                    envir = parent.frame(),
                    run_pandoc = TRUE,
                    quiet = FALSE,
-                   encoding = "UTF-8") {
+                   encoding = "UTF-8",
+                   customize = interactive()) {
+
+  yaml_knit <- yaml_front_matter(input)[["knit"]]
+  if (!is.null(yaml_knit)) {
+    return(eval(parse(text = yaml_knit))(
+      input = input, output_file = output_file, output_dir = output_dir,
+      output_options = output_options, output_yaml = output_yaml,
+      intermediates_dir = intermediates_dir, knit_root_dir = knit_root_dir,
+      runtime = runtime, clean = clean, knit_meta = knit_meta, envir = envir,
+      run_pandoc = run_pandoc, quiet = quiet, encoding = encoding,
+      customize = FALSE
+    ))
+  }
 
   perf_timer_start("render")
 

--- a/R/render.R
+++ b/R/render.R
@@ -255,16 +255,18 @@ render <- function(input,
                    encoding = "UTF-8",
                    customize = FALSE) {
 
-  yaml_knit <- yaml_front_matter(input)[["knit"]]
-  if (!is.null(yaml_knit)) {
-    return(eval(parse(text = yaml_knit))(
-      input = input, output_file = output_file, output_dir = output_dir,
-      output_options = output_options, output_yaml = output_yaml,
-      intermediates_dir = intermediates_dir, knit_root_dir = knit_root_dir,
-      runtime = runtime, clean = clean, knit_meta = knit_meta, envir = envir,
-      run_pandoc = run_pandoc, quiet = quiet, encoding = encoding,
-      customize = FALSE
-    ))
+  if (customize) {
+    yaml_knit <- yaml_front_matter(input)[["knit"]]
+    if (!is.null(yaml_knit)) {
+      return(eval(parse(text = yaml_knit))(
+        input = input, output_file = output_file, output_dir = output_dir,
+        output_options = output_options, output_yaml = output_yaml,
+        intermediates_dir = intermediates_dir, knit_root_dir = knit_root_dir,
+        runtime = runtime, clean = clean, knit_meta = knit_meta, envir = envir,
+        run_pandoc = run_pandoc, quiet = quiet, encoding = encoding,
+        customize = FALSE
+      ))
+    }
   }
 
   perf_timer_start("render")

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -105,7 +105,8 @@ output.}
 
 \item{customize}{Render input by a function defined by the \code{knit}
 field at the top level of the YAML front matter of the input. Default to
-\code{FALSE}.}
+\code{FALSE}. If \code{TRUE}, then only the \code{input} argument is passed
+to the rendering function, and the others are ignored.}
 }
 \value{
 When \code{run_pandoc = TRUE}, the compiled document is written into

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -20,7 +20,8 @@ render(
   envir = parent.frame(),
   run_pandoc = TRUE,
   quiet = FALSE,
-  encoding = "UTF-8"
+  encoding = "UTF-8",
+  customize = interactive()
 )
 }
 \arguments{
@@ -101,6 +102,9 @@ output.}
 \item{quiet}{An option to suppress printing of the pandoc command line.}
 
 \item{encoding}{Ignored. The encoding is always assumed to be UTF-8.}
+
+\item{customize}{Render input by a function defined by the \code{knit}
+field at the top level of the YAML front matter of the input.}
 }
 \value{
 When \code{run_pandoc = TRUE}, the compiled document is written into

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -21,7 +21,7 @@ render(
   run_pandoc = TRUE,
   quiet = FALSE,
   encoding = "UTF-8",
-  customize = interactive()
+  customize = FALSE
 )
 }
 \arguments{
@@ -104,7 +104,8 @@ output.}
 \item{encoding}{Ignored. The encoding is always assumed to be UTF-8.}
 
 \item{customize}{Render input by a function defined by the \code{knit}
-field at the top level of the YAML front matter of the input.}
+field at the top level of the YAML front matter of the input. Default to
+\code{FALSE}.}
 }
 \value{
 When \code{run_pandoc = TRUE}, the compiled document is written into


### PR DESCRIPTION
This PR implements a requested feature in #1711 .
In order to let `render` use function defined at `knit` field, the `customize` parameter must be `TRUE`.
The default value is set to `interactive()` so to avoid the RStudio's knit button from evaluating the `knit` field repeatedly when `knit` field calls `render` again (e.g., when `knit: rmarkdown::render` is specified).