### PR TITLE
Don't add anchors to empty headings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.5.2
+Version: 2.5.3
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.6
 ================================================================================
 
+- Fix issues with `anchor_sections = TRUE` and **learnr** (thanks, @gadenbuie, #1938)
+
 - Enable use of `server.R` and `global.R` alongside `runtime: shinyrmd` documents.
 
 - `pkg_file_lua()` now works with `devtools::load_all()` and **testthat** when used in other packages. 

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -128,7 +128,7 @@ html_dependency_navigation <- function(code_menu, source_embed) {
 html_dependency_anchor_sections <- function() {
 
   htmlDependency(name = "anchor-sections",
-                 version = "1.0",
+                 version = "1.0.1",
                  src = pkg_file("rmd/h/anchor-sections"),
                  script = "anchor-sections.js",
                  stylesheet = "anchor-sections.css")

--- a/inst/rmd/h/anchor-sections/anchor-sections.css
+++ b/inst/rmd/h/anchor-sections/anchor-sections.css
@@ -2,3 +2,4 @@
 a.anchor-section {margin-left: 10px; visibility: hidden; color: inherit;}
 a.anchor-section::before {content: '#';}
 .hasAnchor:hover a.anchor-section {visibility: visible;}
+ul > li > .anchor-section {display: none;}

--- a/inst/rmd/h/anchor-sections/anchor-sections.js
+++ b/inst/rmd/h/anchor-sections/anchor-sections.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // Add anchors
   h.forEach(function(x) {
     const id = x.id || section_id(x.parentElement);
-    if (id === '') {
+    if (id === '' || x.matches(':empty')) {
       return null;
     }
     let anchor = document.createElement('a');


### PR DESCRIPTION
Edit: sorry the PR was submitted accidentally before I could add the description.

This PR fixes #1937 by ensuring that anchors are not added to empty headings.

I also added a CSS rule that hides anchor sections if they end up being a direct child of a list item. This happens on the rare occasion where the HTML is rewritten by another script _after_ anchor sections are added. See https://github.com/rstudio/learnr/issues/446 for such an example.

Finally, I bumped anchor sections to `1.0.1` in `html_dependency_anchor_sections()`.

All of the above were committed individually so you can cherry pick as needed.