### PR TITLE
Add details on supported options for paged_table in the help doc

### DIFF
--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -205,7 +205,25 @@ paged_table_html <- function(x, options = NULL) {
 #' Create a table in HTML with support for paging rows and columns
 #'
 #' @param x a data frame to be rendered as a paged table.
-#' @param options options for printing the paged table
+#' @param options options for printing the paged table. See details for specifics.
+#'
+#' @details
+#' Below are the recognized table pagination options.
+#'
+#' \tabular{rll}{
+#' Option \tab Description \tab Default \cr
+#' \code{max.print} \tab The number of rows to print. \tab 1000 \cr
+#' \code{sql.max.print} \tab The number of rows to print from a SQL data table. \tab 1000 \cr
+#' \code{rows.print} \tab The number of rows to display. \tab 10 \cr
+#' \code{cols.print} \tab The number of columns to display. \tab 10 \cr
+#' \code{cols.min.print} \tab The minimum number of columns to display. \tab - \cr
+#' \code{pages.print} \tab The number of pages to display under page navigation. \tab - \cr
+#' \code{paged.print} \tab When set to FALSE turns off paged tables. \tab TRUE \cr
+#' \code{rownames.print} \tab When set to FALSE turns off row names. \tab TRUE
+#' }
+#'
+#' \bold{Note:} There is a hard cap of 10,000 rows to ensure that pandoc will not
+#' fail when rendering the document.
 #'
 #' @export
 paged_table <- function(x, options = NULL) {

--- a/man/paged_table.Rd
+++ b/man/paged_table.Rd
@@ -9,8 +9,26 @@ paged_table(x, options = NULL)
 \arguments{
 \item{x}{a data frame to be rendered as a paged table.}
 
-\item{options}{options for printing the paged table}
+\item{options}{options for printing the paged table. See details for specifics.}
 }
 \description{
 Create a table in HTML with support for paging rows and columns
+}
+\details{
+Below are the recognized table pagination options.
+
+\tabular{rll}{
+Option \tab Description \tab Default \cr
+\code{max.print} \tab The number of rows to print. \tab 1000 \cr
+\code{sql.max.print} \tab The number of rows to print from a SQL data table. \tab 1000 \cr
+\code{rows.print} \tab The number of rows to display. \tab 10 \cr
+\code{cols.print} \tab The number of columns to display. \tab 10 \cr
+\code{cols.min.print} \tab The minimum number of columns to display. \tab - \cr
+\code{pages.print} \tab The number of pages to display under page navigation. \tab - \cr
+\code{paged.print} \tab When set to FALSE turns off paged tables. \tab TRUE \cr
+\code{rownames.print} \tab When set to FALSE turns off row names. \tab TRUE
+}
+
+\bold{Note:} There is a hard cap of 10,000 rows to ensure that pandoc will not
+fail when rendering the document.
 }


### PR DESCRIPTION
Updates the rmarkdown documentation to include valid options for `paged_table` alongside of defaults. 

<img width="510" alt="Screen Shot 2020-05-18 at 9 33 51 AM" src="https://user-images.githubusercontent.com/833642/82225570-fcd7ed00-98ea-11ea-97ed-b446c2047f13.png">


This was gleamed from reading the code here: 

https://github.com/rstudio/rmarkdown/blob/f11953f7ef05ba37e42c827b1a09bdc1a56600f9/R/html_paged.R#L95-L106

And is partially based on examples from:

- https://bookdown.org/yihui/rmarkdown/html-document.html#data-frame-printing
- https://rstudio.github.io/distill/tables.html