### PR TITLE
fix exceptions on pandoc_convert(citeproc = TRUE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ rmarkdown 2.6
 
 - `pkg_file_lua()` now works with `devtools::load_all()` and **testthat** when used in other packages. 
 
+- Fix `pandoc_convert(citeproc = TRUE)` not supressing the `--natbib` or `--biblatex` options (thanks, @atusy, #1932).
+
 rmarkdown 2.5
 ================================================================================
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -83,7 +83,7 @@ pandoc_convert <- function(input,
   # citeproc filter if requested
   if (citeproc) {
     # --natbib/--biblatex conflicts with '--filter pandoc-citeproc'
-    args <- c(args[!args %in% c("--natbib", "--biblatex")],
+    args <- c(setdiff(args, c("--natbib", "--biblatex")),
               pandoc_citeproc_args())
   }
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -81,9 +81,10 @@ pandoc_convert <- function(input,
   args <- c(args, options)
 
   # citeproc filter if requested
-  if (citeproc && !any(c("--natbib", "--biblatex") %in% options)) {
+  if (citeproc) {
     # --natbib/--biblatex conflicts with '--filter pandoc-citeproc'
-    args <- c(args, pandoc_citeproc_args())
+    args <- c(args[!args %in% c("--natbib", "--biblatex")],
+              pandoc_citeproc_args())
   }
 
   # build the conversion command

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -81,11 +81,9 @@ pandoc_convert <- function(input,
   args <- c(args, options)
 
   # citeproc filter if requested
-  if (citeproc) {
-    args <- c(args, pandoc_citeproc_args())
+  if (citeproc && !any(c("--natbib", "--biblatex") %in% options)) {
     # --natbib/--biblatex conflicts with '--filter pandoc-citeproc'
-    i <- stats::na.omit(match(c("--natbib", "--biblatex"), options))
-    if (length(i)) options <- options[-i]
+    args <- c(args, pandoc_citeproc_args())
   }
 
   # build the conversion command


### PR DESCRIPTION
When citeproc is TRUE, but natbib or biblatex are under use, they are removed from the `options` variable.
However, this variable is no more used after the modification.
Instead, we should modify the `args` variable.

https://github.com/rstudio/rmarkdown/blob/bd2369f9f965c744588a0b056b35dd92e47902cb/R/pandoc.R#L83-L89

Note that the modification of `option` variable was valid when the exception is initially introduced by https://github.com/rstudio/rmarkdown/commit/bbabea82c1bfd3461fc7f675ac674c21560654db