### PR TITLE
only install pkgdown for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
         - "[[ -z ${NETLIFY_AUTH_TOKEN} ]] && exit 0"
         - nvm install stable
         - npm install netlify-cli -g
+        - Rscript -e 'xfun::pkg_load2("pkgdown")'
         - Rscript -e 'pkgdown::build_site(".", document = FALSE, preview = FALSE)' && netlify deploy --prod --dir docs
     - r: devel
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,7 +101,6 @@ Suggests:
     dygraphs,
     tibble,
     fs,
-    pkgdown,
     rsconnect
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org
 URL: https://github.com/rstudio/rmarkdown


### PR DESCRIPTION
This should fix the travis build for R 3.3. It reverts 97142d9453e91c225cd60e8ef786967ba92009f2 but we can revert again when new systemfonts hits CRAN.