### PR TITLE
Support href dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,7 +91,8 @@ Imports:
     tinytex (>= 0.11),
     xfun,
     methods,
-    stringr (>= 1.2.0)
+    stringr (>= 1.2.0),
+    RCurl
 Suggests:
     shiny (>= 0.11),
     tufte,

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -194,16 +194,26 @@ html_reference_path <- function(path, lib_dir, output_dir) {
 # return the html dependencies as an HTML string suitable for inclusion
 # in the head of a document
 html_dependencies_as_string <- function(dependencies, lib_dir, output_dir) {
+  # Only copy deps with path
+  dependencies_href <- filter_dependencies(dependencies, "href")
+  dependencies <- filter_dependencies(dependencies, "file")
 
   if (!is.null(lib_dir)) {
     dependencies <- lapply(dependencies, copyDependencyToDir, lib_dir)
     dependencies <- lapply(dependencies, makeDependencyRelative, output_dir)
   }
-  return(renderDependencies(dependencies, "file", encodeFunc = identity,
+  #return(
+  tags <- renderDependencies(dependencies, "file", encodeFunc = identity,
                             hrefFilter = function(path) {
                               html_reference_path(path, lib_dir, output_dir)
                             })
-  )
+  #)
+  HTML(paste0(c(tags, renderDependencies(dependencies_href, "href")), collapse = "\n"))
+}
+
+filter_dependencies <- function(dependencies, src_type = "file") {
+  deps <- lapply(dependencies, function(dep) if(!is.null(dep$src[[src_type]])) return(dep))
+  deps[!sapply(deps, is.null)]
 }
 
 # check class of passed list for 'html_dependency'
@@ -224,17 +234,29 @@ validate_html_dependency <- function(list) {
   if (is.null(list$version))
     stop("version for html_dependency not provided", call. = FALSE)
   list <- fix_html_dependency(list)
-  if (is.null(list$src$file))
-    stop("path for html_dependency not provided", call. = FALSE)
-  file <- list$src$file
-  if (!is.null(list$package))
-    file <- system.file(file, package = list$package)
-  if (!file.exists(file)) {
-    utils::str(list)
-    stop("path for html_dependency not found: ", file, call. = FALSE)
+  #if (is.null(list$src$file))
+  #  stop("path for html_dependency not provided", call. = FALSE)
+  if (is.null(list$src)) {
+    stop("neither path nor href are provided for html_dependency", call. = FALSE)
+  }
+  if (!is.null(list$src$file)) {
+    file <- list$src$file
+    if (!is.null(list$package))
+      file <- system.file(file, package = list$package)
+    if (!file.exists(file)) {
+      utils::str(list)
+      stop("path for html_dependency not found: ", file, call. = FALSE)
+    }
   }
 
+  if (!is.null(list$src$href)) validate_dependency_url(list$src$href)
+
   list
+}
+
+validate_dependency_url <- function(src) {
+  error <- suppressWarnings(try({download.file(src, tempfile())}, silent = TRUE))
+  error == 0
 }
 
 # monkey patch HTML dependencies; currently only supports highlight.js

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -249,11 +249,16 @@ validate_html_dependency <- function(list) {
     }
   }
 
-  if (!is.null(list$src$href)) validate_dependency_url(list$src$href)
+  if (!is.null(list$src$href)) {
+    href <- list$src$href
+    if (!RCurl::url.exists(href))
+      stop("href for html_dependency not found: ", href, call. = FALSE)
+  }
 
   list
 }
 
+# If we do not want to use RCurl dep
 validate_dependency_url <- function(src) {
   error <- suppressWarnings(try({download.file(src, tempfile())}, silent = TRUE))
   error == 0


### PR DESCRIPTION
If dependencies are provided via the `href` property the document will not render.

This PR checks whether the given url for `href` exists and creates the needed tags for the header, so that the document can be rendered.