### PR TITLE
Added missing lang attribute to ioslides_presentation template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.3
 ================================================================================
 
-* Added customizable `lang` atrribute to `ioslides_presentation` output.
+- Added the customizable `lang` atrribute to `ioslides_presentation` output (thanks, @jooyoungseo, #1841).
 
 
 rmarkdown 2.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.3
 ================================================================================
 
+* Added customizable `lang` atrribute to `ioslides_presentation` output.
 
 
 rmarkdown 2.2

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
 <head>
   <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
 


### PR DESCRIPTION
While both slidy and Rmd default html files have `lang` attribute in their templates, I have found that ioslides_presentation has missed this component which is good to have for accessibility purposes.