### PR TITLE
add css for csl with new built-in pandoc citeproc

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -156,6 +156,34 @@ $endif$
 </style>
 $endif$
 
+$if(csl-css)$
+<style type="text/css">
+/* for pandoc --citeproc since 2.11 */
+div.csl-bib-body { }
+div.csl-entry {
+  clear: both;
+$if(csl-entry-spacing)$
+  margin-bottom: $csl-entry-spacing$;
+$endif$
+}
+.hanging div.csl-entry {
+  margin-left:2em;
+  text-indent:-2em;
+}
+div.csl-left-margin {
+  min-width:2em;
+  float:left;
+}
+div.csl-right-inline {
+  margin-left:2em;
+  padding-left:1em;
+}
+div.csl-indent {
+  margin-left: 2em;
+}
+</style>
+$endif$
+
 $for(css)$
 <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
 $endfor$


### PR DESCRIPTION
Tihs will fix #1959 

`csl-css` variable is only [set internaly by pandoc](https://github.com/jgm/pandoc/blob/2f110265ff4a1dc429d58e7401d68968e42b6db1/src/Text/Pandoc/Writers/HTML.hs#L325) since 2.11. With previous versions, it won't be activated and no css will be added. 

See https://github.com/jgm/pandoc/commit/e0984a43a99231e72c02a0a716c8d0315de9abdf#diff-5ebecb3b5b6a7d7d0144b84e18ff6cebe24a00aa77a3b266a96f5f8924f9766bR124 for changes in Pandoc regarding this. 