### PR TITLE
Use htmltools functions for htmlwidget notebook annotation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.2
 ================================================================================
 
-- Fixed a bug with encoding when rendering `html_notebook` containing htmlwidgets (thanks, @cderv, #1799)  
+- Fixed a bug with encoding when rendering `html_notebook` containing HTML widgets (thanks, @cderv, #1799).
 
 - TOC title can now be specified for `html_document` via the top-level option `toc-title` in the YAML frontmatter (thanks, @atusy, #1771).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.2
 ================================================================================
 
+- Fixed a bug with encoding when rendering `html_notebook` containing htmlwidgets (thanks, @cderv, #1799)  
+
 - TOC title can now be specified for `html_document` via the top-level option `toc-title` in the YAML frontmatter (thanks, @atusy, #1771).
 
 - Floating TOC can now distinguish upper/lower-cases (thanks, @atusy, #1783).

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -9,7 +9,7 @@ notebook_render_html_widget <- function(output) {
   pasted <- paste(before, unpreserved$value, after, sep = "\n")
 
   annotated <- htmltools::restorePreserveChunks(pasted,
-                                                unpreserved$chunk)
+                                                unpreserved$chunks)
   attributes(annotated) <- attributes(output)
 
   return(annotated)

--- a/R/render_html.R
+++ b/R/render_html.R
@@ -1,19 +1,15 @@
 notebook_render_html_widget <- function(output) {
 
-  # TODO: add htmlUnpreserve function to htmlwidgets?
-  unpreserved <- substring(
-    output,
-    n_bytes("<!--html_preserve-->") + 1,
-    n_bytes(output) - n_bytes("<!--/html_preserve-->")
-  )
+  unpreserved <- htmltools::extractPreserveChunks(output)
 
   meta <- base64_encode_object(attr(output, "knit_meta"))
 
   before <- sprintf("\n<!-- rnb-htmlwidget-begin %s-->", meta)
   after  <- "<!-- rnb-htmlwidget-end -->\n"
-  pasted <- paste(before, unpreserved, after, sep = "\n")
+  pasted <- paste(before, unpreserved$value, after, sep = "\n")
 
-  annotated <- htmltools::htmlPreserve(pasted)
+  annotated <- htmltools::restorePreserveChunks(pasted,
+                                                unpreserved$chunk)
   attributes(annotated) <- attributes(output)
 
   return(annotated)

--- a/tests/testthat/test-notebook.R
+++ b/tests/testthat/test-notebook.R
@@ -109,3 +109,25 @@ test_that("a custom output_source can be used on render", {
   parsed <- parse_html_notebook(output_file)
 
 })
+
+test_that("UFT8 character in html widget does not break notebook annotation", {
+  skip_on_cran()
+  # simulate html widget code
+  html_dependency_dummy <- function()  {
+    htmltools::htmlDependency(
+      name = "dummy",
+      version = "0.0.0",
+      src = "dummy_file",
+      script = "dummy.js")
+  }
+  utf8_strings <- enc2utf8("éà")
+  output <- htmltools::htmlPreserve(utf8_strings)
+  output <- knitr::asis_output(output, meta = html_dependency_dummy())
+  reg_res <- paste0(
+    "<!-- rnb-htmlwidget-begin .*-->\n",
+    utf8_strings,"\n",
+    "<!-- rnb-htmlwidget-end -->\n"
+  )
+  expect_match(notebook_render_html_widget(output),
+               reg_res)
+})

--- a/tests/testthat/test-notebook.R
+++ b/tests/testthat/test-notebook.R
@@ -111,6 +111,7 @@ test_that("a custom output_source can be used on render", {
 })
 
 test_that("UFT8 character in html widget does not break notebook annotation", {
+  # from issue in https://github.com/rstudio/rmarkdown/issues/1762
   skip_on_cran()
   # simulate html widget code
   html_dependency_dummy <- function()  {


### PR DESCRIPTION
This fixes #1762 

The issue was in the unpreserving html widget code for UFT8 special character encoded on two byte. (see https://github.com/rstudio/rmarkdown/issues/1762#issuecomment-611189889). 

Using the `htmltools` functions to deal with preserved code extraction seems now the way to do it. 

I tried to add a test by simplifying the code I used to come up with the solution. Not sure if this is the simplest unit test. Also I added `skip_on_cran()` because the other test had this too ☺️ 

In addition, I think this could also have been resolved by making sure to use `bytes` Encoding before using `substrings` like in 
https://github.com/rstudio/rmarkdown/blob/1c859f47b990c1b6d3a1fbc4b877fbaf5ff18512/R/util.R#L283-L288
However, `htmltools` functions seemed dedicated to this usage. 