### PR TITLE
Enable toc-title in default.html

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.2
 ================================================================================
 
-- TOC title can now be specified for `html_document` via `toc-title` top-level YAML frontmatter (thanks, @atusy, #1771).
+- TOC title can now be specified for `html_document` via the top-level option `toc-title` in the YAML frontmatter (thanks, @atusy, #1771).
 
 
 rmarkdown 2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.2
 ================================================================================
 
+- TOC title can now be specified for `html_document` via `toc-title` top-level YAML frontmatter (thanks, @atusy, #1771).
 
 
 rmarkdown 2.1

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -535,7 +535,7 @@ $if(toc)$
 $if(toc-title)$
 <h2 id="$idprefix$toc-title">$toc-title$</h2>
 $endif$
-$table-of-contents$
+$toc$
 </div>
 $endif$
 $endif$

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -453,6 +453,9 @@ $if(toc_float)$
 <!-- setup 3col/9col grid for toc_float and main content  -->
 <div class="row-fluid">
 <div class="col-xs-12 col-sm-4 col-md-3">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
 <div id="$idprefix$TOC" class="tocify">
 </div>
 </div>
@@ -529,7 +532,10 @@ $if(toc_float)$
 $else$
 $if(toc)$
 <div id="$idprefix$TOC">
-$toc$
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
+$table-of-contents$
 </div>
 $endif$
 $endif$


### PR DESCRIPTION
Recent pandoc has an option `toc-title`.
This PR updates `default.html` to enable the option.
It works bot for `toc_float` as well.

For the consistency with other parameters, maybe it is a choice to add `toc_title` as a parameter of `html_document`.
If so, we should also consider adding the parameter to other output formats (e.g., `word_document`)

````
---
output:
  html_document:
    toc: true
    toc_float: true
toc-title: TOC
---

# foo

# bar
````