### PR TITLE
updated Google Analytics tracking code to enable cross-domain tracking

### DIFF
--- a/js/ga.js
+++ b/js/ga.js
@@ -1,7 +1,6 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){ (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o), m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m) })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-20375833-14', 'auto');
+ga('create', 'UA-20375833-3', 'auto', {'allowLinker': true});
+ga('require', 'linker');
+ga('linker:autoLink', ['rstudio.com', 'http://rstudio.github.io/shiny/tutorial/', 'rstudio.github.io/packrat/', 'rviews.rstudio.com', 'community.rstudio.com', 'rpubs.rstudio.com', 'environments.rstudio.com', 'rstudio.org', 'dailies.rstudio.com', 'pages.rstudio.com', 'db.rstudio.com', 'solutions.rstudio.com', 'docs.rstudio.com', 'spark.rstudio.com', 'shiny.rstudio.com', 'education.rstudio.com', 'rstudio.cloud', 'shinyapps.io', 'teamadmin.rstudio.com', 'blog.rstudio.com', 'support.rstudio.com'] );
 ga('send', 'pageview');


### PR DESCRIPTION
@yihui 
I’ve replaced your Google Analytics tracking number with the one for rstudio.com, which enables us to track users across domains.  Your site’s analytics will now be found under the rstudio.com property and I have built a filter and dashboard for you to view your site’s metrics separate from other domains.  Data will populate from today forward and you will need to visit your previous property for historical data.  Thank you for merging this pull request so that we can get a full picture of online user behavior.