### PR TITLE
pkg_file_lua now works with devtools

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.6
 
 - Enable use of `server.R` and `global.R` alongside `runtime: shinyrmd` documents.
 
+- `pkg_file_lua()` now works with `devtools::load_all()` and **testthat** when used in other packages. 
+
 rmarkdown 2.5
 ================================================================================
 

--- a/R/util.R
+++ b/R/util.R
@@ -33,8 +33,17 @@ pandoc_output_ext <- function(ext, to, input) {
   paste0(".", to)
 }
 
-pkg_file <- function(..., package = "rmarkdown") {
-  system.file(..., package = package)
+# needs to handle the case when this function is used in a package loaded with
+# devtools or pkgload load_all(). Required for testing with testthat also.
+# From pkgdown:
+# https://github.com/r-lib/pkgdown/blob/04d3a76892320ac4bd918b39604c157e9f83507a/R/utils-fs.R#L85
+pkg_file <- function(..., package = "rmarkdown", mustWork = FALSE) {
+  if (is.null(devtools_meta(package))) {
+    system.file(..., package = package, mustWork = mustWork)
+  } else {
+    # used only if package has been loaded with devtools or pkgload
+    file.path(getNamespaceInfo(package, "path"), "inst", ...)
+  }
 }
 
 pkg_file_arg <- function(..., package = "rmarkdown") {
@@ -528,4 +537,14 @@ get_loaded_packages <- function() {
     version = version,
     row.names = NULL, stringsAsFactors = FALSE
   )
+}
+
+# devtools metadata -------------------------------------------------------
+
+# from pkgdown
+# https://github.com/r-lib/pkgdown/blob/77f909b0138a1d7191ad9bb3cf95e78d8e8d93b9/R/utils.r#L52
+
+devtools_meta <- function(package) {
+  ns <- .getNamespace(package)
+  ns[[".__DEVTOOLS__"]]
 }

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -67,3 +67,8 @@ test_that("formats have the expected Lua filter", {
     word_document(number_sections = TRUE),
     c("pagebreak", if (!pandoc_available("2.10.1")) "number-sections"))
 })
+
+test_that("lua file are correctly found", {
+  expect_match(basename(pkg_file_lua()),  ".*[.]lua$")
+  expect_match(basename(pkg_file_lua("number-sections.lua")),  "^number-sections.lua$")
+})


### PR DESCRIPTION
The fact that it does not work with `devtools::load_all`, and so **testthat** is a bit annoying. 

I reused a trick from **pkgdown** to make it work - hope it is fine. 

With this PR, this now works from **bookdown*** for example

```r
devtools::load_all()
lua_filter()
```

