### PR TITLE
Support 'href' dependencies

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -213,7 +213,7 @@ html_dependencies_as_string <- function(dependencies, lib_dir, output_dir) {
 
 filter_dependencies <- function(dependencies, src_type = "file") {
   deps <- lapply(dependencies, function(dep) if(!is.null(dep$src[[src_type]])) return(dep))
-  deps[!sapply(deps, is.null)]
+  deps[!vapply(deps, is.null, logical(1))]
 }
 
 # check class of passed list for 'html_dependency'

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -194,16 +194,26 @@ html_reference_path <- function(path, lib_dir, output_dir) {
 # return the html dependencies as an HTML string suitable for inclusion
 # in the head of a document
 html_dependencies_as_string <- function(dependencies, lib_dir, output_dir) {
+  # Only copy deps with path
+  dependencies_href <- filter_dependencies(dependencies, "href")
+  dependencies <- filter_dependencies(dependencies, "file")
 
   if (!is.null(lib_dir)) {
     dependencies <- lapply(dependencies, copyDependencyToDir, lib_dir)
     dependencies <- lapply(dependencies, makeDependencyRelative, output_dir)
   }
-  return(renderDependencies(dependencies, "file", encodeFunc = identity,
+  #return(
+  tags <- renderDependencies(dependencies, "file", encodeFunc = identity,
                             hrefFilter = function(path) {
                               html_reference_path(path, lib_dir, output_dir)
                             })
-  )
+  #)
+  HTML(paste0(c(tags, renderDependencies(dependencies_href, "href")), collapse = "\n"))
+}
+
+filter_dependencies <- function(dependencies, src_type = "file") {
+  deps <- lapply(dependencies, function(dep) if(!is.null(dep$src[[src_type]])) return(dep))
+  deps[!sapply(deps, is.null)]
 }
 
 # check class of passed list for 'html_dependency'
@@ -223,15 +233,20 @@ validate_html_dependency <- function(list) {
     stop("name for html_dependency not provided", call. = FALSE)
   if (is.null(list$version))
     stop("version for html_dependency not provided", call. = FALSE)
-  list <- fix_html_dependency(list)
-  if (is.null(list$src$file))
-    stop("path for html_dependency not provided", call. = FALSE)
-  file <- list$src$file
-  if (!is.null(list$package))
-    file <- system.file(file, package = list$package)
-  if (!file.exists(file)) {
-    utils::str(list)
-    stop("path for html_dependency not found: ", file, call. = FALSE)
+  list <- fix_html_dependency(list) 
+
+  # check src path or href are given
+  if (is.null(list$src)) {
+    stop("neither path nor href are provided for html_dependency", call. = FALSE)
+  }
+  if (!is.null(list$src$file)) {
+    file <- list$src$file
+    if (!is.null(list$package))
+      file <- system.file(file, package = list$package)
+    if (!file.exists(file)) {
+      utils::str(list)
+      stop("path for html_dependency not found: ", file, call. = FALSE)
+    }
   }
 
   list


### PR DESCRIPTION
Resolves #794

Based on #1805 but no longer includes href reachability tests to validate URLs (They're either online, or they're not at runtime, but the server rendering the document doesn't actually need to use the frontend resources). 

Also no longer includes the RCurl dependency introduced in #1805 . 
If this is merged, #1805 should be closed.

Squash of:

- Support 'href' dependencies ( @crazycapivara )
- Use 'RCurl' to check whether url exists ( @crazycapivara )
- Revert "Use 'RCurl' to check whether url exists"
  This reverts commit 4894bd9f87b523f113a4d0ea7b19abbd9a4d18c1.
  ( @matthewstrasiotto )
- Remove href dependency url check from render side
  Build time reachability is not a requirement for a referenced dependency
  to be available at runtime. ( @matthewstrasiotto )

Co-authored-by: skuethe <crazycapivara@gmail.com>
Co-authored-by: Matthew Strasiotto <39424834+matthewstrasiotto@users.noreply.github.com>