### PR TITLE
apply the flag --atx-headers only for pandoc version before 2.11.2

### DIFF
--- a/R/github_document.R
+++ b/R/github_document.R
@@ -48,9 +48,8 @@ github_document <- function(toc = FALSE,
 
   # atx headers are the default in pandoc 2.11.2 and the flag has been deprecated
   # to be replace by `--markdown-headings=atx|setx`
-  pandoc_args <- c(
-    if (!pandoc_available("2.11.2")) "--atx-headers",
-        pandoc_args
+  if (!pandoc_available("2.11.2")) pandoc_args <- c(
+    "--atx-headers", pandoc_args
   )
 
   format <- md_document(

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -46,12 +46,19 @@ github_document <- function(toc = FALSE,
   }
   if (!hard_line_breaks) variant <- paste0(variant, "-hard_line_breaks")
 
+  # atx headers are the default in pandoc 2.11.2 and the flag has been deprecated
+  # to be replace by `--markdown-headings=atx|setx`
+  pandoc_args <- c(
+    if (!pandoc_available("2.11.2")) "--atx-headers",
+        pandoc_args
+  )
+
   format <- md_document(
     variant = variant, toc = toc, toc_depth = toc_depth,
     number_sections = number_sections, fig_width = fig_width,
     fig_height = fig_height, dev = dev, df_print = df_print,
     includes = includes, md_extensions = md_extensions,
-    pandoc_args = c("--atx-headers", pandoc_args)
+    pandoc_args = pandoc_args
   )
 
   # add a post processor for generating a preview if requested


### PR DESCRIPTION
closes #1919)

I started to do a fix which would have been more complicated, that is creating a wrapper function `pandoc_atxheaders_args(activate = TRUE)` to deal with all the versions of Pandoc

* Before Pandoc 1.9, everything was ATX headers
* `--atx-headers` exists since Pandoc 1.9 because they change the default for markdown writer to setex for level 1 and 2
*  Pandoc 2.11.2 resets the default to ATX headers, and change the flag to `--markdown-headings`

So a function like 
```r
pandoc_atxheaders_args <- function(activate = TRUE) {
  if (pandoc_available("2.11.2")) {
    # atx headers are the default in Pandoc 2.11.2+
	if (!activate) "--markdown-headings=setext"
  } else if (pandoc_available("1.9")) {
    # atx headers were removed as default in 1.9
    if (activate) "--atx-headers"
  }
  # before Pandoc 1.9 that was only ATX headers
}
```

But it does not seem we do that much conditional in **rmarkdown** and we try to have minimal scoped fix. 

@yihui do you think a wrapper like would be interesting ?  


