### PR TITLE
md_document gains knitr as a markdown variant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rmarkdown 2.4
 
 - When customizing formats with the `output_format` function, `pre_knit`, `opts_hooks`, and `knit_hooks` can now refer to `rmarkdown::metadata`. Previously, `rmarkdown::metadata` returned `list()` in these functions (thanks, @atusy, #1855).
 
+- `md_document` gains "knitr" as a markdown variant so to create `knitr::knit`ted markdown instead of `pandoc`ed markdown (thanks, @atusy, #1863).
+
 rmarkdown 2.3
 ================================================================================
 

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -13,7 +13,7 @@
 #' @param variant Markdown variant to produce (defaults to "markdown_strict").
 #'   Other valid values are "commonmark", "markdown_github", "markdown_mmd",
 #'   markdown_phpextra", "markdown" (which produces pandoc markdown), or "knitr"
-#'   (which produces \code{\link{knitr::knit)}}ed markdown). Note that "knitr"
+#'   (which produces \code{knitr::knit)}ed markdown). Note that "knitr"
 #'   ignores the parameters, `toc`, `toc_depth`, `md_extensions`, and `pandoc_args`.
 #'   You can also compose custom markdown variants, see the
 #'   \href{http://pandoc.org/README.html}{pandoc online documentation}

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -24,7 +24,7 @@ md_document(
 \item{variant}{Markdown variant to produce (defaults to "markdown_strict").
 Other valid values are "commonmark", "markdown_github", "markdown_mmd",
 markdown_phpextra", "markdown" (which produces pandoc markdown), or "knitr"
-(which produces \code{\link{knitr::knit)}}ed markdown). Note that "knitr"
+(which produces \code{knitr::knit)}ed markdown). Note that "knitr"
 ignores the parameters, `toc`, `toc_depth`, `md_extensions`, and `pandoc_args`.
 You can also compose custom markdown variants, see the
 \href{http://pandoc.org/README.html}{pandoc online documentation}

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -23,7 +23,9 @@ md_document(
 \arguments{
 \item{variant}{Markdown variant to produce (defaults to "markdown_strict").
 Other valid values are "commonmark", "markdown_github", "markdown_mmd",
-markdown_phpextra", or even "markdown" (which produces pandoc markdown).
+markdown_phpextra", "markdown" (which produces pandoc markdown), or "knitr"
+(which produces \code{\link{knitr::knit)}}ed markdown). Note that "knitr"
+ignores the parameters, `toc`, `toc_depth`, `md_extensions`, and `pandoc_args`.
 You can also compose custom markdown variants, see the
 \href{http://pandoc.org/README.html}{pandoc online documentation}
 for details.}


### PR DESCRIPTION
This PR solves #1860 by allowing `md_document` to output `knitr::knit`ted markdown.
It internally runs pandoc, but replaces the result with an input markdown.