### PR TITLE
handle new prefix in fontawesome 5

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -141,7 +141,7 @@ navbar_icon_dependencies <- function(navbar) {
   source <- read_utf8(navbar)
 
   # find icon references
-  res <- regexec('<(span|i) +class *= *("|\') *(fa fa|ion ion)-', source)
+  res <- regexec('<(span|i) +class *= *("|\') *(fa\\w fa|ion ion)-', source)
   matches <- regmatches(source, res)
   libs <- c()
   for (match in matches) {
@@ -151,7 +151,9 @@ navbar_icon_dependencies <- function(navbar) {
   libs <- unique(libs)
 
   # return their dependencies
-  html_dependencies_fonts("fa fa" %in% libs, "ion ion" %in% libs)
+  any_fa <- any(grepl("fa\\w fa", libs))
+  any_ion <- any(grepl("ion ion", libs))
+  html_dependencies_fonts(any_fa, any_ion)
 }
 
 # utility function to return a list of font dependencies based

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -646,7 +646,18 @@ navbar_link_text <- function(x, ...) {
       iconset <- split[[1]][[1]]
     else
       iconset <- ""
-    tagList(tags$span(class = paste(iconset, x$icon)), " ", x$text, ...)
+    # check if a full class is passed for fontawesome
+    # use default 'fas' otherwise
+    # https://github.com/rstudio/rmarkdown/issues/1554
+    class = if (grepl("^fa\\w fa", iconset)) {
+      x$icon
+    } else if (iconset == "fa") {
+      paste("fas", x$icon)
+    } else {
+      # should be other than FontAwesome
+      paste(iconset, x$icon)
+    }
+    tagList(tags$span(class = class), " ", x$text, ...)
   }
   else
     tagList(x$text, ...)


### PR DESCRIPTION
This will fix #1554

Following fontawesome update to V5 in #1340, there was some missing changes for Rmarkdown website, for which icon can be set in navbar using `icon: `

With this change, I believe it will not break current behavior as 
* Ionicons can still be used (we have a very old version but it is still working) and class will be `ion ion-...`
* Fontawesome icons can be passed as before `fa-home`. in that case `fas` prefix will be added - the new default one.
* Fontawesome icons can also be passed as full name like `fab fa-r-project`. In that case, the full name will be used as class for the span. 

I have chosen to not be specific on the prefix using `fa\\w`, but we could only check for supported prefix `fa(b|s|r|l|d)` instead.

This is a quick fix without rethinking the all logic for icons. 

I did not find any documentation in the package. 

Maybe I should update https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html ? 