### PR TITLE
Correctly parse yaml front matter in html_notebook in intermediary knit files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.1
 ================================================================================
 
+- Yaml header is now correctly parsed in `html_notebook` intermediary knit file so that features like adding bibliography works again (thanks, @everdark, @cderv, #1747)
+
 - `ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML (thanks, @jooyoungseo #1735, @cgrudz #1663).
 
 - No longer center the `#header` element in the `html_vignette()` output (thanks, @EmilHvitfeldt, #1742).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.1
 ================================================================================
 
-- Yaml header is now correctly parsed in `html_notebook` intermediary knit file so that features like adding bibliography works again (thanks, @everdark, @cderv, #1747)
+- YAML header is now correctly parsed in `html_notebook`'s intermediate `.knit.md` file so that features like adding bibliography works again (thanks, @everdark, @cderv, #1747).
 
 - `ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML (thanks, @jooyoungseo #1735, @cgrudz #1663).
 

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -700,11 +700,17 @@ partition_yaml_front_matter <- function(input_lines) {
     if (length(delimiters) >= 2 &&
         (delimiters[2] - delimiters[1] > 1) &&
         grepl("^---\\s*$", input_lines[delimiters[1]])) {
-      # verify that it's truly front matter (not preceded by other content)
-      if (delimiters[1] == 1)
+      # verify that it's truly front matter, not preceded by
+      # other content except blank lines or special comment
+      # in html notebook intermediary .knit.md
+      if (delimiters[1] == 1) {
         TRUE
-      else
-        is_blank(input_lines[1:delimiters[1] - 1])
+      } else {
+        all(vapply(input_lines[1:delimiters[1] - 1],
+                   function(x) is_blank(x) || is_rnb_comment(x),
+                   TRUE, USE.NAMES = FALSE
+        ))
+      }
     } else {
       FALSE
     }

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -705,12 +705,10 @@ partition_yaml_front_matter <- function(input_lines) {
       # in html notebook intermediary .knit.md
       if (delimiters[1] == 1) {
         TRUE
-      } else {
-        all(vapply(input_lines[1:delimiters[1] - 1],
-                   function(x) is_blank(x) || is_rnb_comment(x),
-                   logical(1), USE.NAMES = FALSE
-        ))
-      }
+      } else all(grepl(
+        "^\\s*(<!-- rnb-\\w*-(begin|end) -->)?\\s*$",
+        input_lines[1:delimiters[1] - 1]
+      ))
     } else {
       FALSE
     }

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -701,8 +701,8 @@ partition_yaml_front_matter <- function(input_lines) {
         (delimiters[2] - delimiters[1] > 1) &&
         grepl("^---\\s*$", input_lines[delimiters[1]])) {
       # verify that it's truly front matter, not preceded by
-      # other content except blank lines or special comment
-      # in html notebook intermediary .knit.md
+      # other content except blank lines or special comments
+      # in html_notebook's intermediate .knit.md
       if (delimiters[1] == 1) {
         TRUE
       } else all(grepl(

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -708,7 +708,7 @@ partition_yaml_front_matter <- function(input_lines) {
       } else {
         all(vapply(input_lines[1:delimiters[1] - 1],
                    function(x) is_blank(x) || is_rnb_comment(x),
-                   TRUE, USE.NAMES = FALSE
+                   logical(1), USE.NAMES = FALSE
         ))
       }
     } else {

--- a/R/util.R
+++ b/R/util.R
@@ -218,12 +218,6 @@ is_blank <- function(x) {
   else TRUE
 }
 
-is_rnb_comment <- function(x) {
-  if (length(x))
-    all(grepl("<!-- rnb-\\w*-(begin|end) -->", x))
-  else FALSE
-}
-
 trim_trailing_ws <- function(x) {
   sub("\\s+$", "", x)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -218,6 +218,12 @@ is_blank <- function(x) {
   else TRUE
 }
 
+is_rnb_comment <- function(x) {
+  if (length(x))
+    all(grepl("<!-- rnb-\\w*-(begin|end) -->", x))
+  else FALSE
+}
+
 trim_trailing_ws <- function(x) {
   sub("\\s+$", "", x)
 }

--- a/tests/testthat/test-yml-parsing.R
+++ b/tests/testthat/test-yml-parsing.R
@@ -1,0 +1,28 @@
+context("yaml front matter")
+
+test_that("yaml header is correctly parsed", {
+  tmp_file <- tempfile(fileext = ".Rmd")
+  on.exit(unlink(tmp_file), add = TRUE)
+  yaml_header <- c(
+    "---",
+    "title: test",
+    "output: html_document",
+    "---"
+  )
+  xfun::write_utf8(yaml_header,
+                   tmp_file)
+  yml_parsed <- list(title = "test", output = "html_document")
+  expect_equal(yaml_front_matter(tmp_file),
+               yml_parsed)
+  xfun::write_utf8(c("", "", yaml_header),
+                   tmp_file)
+  expect_equal(yaml_front_matter(tmp_file),
+               yml_parsed)
+  xfun::write_utf8(c("", "<!-- rnb-text-begin -->", "", yaml_header),
+                   tmp_file)
+  expect_equal(yaml_front_matter(tmp_file),
+               yml_parsed)
+  xfun::write_utf8(c("", "anything", "", yaml_header),
+                   tmp_file)
+  expect_length(yaml_front_matter(tmp_file), 0L)
+})


### PR DESCRIPTION
This will fix #1747 

Following the change in https://github.com/rstudio/rmarkdown/pull/1710, rmarkdown now reads the yaml header from the knit intermediary file, and not the Rmd input file.

However, `html_notebook` has a special behavior where it adds some special html comments like `<!-- rnb-text-begin -->` before the yaml header. This means `yaml_front_matter` does not manage to parse the yaml in this `.knit.md` file, as it does not see it as valid.

This PR fixes this by letting `yaml_front_matter` ignores the blank line and also rnb comments.

I also added a test about yaml parsing. 