### PR TITLE
Remove duplicate insertion of Pandoc's higlighting css

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.4.4
+Version: 2.4.5
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ rmarkdown 2.5
 
 - Supports new Pandoc 2.11 `--citeproc` flags usage instead of `pandoc-citeproc` external filter. `pandoc_convert()` and `pandoc_citeproc_convert()` will now use the correct flags according to the Pandoc version used. The logic is exported in `pandoc_citeproc_args()`. See [Pandoc release note](https://github.com/jgm/pandoc/releases/tag/2.11) for more information about the new `citeproc` processing (#1916).
 
+- Fixed the code highlighting when code block is hidden. Previous version introduced a regression where non default code highlighting was still shown when `code_folding` is activated and code block is hidden. (thanks, @matthewcarlucci, #1921)
+
 
 rmarkdown 2.4
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,6 @@ rmarkdown 2.5
 
 - Fixed the code highlighting when code block is hidden. Previous version introduced a regression where non default code highlighting was still shown when `code_folding` is activated and code block is hidden. (thanks, @matthewcarlucci, #1921)
 
-
 rmarkdown 2.4
 ================================================================================
 

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -37,9 +37,6 @@ $endfor$
   $if(quotes)$
   q { quotes: "“" "”" "‘" "’"; }
   $endif$
-  $if(highlighting-css)$
-  $highlighting-css$
-  $endif$
   $if(displaymath-css)$
   .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   $endif$


### PR DESCRIPTION
This fixes #1921 

Previous version we pushed on CRAN introduced a regression in https://github.com/rstudio/rmarkdown/pull/1878 where `highlighting-css` was included a second time. 

This broke the special JS treatment we are doing to move `div.sourceCode` to `pre.sourceCode` which helps when code folding is activated. 

We just remove the duplicate and live the new css inserted previously as-is