### PR TITLE
Return output from shiny::runApp within rmarkdown::run

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.1
 ================================================================================
 
-- Added the returned output from `shiny::runApp()` within `rmarkdown::run()` (#1760)
+- Added the returned output from `shiny::runApp()` within `rmarkdown::run()` (thanks, @schloerke, #1760).
 
 - YAML header is now correctly parsed in `html_notebook`'s intermediate `.knit.md` file so that features like adding bibliography works again (thanks, @everdark, @cderv, #1747).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.1
 ================================================================================
 
+- Added the returned output from `shiny::runApp()` within `rmarkdown::run()` (#1760)
+
 - YAML header is now correctly parsed in `html_notebook`'s intermediate `.knit.md` file so that features like adding bibliography works again (thanks, @everdark, @cderv, #1747).
 
 - `ioslides_presentation` template no longer generates an empty `<h2>` tag when `subtitle` is not specified in YAML (thanks, @jooyoungseo #1735, @cgrudz #1663).

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -172,8 +172,8 @@ run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
 
   shiny_args <- merge_lists(list(appDir = app, launch.browser = launch_browser),
                             shiny_args)
-  do.call(shiny::runApp, shiny_args)
-  invisible(NULL)
+  ret <- do.call(shiny::runApp, shiny_args)
+  invisible(ret)
 }
 
 # create the Shiny server function


### PR DESCRIPTION
`shiny::runApp` can return a value `x` by using `shiny::stopApp(x)`.  It would be nice to be able to retrieve this information when using `rmarkdown::run()`