### PR TITLE
Added number_sections for docx

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -106,6 +106,6 @@ SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 URL: https://github.com/rstudio/rmarkdown
 BugReports: https://github.com/rstudio/rmarkdown/issues
 License: GPL-3
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rmarkdown 2.4
 
 - When customizing formats with the `output_format` function, `pre_knit`, `opts_hooks`, and `knit_hooks` can now refer to `rmarkdown::metadata`. Previously, `rmarkdown::metadata` returned `list()` in these functions (thanks, @atusy, #1855).
 
+- `number_sections` argument is supported for `word_document()` output_format. This requires pandoc >= v2.10.1, and set to FALSE by default (thanks, @jooyoungseo).
+
 rmarkdown 2.3
 ================================================================================
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ rmarkdown 2.4
 
 - When customizing formats with the `output_format` function, `pre_knit`, `opts_hooks`, and `knit_hooks` can now refer to `rmarkdown::metadata`. Previously, `rmarkdown::metadata` returned `list()` in these functions (thanks, @atusy, #1855).
 
-- `number_sections` argument is supported for `word_document()` output_format. This requires pandoc >= v2.10.1, and set to FALSE by default (thanks, @jooyoungseo).
+- `number_sections` argument is supported for `word_document()` output_format. This requires pandoc >= v2.10.1, and set to FALSE by default (thanks, @jooyoungseo, #1869).
 
 rmarkdown 2.3
 ================================================================================

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -33,6 +33,7 @@
 #' @export
 word_document <- function(toc = FALSE,
                           toc_depth = 3,
+                          number_sections = FALSE,
                           fig_width = 5,
                           fig_height = 4,
                           fig_caption = TRUE,
@@ -59,6 +60,13 @@ word_document <- function(toc = FALSE,
     args <- c(args, pandoc_toc_args(toc, toc_depth))
   else
     warning("table of contents for word_document requires pandoc >= 1.14")
+
+  # numbered sections
+  if (number_sections)
+    if (pandoc_available("2.10.1"))
+      args <- c(args, "--number-sections")
+    else
+      warning("number_sections for word_document requires pandoc >= 2.10.1")
 
   # highlighting
   if (!is.null(highlight))

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -62,11 +62,13 @@ word_document <- function(toc = FALSE,
     warning("table of contents for word_document requires pandoc >= 1.14")
 
   # numbered sections
-  if (number_sections)
-    if (pandoc_available("2.10.1"))
+  if (number_sections) {
+    if (pandoc_available("2.10.1")) {
       args <- c(args, "--number-sections")
-    else
-      warning("number_sections for word_document requires pandoc >= 2.10.1")
+    } else {
+      warning("number_sections for word_document requires Pandoc >= 2.10.1")
+    }
+  }
 
   # highlighting
   if (!is.null(highlight))

--- a/man/word_document.Rd
+++ b/man/word_document.Rd
@@ -7,6 +7,7 @@
 word_document(
   toc = FALSE,
   toc_depth = 3,
+  number_sections = FALSE,
   fig_width = 5,
   fig_height = 4,
   fig_caption = TRUE,
@@ -22,6 +23,8 @@ word_document(
 \item{toc}{\code{TRUE} to include a table of contents in the output}
 
 \item{toc_depth}{Depth of headers to include in table of contents}
+
+\item{number_sections}{\code{TRUE} to number section headings}
 
 \item{fig_width}{Default width (in inches) for figures}
 


### PR DESCRIPTION
This PR is the first step to address [bookdown#756](https://github.com/rstudio/bookdown/issues/756#issuecomment-521664200).

Now that `--number-sections` is supported for Docx writer via [pandoc v2.10.1](https://github.com/jgm/pandoc/releases/tag/2.10.1), I've added `number_sections` argument to `word_document()` output_format (set to FALSE by default).

I've also made a condition to ignore the argument when fired in a session < pandoc v2.10.1, and added a gentle warning message.

I've tested the following document with pandoc v2.10.1, and confirmed that this works.

```
---
output:
  word_document:
    number_sections: true
---

# Introduction

# Body

# Conclusion
```
