### PR TITLE
Clean up temporary files

### DIFF
--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -345,7 +345,7 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
   )
 
   # clean up output file and its supporting files directory
-  temp_files <- c(temp_files, html_file, knitr_files_dir(md_file))
+  temp_files <- c(temp_files, html_file, knitr_files_dir(md_file), knitr_files_dir(html_file))
 
   # run the HTML resource discovery mechanism on the rendered output
   discover_html_resources(html_file, discover_single_resource)


### PR DESCRIPTION
The `render()` function leaves behind a temporary folder created when producing a temporary html file to discover resources used by the Rmd file. This can create issues with disk quota when rendering many Rmd files unsupervised.