### PR TITLE
incorporate CSS styles from latest Pandoc's tempalte

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -27,6 +27,24 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+<style type="text/css">
+  code{white-space: pre-wrap;}
+  span.smallcaps{font-variant: small-caps;}
+  span.underline{text-decoration: underline;}
+  div.column{display: inline-block; vertical-align: top; width: 50%;}
+  div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+  ul.task-list{list-style: none;}
+  $if(quotes)$
+  q { quotes: "“" "”" "‘" "’"; }
+  $endif$
+  $if(highlighting-css)$
+  $highlighting-css$
+  $endif$
+  $if(displaymath-css)$
+  .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  $endif$
+</style>
+
 $if(highlightjs)$
 <style type="text/css">code{white-space: pre;}</style>
 $if(theme)$

--- a/inst/rmd/slidy/default.html
+++ b/inst/rmd/slidy/default.html
@@ -19,7 +19,23 @@ $if(font-size-adjustment)$
   <meta name="font-size-adjustment" content="$font-size-adjustment$"/>
 $endif$
   <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
-  <style type="text/css">code{white-space: pre;}</style>
+  <style type="text/css">
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    span.underline{text-decoration: underline;}
+    div.column{display: inline-block; vertical-align: top; width: 50%;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    $if(quotes)$
+    q { quotes: "“" "”" "‘" "’"; }
+    $endif$
+    $if(highlighting-css)$
+    $highlighting-css$
+    $endif$
+    $if(displaymath-css)$
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+    $endif$
+  </style>
 $if(highlighting-css)$
   <style type="text/css">
 $highlighting-css$


### PR DESCRIPTION
This will enable styles such as underlines, smallcaps, and multi-column layouts...

CSS is added to templates of 

- html_document
- slidy

If it is preferred to added to ioslides as well, let me know.

I suggest the same changes to revealjs as well (https://github.com/rstudio/revealjs/pull/82).