### PR TITLE
Specify that `htmltools::htmlPreserve()` should use the pandoc raw attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ rmarkdown 2.6
 
 - Fix `pandoc_convert(citeproc = TRUE)` not supressing the `--natbib` or `--biblatex` options (thanks, @atusy, #1932).
 
+- Specify that `htmltools::htmlPreserve()` should use the pandoc raw attribute 
+  rather than preservation tokens when pandoc >= v2.0. Note that this option will
+  have the intended effect only for versions of htmltools >= 0.5.0.9003.
+
 
 rmarkdown 2.5
 ================================================================================

--- a/R/render.R
+++ b/R/render.R
@@ -585,6 +585,18 @@ render <- function(input,
     templates <- knitr::opts_template$get()
     on.exit(knitr::opts_template$restore(templates), add = TRUE)
 
+    # specify that htmltools::htmlPreserve should use the pandoc raw
+    # attribute (e.g. ```{=html}) rather than preservation tokens when
+    # pandoc >= v2.0. Note that this option will have the intended effect
+    # only for versions of htmltools >= 0.5.0.9003.
+    if (pandoc2.0()) {
+      prev <- getOption("htmltools.preserve.raw", default = NA)
+      options(htmltools.preserve.raw = TRUE)
+      if (!is.na(prev)) {
+        on.exit(options(htmltools.preserve.raw = prev), add = TRUE)
+      }
+    }
+
     # run render on_exit (run after the knit hooks are saved so that
     # any hook restoration can take precedence)
     if (is.function(output_format$on_exit))

--- a/tests/testthat/test-notebook.R
+++ b/tests/testthat/test-notebook.R
@@ -107,6 +107,10 @@ test_that("a custom output_source can be used on render", {
 })
 
 test_that("UFT8 character in html widget does not break notebook annotation", {
+
+  # as of htmltools v0.5.0.9003 we no longer use token based htmlPreserve
+  skip_if(packageVersion("htmltools") >= "0.5.0.9003")
+
   # from issue in https://github.com/rstudio/rmarkdown/issues/1762
   # simulate html widget code
   html_dependency_dummy <- function()  {


### PR DESCRIPTION
Rather than using preservation tokens (only when pandoc >= v2.0, which is required for the raw attribute)

Note that this option will have the intended effect only for versions of htmltools >= 0.5.0.9003.

This causes 1 test to fail b/c it's testing for htmlPreserve output that no longer conforms. The test will pass/fail depending on which version of htmltools is installed, so we may want to make it conditional.

cc @jcheng5 @cpsievert 