### PR TITLE
Enable use of pandoc --file-scope for input files originating from multiple Rmds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.2.1
+Version: 2.2.2
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.3
 ================================================================================
 
-
+- Added `md_file_splitter` option to `render()`, used to split markdown inputs to pandoc into multiple files. This is for the purpose of invoking pandoc with the `--file-scope` option, which in turn enables graceful handling of duplicate footnote numbers across chapters.
 
 rmarkdown 2.2
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.3
 ================================================================================
 
-- Added `md_file_splitter` option to `render()`, used to split markdown inputs to pandoc into multiple files. This is for the purpose of invoking pandoc with the `--file-scope` option, which in turn enables graceful handling of duplicate footnote numbers across chapters.
+- Added `file_scope` option to `render()`, a function used to split markdown inputs to pandoc into multiple files. This is for the purpose of invoking pandoc with the `--file-scope` option, which in turn enables graceful handling of duplicate footnote numbers across chapters.
 
 rmarkdown 2.2
 ================================================================================

--- a/R/render.R
+++ b/R/render.R
@@ -190,7 +190,7 @@ NULL
 #' uses knitr's \code{root.dir} knit option. If \code{NULL} then the behavior
 #' will follow the knitr default, which is to use the parent directory of the
 #' document.
-#' @param md_file_splitter An optional function that will split markdown
+#' @param file_scope An optional function that will split markdown
 #' inputs to pandoc into multiple files. This is for the purpose of invoking
 #' pandoc with the \code{--file-scope} option, which allows footnotes in
 #' different files with the same identifiers to work as expected. This is
@@ -250,7 +250,7 @@ render <- function(input,
                    output_yaml = NULL,
                    intermediates_dir = NULL,
                    knit_root_dir = NULL,
-                   md_file_splitter = NULL,
+                   file_scope = NULL,
                    runtime =  c("auto", "static", "shiny", "shiny_prerendered"),
                    clean = TRUE,
                    params = NULL,
@@ -295,7 +295,7 @@ render <- function(input,
                        output_options = output_options,
                        intermediates_dir = intermediates_dir,
                        knit_root_dir = knit_root_dir,
-                       md_file_splitter = md_file_splitter,
+                       file_scope = file_scope,
                        runtime = runtime,
                        clean = clean,
                        params = params,
@@ -857,17 +857,17 @@ render <- function(input,
       utf8_input <- path.expand(utf8_input)
       output     <- path.expand(output)
 
-      # determine args and input files (if we have an md_file_splitter then we
+      # determine args and input files (if we have an file_scope then we
       # we need to split the files use it here)
       pandoc_args <- output_format$pandoc$args
       input_files <- utf8_input
-      if (!is.null(md_file_splitter)) {
+      if (!is.null(file_scope)) {
 
         # add the --file-scope option
         pandoc_args <- c(pandoc_args, "--file-scope")
 
         # determine new input files
-        inputs <- md_file_splitter(utf8_input)
+        inputs <- file_scope(utf8_input)
         input_files <- unlist(lapply(inputs, function(input) {
           file <- file_with_meta_ext(input$name, "split", "md")
           file <- file.path(dirname(utf8_input), file)

--- a/R/render.R
+++ b/R/render.R
@@ -190,6 +190,14 @@ NULL
 #' uses knitr's \code{root.dir} knit option. If \code{NULL} then the behavior
 #' will follow the knitr default, which is to use the parent directory of the
 #' document.
+#' @param md_file_splitter An optional function that will split markdown
+#' inputs to pandoc into multiple files. This is for the purpose of invoking
+#' pandoc with the \code{--file-scope} option, which allows footnotes in
+#' different files with the same identifiers to work as expected. This is
+#' useful when the caller has concatenated a set of Rmd files together (as
+#' \pkg{bookdown} does), and those files may have conflicting footnote numbers.
+#' The function should return a named list of files w/ \code{name} and
+#' \code{content} for each file.
 #' @param runtime The runtime target for rendering. The \code{static} option
 #' produces output intended for static files; \code{shiny} produces output
 #' suitable for use in a Shiny document (see \code{\link{run}}). The default,
@@ -242,6 +250,7 @@ render <- function(input,
                    output_yaml = NULL,
                    intermediates_dir = NULL,
                    knit_root_dir = NULL,
+                   md_file_splitter = NULL,
                    runtime =  c("auto", "static", "shiny", "shiny_prerendered"),
                    clean = TRUE,
                    params = NULL,
@@ -286,6 +295,7 @@ render <- function(input,
                        output_options = output_options,
                        intermediates_dir = intermediates_dir,
                        knit_root_dir = knit_root_dir,
+                       md_file_splitter = md_file_splitter,
                        runtime = runtime,
                        clean = clean,
                        params = params,
@@ -847,12 +857,34 @@ render <- function(input,
       utf8_input <- path.expand(utf8_input)
       output     <- path.expand(output)
 
+      # determine args and input files (if we have an md_file_splitter then we
+      # we need to split the files use it here)
+      pandoc_args <- output_format$pandoc$args
+      input_files <- utf8_input
+      if (!is.null(md_file_splitter)) {
+
+        # add the --file-scope option
+        pandoc_args <- c(pandoc_args, "--file-scope")
+
+        # determine new input files
+        inputs <- md_file_splitter(utf8_input)
+        input_files <- unlist(lapply(inputs, function(input) {
+          file <- file_with_meta_ext(input$name, "split", "md")
+          file <- file.path(dirname(utf8_input), file)
+          write_utf8(input$content, file)
+          file
+        }))
+
+        # cleanup the split files after render
+        on.exit(unlink(input_files), add = TRUE)
+      }
+
       # if we don't detect any invalid shell characters in the
       # target path, then just call pandoc directly
       if (!grepl(.shell_chars_regex, output) && !grepl(.shell_chars_regex, utf8_input)) {
         return(pandoc_convert(
-          utf8_input, pandoc_to, output_format$pandoc$from, output,
-          citeproc, output_format$pandoc$args, !quiet
+          input_files, pandoc_to, output_format$pandoc$from, output,
+          citeproc, pandoc_args, !quiet
         ))
       }
 
@@ -874,8 +906,8 @@ render <- function(input,
 
       # call pandoc to render file
       status <- pandoc_convert(
-        utf8_input, pandoc_to, output_format$pandoc$from, pandoc_output_tmp,
-        citeproc, output_format$pandoc$args, !quiet
+        input_files, pandoc_to, output_format$pandoc$from, pandoc_output_tmp,
+        citeproc, pandoc_args, !quiet
       )
 
       # construct output path (when passed only a file name to '--output',

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -13,7 +13,7 @@ render(
   output_yaml = NULL,
   intermediates_dir = NULL,
   knit_root_dir = NULL,
-  md_file_splitter = NULL,
+  file_scope = NULL,
   runtime = c("auto", "static", "shiny", "shiny_prerendered"),
   clean = TRUE,
   params = NULL,
@@ -75,7 +75,7 @@ uses knitr's \code{root.dir} knit option. If \code{NULL} then the behavior
 will follow the knitr default, which is to use the parent directory of the
 document.}
 
-\item{md_file_splitter}{An optional function that will split markdown
+\item{file_scope}{An optional function that will split markdown
 inputs to pandoc into multiple files. This is for the purpose of invoking
 pandoc with the \code{--file-scope} option, which allows footnotes in
 different files with the same identifiers to work as expected. This is

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -13,6 +13,7 @@ render(
   output_yaml = NULL,
   intermediates_dir = NULL,
   knit_root_dir = NULL,
+  md_file_splitter = NULL,
   runtime = c("auto", "static", "shiny", "shiny_prerendered"),
   clean = TRUE,
   params = NULL,
@@ -73,6 +74,15 @@ intermediate files are written to the same directory as the input file.}
 uses knitr's \code{root.dir} knit option. If \code{NULL} then the behavior
 will follow the knitr default, which is to use the parent directory of the
 document.}
+
+\item{md_file_splitter}{An optional function that will split markdown
+inputs to pandoc into multiple files. This is for the purpose of invoking
+pandoc with the \code{--file-scope} option, which allows footnotes in
+different files with the same identifiers to work as expected. This is
+useful when the caller has concatenated a set of Rmd files together (as
+\pkg{bookdown} does), and those files may have conflicting footnote numbers.
+The function should return a named list of files w/ \code{name} and
+\code{content} for each file.}
 
 \item{runtime}{The runtime target for rendering. The \code{static} option
 produces output intended for static files; \code{shiny} produces output


### PR DESCRIPTION
Caller must provide a `file_scope` function used to break apart a markdown file to be passed to pandoc into multiple files. This in turn enables the use of pandoc's `--file-scope` (https://pandoc.org/MANUAL.html#option--file-scope), which in turn resolves duplicate numeric footnote id's across files.

In the short term this will be used by bookdown to enable correct handling of duplicate numbered footnotes across chapters.

Note that if `render()` handled multiple input files by passing them all to pandoc, we could make `file_scope` a boolean or a function (where the boolean would result in just passing `--file-scope` without any splitting). However, for multiple inputs `render()` calls itself recursively (meaning that pandoc always gets a single Rmd anyway, so `--file-scope` would have no meaning).