### PR TITLE
Evaluate path arguments before changing working directory

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -49,6 +49,10 @@ pandoc_convert <- function(input,
   # ensure we've scanned for pandoc
   find_pandoc()
 
+  # evaluate path arguments before changing working directory
+  force(from)
+  force(to)
+
   # execute in specified working directory
   if (is.null(wd)) {
     wd <- base_dir(input)

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -50,8 +50,7 @@ pandoc_convert <- function(input,
   find_pandoc()
 
   # evaluate path arguments before changing working directory
-  force(from)
-  force(to)
+  force(output)
 
   # execute in specified working directory
   if (is.null(wd)) {


### PR DESCRIPTION
Closes #1889.

``` r
input <- tempfile("in", fileext = ".md")
input
#> [1] "/tmp/RtmpSsJUcs/in75d01f49793a.md"
writeLines("# Document", input)

output <- "out.md"

# Works now
writeLines("bogus", output)
normalizePath(output, mustWork = FALSE)
#> [1] "/tmp/RtmppTOsNd/reprex755f2372650c/out.md"
rmarkdown::pandoc_convert(input, output = normalizePath(output, mustWork = FALSE), verbose = TRUE)
#> /usr/lib/rstudio/bin/pandoc/pandoc +RTS -K512m -RTS /tmp/RtmpSsJUcs/in75d01f49793a.md --output /tmp/RtmppTOsNd/reprex755f2372650c/out.md
readLines(output)
#> [1] "Document" "========"
```

<sup>Created on 2020-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>