### PR TITLE
read metadata before running pre_knit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ rmarkdown 2.4
 
 - The two Lua fitlers `pagebreak.lua` and `latex-div.lua` (introduced in **rmarkdown** 1.16) are also applied to the output format `beamer_presentation` now (thanks, @XiangyunHuang, #1815).
 
+- When customizing formats with the `output_format` function, `pre_knit`, `opts_hooks`, and `knit_hooks` can now refer to `rmarkdown::metadata`. Previously, `rmarkdown::metadata` returned `list()` in these functions (thanks, @atusy, #1855).
 
 rmarkdown 2.3
 ================================================================================

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -2,11 +2,13 @@ test_that("Metadata is available before pre_knit", {
   message_pre_knit = 'pre_knit handles metadata'
   fmt <- md_document()
   fmt$pre_knit <- function(input, ...) {
-    if (!identical(metadata, list(foo = 'bar'))) {
+    # `metadata` requires `rmarkdown::`-prefix. Otherwise, it becomes `list()`.
+    if (identical(rmarkdown::metadata, list(foo = 'bar'))) {
       message(message_pre_knit)
     }
+    options
   }
   input_file = tempfile(fileext = '.md')
   writeLines('---\nfoo: bar\n---', input_file)
-  expect_message(render(input_file, fmt), message_pre_knit)
+  expect_message(render(input_file, fmt, quiet = TRUE), message_pre_knit)
 })

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,0 +1,12 @@
+test_that("Metadata is available before pre_knit", {
+  message_pre_knit = 'pre_knit handles metadata'
+  fmt <- md_document()
+  fmt$pre_knit <- function(input, ...) {
+    if (!identical(metadata, list(foo = 'bar'))) {
+      message(message_pre_knit)
+    }
+  }
+  input_file = tempfile(fileext = '.md')
+  writeLines('---\nfoo: bar\n---', input_file)
+  testthat::expect_message(render(input_file, fmt), message_pre_knit)
+})

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -6,7 +6,6 @@ test_that("Metadata is available before pre_knit", {
     if (identical(rmarkdown::metadata, list(foo = 'bar'))) {
       message(message_pre_knit)
     }
-    options
   }
   input_file = tempfile(fileext = '.md')
   writeLines('---\nfoo: bar\n---', input_file)

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -8,5 +8,5 @@ test_that("Metadata is available before pre_knit", {
   }
   input_file = tempfile(fileext = '.md')
   writeLines('---\nfoo: bar\n---', input_file)
-  testthat::expect_message(render(input_file, fmt), message_pre_knit)
+  expect_message(render(input_file, fmt), message_pre_knit)
 })


### PR DESCRIPTION
By this PR, output formats gains more flexible access to metadata.
In particular, the pre_knit function and hook functions (opts_hooks, knit_hooks) can see `rmarkdown::metadata`.
Currently, they appears to be `NULL`.

This is slightly related to #673, but does not solve it because there is output formats do not know input files until rendering.