### PR TITLE
Support pandoc headerless table in table formatting 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.5
 ================================================================================
 
+- Headerless pandoc's [simple table](https://pandoc.org/MANUAL.html#extension-simple_tables) are now formatted correctly when using `html_document()` format (thanks, @fkohrt, #1893)
 
 rmarkdown 2.4
 ================================================================================

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -577,7 +577,7 @@ $endif$
 
 // add bootstrap table styles to pandoc tables
 function bootstrapStylePandocTables() {
-  $$('tr.header').parent('thead').parent('table').addClass('table table-condensed');
+  $$('tr.odd').parent('tbody').parent('table').addClass('table table-condensed');
 }
 $$(document).ready(function () {
   bootstrapStylePandocTables();


### PR DESCRIPTION
I find this one easy to fix #1893 but I agree that this script exists from some time now (https://github.com/rstudio/rmarkdown/issues/1893#issuecomment-688877872) 

pandoc table can have no header so we could point the selector toward another pandoc table specific class. 
See https://github.com/jgm/pandoc/blob/9cad5499c45022b9893156bb5e0468cabefca974/src/Text/Pandoc/Writers/HTML.hs#L954
pandoc adds `header` class to `tr` in table header but it also add `odd` (or `even`) as class in `tr` inside `tbody`. We could use that to target pandoc table. But maybe that is more common class addition than the previous selector. 

As you suggested @yihui we could not add support for that and leave the user customise itself using JS (but it must know how...)

If we want to continue with this PR, I'll add some more tests to be sure.
 