### PR TITLE
Add missing lua filter vignettes to articles in pkgdown

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -36,6 +36,8 @@ navbar:
           href: articles/rmarkdown.html
         - text: "Install Pandoc"
           href: articles/pandoc.html
+        - text: "About Lua filters"
+          href: articles/lua-filters.html
     news:
       text: Changelog
       href: news/index.html


### PR DESCRIPTION
Don't know if it was not included on purpose but I think it is worth adding