### PR TITLE
Revert change about formatting for Pandoc headerless simple table

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -602,7 +602,7 @@ $endif$
 
 // add bootstrap table styles to pandoc tables
 function bootstrapStylePandocTables() {
-  $$('tr.odd').parent('tbody').parent('table').addClass('table table-condensed');
+  $$('tr.header').parent('thead').parent('table').addClass('table table-condensed');
 }
 $$(document).ready(function () {
   bootstrapStylePandocTables();


### PR DESCRIPTION
Close #1954 by revertgin the change in #1895 for #1894
This reverts commit e1aebefffcc89d0f71b74805ee7f7aeb7f89a620

Should we found another JS solution for #1894 or just document in NEWS.md that one could use 
````md
```{js, echo=FALSE}
$('table').addClass('table table-condensed'); 
```
````
to get the correct formatting for headerless table ? 