### PR TITLE
Test more R versions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,31 @@ pandoc_version: 2.3.1
 cran: https://cran.rstudio.com
 
 env:
-  global:
-    - _R_CHECK_TESTS_NLINES_=0
-  matrix:
-    - PANDOC_VERSION=default NETLIFY_SITE_ID=5d77c13c-e2ee-4a31-87ca-2fe657196160
-    - PANDOC_VERSION=latest PATH=$HOME/bin:$PATH
+  - _R_CHECK_TESTS_NLINES_=0
 
 before_install:
-  - "[[ ${PANDOC_VERSION} = latest ]] && ./tools/install-pandoc.sh || true"
   - pandoc --version
 
-after_success:
-  - "[[ ${TRAVIS_BRANCH}  = master  ]] || exit 0"
-  - "[[ ${PANDOC_VERSION} = default ]] || exit 0"
-  - "[[ -z ${NETLIFY_AUTH_TOKEN} ]] && exit 0"
-  - nvm install stable
-  - npm install netlify-cli -g
-  - Rscript -e 'pkgdown::build_site(".", document = FALSE, preview = FALSE)' && netlify deploy --prod --dir docs
+jobs:
+  include:
+    - r: 3.3
+    - r: 3.4
+    - r: 3.5
+    - r: 3.6
+    - r: release
+      name: last R and Pandoc versions
+      env: PATH=$HOME/bin:$PATH
+      before_install:
+        - ./tools/install-pandoc.sh || true
+        - pandoc --version
+    - r: release
+      name: last R and default Pandoc versions
+      env: NETLIFY_SITE_ID=5d77c13c-e2ee-4a31-87ca-2fe657196160
+      after_success:
+        - "[[ ${TRAVIS_BRANCH}  = master  ]] || exit 0"
+        - "[[ -z ${NETLIFY_AUTH_TOKEN} ]] && exit 0"
+        - nvm install stable
+        - npm install netlify-cli -g
+        - Rscript -e 'pkgdown::build_site(".", document = FALSE, preview = FALSE)' && netlify deploy --prod --dir docs
+    - r: devel
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ pandoc_version: 2.3.1
 cran: https://cran.rstudio.com
 
 env:
-  - _R_CHECK_TESTS_NLINES_=0
+  global:
+    - _R_CHECK_TESTS_NLINES_=0
 
 before_install:
   - pandoc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ dist: bionic
 language: r
 cache:
   packages: yes
+  directories:
+  - "$PANDOC"
 pandoc_version: 2.3.1
 cran: https://cran.rstudio.com
 
 env:
   global:
     - _R_CHECK_TESTS_NLINES_=0
+    - PANDOC="$HOME/.pandoc"
+    - PANDOC_DEB="https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-1-amd64.deb"
 
 before_install:
   - pandoc --version
@@ -25,7 +29,13 @@ jobs:
         - ./tools/install-pandoc.sh || true
         - pandoc --version
     - r: release
-      name: last R and default Pandoc versions
+      name: last R and Pandoc 2.7.3
+      env: PATH=$PANDOC/usr/bin:$PATH
+      before_install:
+        - if [[ ! -f "$PANDOC/pandoc.deb" ]]; then curl -L "$PANDOC_DEB" -o "$PANDOC/pandoc.deb" && dpkg -x "$PANDOC/pandoc.deb" "$PANDOC"; fi
+        - pandoc --version
+    - r: release
+      name: last R and Pandoc 2.3.1 versions
       env: NETLIFY_SITE_ID=5d77c13c-e2ee-4a31-87ca-2fe657196160
       after_success:
         - "[[ ${TRAVIS_BRANCH}  = master  ]] || exit 0"

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -24,6 +24,11 @@ test_that("vignette_pre_processor warns against differences in vignette index en
   opts <- options(rmarkdown.html_vignette.check_title = TRUE)
   on.exit(options(opts), add = TRUE)
   input_file <- .generate_temp_vignette('document title', 'vignette title')
-  expect_warning(vignette_pre_processor(input_file), 'rmarkdown.html_vignette.check_title')
+  # only warns for R 3.6 and later
+  if (getRversion() >= 3.6) {
+    expect_warning(vignette_pre_processor(input_file), 'rmarkdown.html_vignette.check_title')
+  } else {
+    expect_null(vignette_pre_processor(input_file))
+  }
   unlink(input_file)
 })


### PR DESCRIPTION
This will resolve #1838 

It improve `.travis.yaml` by 

* Now testing several R versions from 3.3 to 4.0, including R-devel
* With R current release, testing one more version of Pandoc, 2.7.3 the one now shipped with RStudio 1.3

For the rest, I kept what was done already. For example, the linux version used is Bionic. Also, the deployment of the website is only for master with current R version and default pandoc 2.3.1. I wonder if we should use a newer pandoc ? 🤔 

I also adapted the fix from #1832 to pass all R versions. 

This is a quick solution still with travis, before switching to GHA later, but it will surely help to prevent breaking change with older version, and is more align with the tidyverse testing ecosystem.

 

