### PR TITLE
enable fold-hide class to hide the code blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ rmarkdown 2.2
 
 - Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783).
 
+- When `code_folding='show'`, code blocks can be individually hidden for the first time by speccifying `class.source='fold-hide'` to the chunk option (thanks, @atusy, #1798).
+
 
 rmarkdown 2.1
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ rmarkdown 2.2
 
 - Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783).
 
-- When `code_folding='show'`, code blocks can be individually hidden for the first time by specifying `class.source='fold-hide'` to the chunk option (thanks, @atusy, #1798).
+- When `code_folding='show'` for the output format `html_document`, code blocks can be individually hidden initially by specifying the chunk option `class.source='fold-hide'` (thanks, @atusy, #1798).
 
 
 rmarkdown 2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ rmarkdown 2.2
 
 - Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783).
 
-- When `code_folding='show'`, code blocks can be individually hidden for the first time by speccifying `class.source='fold-hide'` to the chunk option (thanks, @atusy, #1798).
+- When `code_folding='show'`, code blocks can be individually hidden for the first time by specifying `class.source='fold-hide'` to the chunk option (thanks, @atusy, #1798).
 
 
 rmarkdown 2.1

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -22,8 +22,8 @@ window.initializeCodeFolding = function(show) {
 
     // create a collapsable div to wrap the code in
     var div = $('<div class="collapse r-code-collapse"></div>');
-    if (show || $(this)[0].classList.contains('fold-show'))
-      div.addClass('in');
+    show = (show || $(this).hasClass('fold-show')) && !$(this).hasClass('fold-hide');
+    if (show) div.addClass('in');
     var id = 'rcode-643E0F36' + currentIndex++;
     div.attr('id', id);
     $(this).before(div);


### PR DESCRIPTION
Regarding to the request on https://github.com/rstudio/rmarkdown/pull/1602#issuecomment-614166924
As far as I tested, it works well.

````
---
output:
  html_document:
    code_folding: show
---

```{r}
1
```

```{r, class.source='fold-hide'}
2
```
````