### PR TITLE
support vctrs abbreviations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,14 +91,14 @@ Imports:
     tinytex (>= 0.11),
     xfun (>= 0.15),
     methods,
-    stringr (>= 1.2.0),
-    vctrs (>= 0.3.2)
+    stringr (>= 1.2.0)
 Suggests:
     shiny (>= 0.11),
     tufte,
     testthat,
     digest,
     dygraphs,
+    vctrs,
     tibble,
     fs,
     rsconnect

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,7 +91,8 @@ Imports:
     tinytex (>= 0.11),
     xfun (>= 0.15),
     methods,
-    stringr (>= 1.2.0)
+    stringr (>= 1.2.0),
+    vctrs (>= 0.3.2)
 Suggests:
     shiny (>= 0.11),
     tufte,

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -1,6 +1,7 @@
 # paged_table_type_sum and paged_table_obj_sum should be replaced
 # by tibble::type_sum once tibble supports R 3.0.0.
 paged_table_type_sum <- function(x) {
+  if (vctrs::vec_is(x)) return(vctrs::vec_ptype_abbr(x))
   type_sum <- function(x)
   {
     format_sum <- switch(

--- a/R/html_paged.R
+++ b/R/html_paged.R
@@ -1,7 +1,8 @@
 # paged_table_type_sum and paged_table_obj_sum should be replaced
 # by tibble::type_sum once tibble supports R 3.0.0.
 paged_table_type_sum <- function(x) {
-  if (vctrs::vec_is(x)) return(vctrs::vec_ptype_abbr(x))
+  #  support vctrs-type vectors if the package is installed
+  if (xfun::loadable("vctrs") && vctrs::vec_is(x)) return(vctrs::vec_ptype_abbr(x))
   type_sum <- function(x)
   {
     format_sum <- switch(


### PR DESCRIPTION
Suggested fix for #1487 , this follows the equivalent use of `vctrs::vec_ptype_abbr` in the pillar package (see [code](https://github.com/r-lib/pillar/blob/08a96a94acdad5c69f524b518ace9287c6e1a463/R/type-sum.R#L38)). 

Note that it would be possible to replace the `paged_table_type_sum()` function almost entirely with what is implemented broadly by the `vctrs::vec_ptype_abbr` generic (see e.g. implementation for [atomic data types](https://github.com/r-lib/vctrs/blob/e1d02ed99a0a22292018e03adf2af7c8c2aad213/R/ptype-abbr-full.R#L62), [date time](https://github.com/r-lib/vctrs/blob/f5f57e0219a010dc09d8228e690969e6845050f5/R/type-date-time.R#L114), and [factors](https://github.com/r-lib/vctrs/blob/09aabd71d3f79bfda8b22489ead69b44d28bfab0/R/type-factor.R#L65)) but it would introduce small differences (e.g. the factor abbreviation would become `fct` instead of `fctr`) and I wasn't sure if this is something you'd be interested in.

ps: since this is my first pull request to rstudio, I have sent the signed contributor agreement to jj@rstudio.com