### PR TITLE
update connect links on homepage

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -55,7 +55,7 @@ $("#pageContent").removeClass("standardPadding");
   <div class="band full gray2 fourth leftText">
     <div class="bandContent vCenter">
       <div class="blurb">
-        <div>Need R Markdown in production? Learn how to <a href="https://docs.rstudio.com/connect/user/publishing.html#publishing-documents">publish</a> and <a href="https://docs.rstudio.com/connect/user/r-markdown-schedule.html">schedule</a> reports, <a href="https://docs.rstudio.com/connect/user/param-rmarkdown.html">enable self-service customization</a>, and distribute beautiful emails using <a href='https://rstudio.com/products/connect'> RStudio Connect</a>.
+        <div>Need R Markdown in production? Learn how to <a href="https://docs.rstudio.com/connect/user/publishing/">publish</a> and <a href="https://docs.rstudio.com/connect/user/scheduling/">schedule</a> reports, <a href="https://docs.rstudio.com/connect/user/param-rmarkdown/">enable self-service customization</a>, and distribute beautiful emails using <a href='https://rstudio.com/products/connect'> RStudio Connect</a>.
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
 <title>R Markdown</title>
 
-<script src="site_libs/header-attrs-2.1.2/header-attrs.js"></script>
+<script src="site_libs/header-attrs-2.2/header-attrs.js"></script>
 <script src="site_libs/jquery-1.11.3/jquery.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/cosmo.min.css" rel="stylesheet" />
@@ -286,7 +286,7 @@ $("#pageContent").removeClass("standardPadding");
   <div class="band full gray2 fourth leftText">
     <div class="bandContent vCenter">
       <div class="blurb">
-        <div>Need R Markdown in production? Learn how to <a href="https://docs.rstudio.com/connect/user/publishing.html#publishing-documents">publish</a> and <a href="https://docs.rstudio.com/connect/user/r-markdown-schedule.html">schedule</a> reports, <a href="https://docs.rstudio.com/connect/user/param-rmarkdown.html">enable self-service customization</a>, and distribute beautiful emails using <a href='https://rstudio.com/products/connect'> RStudio Connect</a>.
+        <div>Need R Markdown in production? Learn how to <a href="https://docs.rstudio.com/connect/user/publishing/">publish</a> and <a href="https://docs.rstudio.com/connect/user/scheduling/">schedule</a> reports, <a href="https://docs.rstudio.com/connect/user/param-rmarkdown/">enable self-service customization</a>, and distribute beautiful emails using <a href='https://rstudio.com/products/connect'> RStudio Connect</a>.
         </div>
       </div>
     </div>


### PR DESCRIPTION
A few Connect links have changed:

publish ⧉ >> https://docs.rstudio.com/connect/user/publishing/
schedule ⧉ >> https://docs.rstudio.com/connect/user/scheduling/
enable self-service customization ⧉ >> https://docs.rstudio.com/connect/user/param-rmarkdown/