### PR TITLE
Keep uppercase for tocify's hash (fix #975)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ rmarkdown 2.2
 ================================================================================
 
 - TOC title can now be specified for `html_document` via the top-level option `toc-title` in the YAML frontmatter (thanks, @atusy, #1771).
-
+- Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783)
 
 rmarkdown 2.1
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@ rmarkdown 2.2
 ================================================================================
 
 - TOC title can now be specified for `html_document` via the top-level option `toc-title` in the YAML frontmatter (thanks, @atusy, #1771).
-- Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783)
+
+- Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783).
+
 
 rmarkdown 2.1
 ================================================================================

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -625,7 +625,7 @@ $$(document).ready(function ()  {
       theme: "bootstrap3",
       context: '.toc-content',
       hashGenerator: function (text) {
-        return text.replace(/[.\\/?&!#<>]/g, '').replace(/\s/g, '_').toLowerCase();
+        return text.replace(/[.\\/?&!#<>]/g, '').replace(/\s/g, '_');
       },
       ignoreSelector: ".toc-ignore",
       scrollTo: 0


### PR DESCRIPTION
This PR fixes #975

For floating TOC, custom hashGenerator is defined by https://github.com/rstudio/rmarkdown/commit/5b98ee15eae8a079e6b3929be56862cf461bdc35 .
There, `.toLower()` is introduced, which made "Foo" and "foo" indistinctive.
I fixed the problem by removing `.toLower()`.

## reprex

````
---
title: title
output:
  html_document:
    toc: true
    toc_float: true
---

# foo

```{r}
iris
```

# Foo
````