### PR TITLE
Default anchor_sections to FALSE and document how to change content.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ rmarkdown 2.6
   rather than preservation tokens when pandoc >= v2.0. Note that this option will
   have the intended effect only for versions of htmltools >= 0.5.0.9003.
 
-- `anchor_sections` in `html_documents()` now default to `FALSE`. It was introduced in previous version with a default to `TRUE` but it is reverted now after hearing feedbacks from the community. (Thank you!). The `#` is still used as the character for the anchor but you can easily change that using css rule. Examples have been added in `?html_document`. 
+- `anchor_sections` in `html_documents()` now defaults to `FALSE`. It was introduced in previous version with a default to `TRUE`, but it is reverted now after hearing feedbacks from the community (thank you!). The `#` is still used as the character for the anchor but you can easily change that using CSS rules. Examples have been added to the help page `?html_document`.
 
 rmarkdown 2.5
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,13 +15,14 @@ rmarkdown 2.6
   rather than preservation tokens when pandoc >= v2.0. Note that this option will
   have the intended effect only for versions of htmltools >= 0.5.0.9003.
 
+- `anchor_sections` in `html_documents()` now default to `FALSE`. It was introduced in previous version with a default to `TRUE` but it is reverted now after hearing feedbacks from the community. (Thank you!). The `#` is still used as the character for the anchor but you can easily change that using css rule. Examples have been added in `?html_document`. 
 
 rmarkdown 2.5
 ================================================================================
 
 - Tables without header rows (wich can be possible in Pandoc's [simple table](https://pandoc.org/MANUAL.html#extension-simple_tables)) are now formatted correctly when using `html_document()` format (thanks, @fkohrt, #1893).
 
-- `html_document` gains the `anchor_sections` argument, which is `TRUE` by default, so that readers can get links to section headers easily---when you mouse over a section header, you will see a hash symbol `#` at the end of the header, which contains the anchor link to this header. You can click on this link and get the URL in the addres bar of your web browser, or right-click on it and copy the URL from the context menu. The hash symbol is defined by the CSS rule `a.anchor-section::before {content: '#';}`. You can customize it by overriding this rule (e.g., via the `css` argument of `html_document`) and use any other symbols or icons, e.g., `content: "\02AD8;"` (thanks, @atusy, #1884).
+- `html_document()` gains the `anchor_sections` argument, which is `TRUE` by default, so that readers can get links to section headers easily---when you mouse over a section header, you will see a hash symbol `#` at the end of the header, which contains the anchor link to this header. You can click on this link and get the URL in the addres bar of your web browser, or right-click on it and copy the URL from the context menu. The hash symbol is defined by the CSS rule `a.anchor-section::before {content: '#';}`. You can customize it by overriding this rule (e.g., via the `css` argument of `html_document`) and use any other symbols or icons, e.g., `content: "\02AD8;"` (thanks, @atusy, #1884).
 
 - `pkg_file_lua()` should have thrown an error if the expected Lua file does not exist.
 

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -86,11 +86,23 @@
 #'  document. For example, to add a \href{https://codepoints.net/U+1F517}{link
 #'  symbol} \if{html}{\out{(&#x1F517;&#xFE0E;)}} instead:
 #'  \preformatted{
-#'    a.anchor-section::before {
-#'      content: '\\01F517\\00FE0E';
+#'  a.anchor-section::before {
+#'    content: '\\01F517\\00FE0E';
 #'  }}
 #'  You can remove \samp{\\00FE0E} to get a more complex link pictogram
 #'  \if{html}{\out{(&#x1F517;)}}.
+#'
+#'  If you prefer an svg icon, you can also use one using for example a direct link or downloading it from
+#'  \url{https://material.io/resources/icons/}.
+#'  \preformatted{
+#'  /* From https://material.io/resources/icons/
+#'     Licence: https://www.apache.org/licenses/LICENSE-2.0.html */
+#'  a.anchor-section::before {
+#'    content: url(https://fonts.gstatic.com/s/i/materialicons/link/v7/24px.svg);
+#'  }}
+#'
+#'  About how to apply custom CSS, see
+#'  \url{https://bookdown.org/yihui/rmarkdown-cookbook/html-css.html}
 #'
 #'@section Navigation Bars:
 #'

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -22,7 +22,8 @@
 #'  options that control the behavior of the floating table of contents. See the
 #'  \emph{Floating Table of Contents} section below for details.
 #'@param number_sections \code{TRUE} to number section headings
-#'@param anchor_sections \code{TRUE} to show section anchors when mouse hovers
+#'@param anchor_sections \code{TRUE} to show section anchors when mouse hovers.
+#'  See \link[rmarkdown:html_document]{Anchor Sections Customization section}.
 #'@param fig_width Default width (in inches) for figures
 #'@param fig_height Default height (in inches) for figures
 #'@param fig_retina Scaling to perform for retina displays (defaults to 2, which
@@ -78,6 +79,19 @@
 #'@param extra_dependencies,... Additional function arguments to pass to the
 #'  base R Markdown HTML output formatter \code{\link{html_document_base}}
 #'@return R Markdown output format to pass to \code{\link{render}}
+#'
+#'@section Anchor Sections Customization:
+#'  By default, a \samp{#} is used as a minimalist choice, referring to the id selector
+#'  in HTML and CSS. You can easily change that using a css rule in your
+#'  document. For example, to add a \href{https://codepoints.net/U+1F517}{link
+#'  symbol} \if{html}{\out{(&#x1F517;&#xFE0E;)}} instead:
+#'  \preformatted{
+#'    a.anchor-section::before {
+#'      content: '\\01F517\\00FE0E';
+#'  }}
+#'  You can remove \samp{\\00FE0E} to get a more complex link pictogram
+#'  \if{html}{\out{(&#x1F517;)}}.
+#'
 #'@section Navigation Bars:
 #'
 #'  If you have a set of html documents which you'd like to provide a common
@@ -180,7 +194,7 @@ html_document <- function(toc = FALSE,
                           toc_depth = 3,
                           toc_float = FALSE,
                           number_sections = FALSE,
-                          anchor_sections = TRUE,
+                          anchor_sections = FALSE,
                           section_divs = TRUE,
                           fig_width = 7,
                           fig_height = 5,

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -162,11 +162,23 @@ and Citations} article in the online documentation.
  document. For example, to add a \href{https://codepoints.net/U+1F517}{link
  symbol} \if{html}{\out{(&#x1F517;&#xFE0E;)}} instead:
  \preformatted{
-   a.anchor-section::before {
-     content: '\\01F517\\00FE0E';
+ a.anchor-section::before {
+   content: '\\01F517\\00FE0E';
  }}
  You can remove \samp{\\00FE0E} to get a more complex link pictogram
  \if{html}{\out{(&#x1F517;)}}.
+
+ If you prefer an svg icon, you can also use one using for example a direct link or downloading it from
+ \url{https://material.io/resources/icons/}.
+ \preformatted{
+ /* From https://material.io/resources/icons/
+    Licence: https://www.apache.org/licenses/LICENSE-2.0.html */
+ a.anchor-section::before {
+   content: url(https://fonts.gstatic.com/s/i/materialicons/link/v7/24px.svg);
+ }}
+
+ About how to apply custom CSS, see
+ \url{https://bookdown.org/yihui/rmarkdown-cookbook/html-css.html}
 }
 
 \section{Navigation Bars}{

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -9,7 +9,7 @@ html_document(
   toc_depth = 3,
   toc_float = FALSE,
   number_sections = FALSE,
-  anchor_sections = TRUE,
+  anchor_sections = FALSE,
   section_divs = TRUE,
   fig_width = 7,
   fig_height = 5,
@@ -46,7 +46,8 @@ options that control the behavior of the floating table of contents. See the
 
 \item{number_sections}{\code{TRUE} to number section headings}
 
-\item{anchor_sections}{\code{TRUE} to show section anchors when mouse hovers}
+\item{anchor_sections}{\code{TRUE} to show section anchors when mouse hovers.
+See \link[rmarkdown:html_document]{Anchor Sections Customization section}.}
 
 \item{section_divs}{Wrap sections in <div> tags, and attach identifiers to the
 enclosing <div> rather than the header itself.}
@@ -154,6 +155,20 @@ the markdown syntax for citations in the
 \href{https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html}{Bibliographies
 and Citations} article in the online documentation.
 }
+\section{Anchor Sections Customization}{
+
+ By default, a \samp{#} is used as a minimalist choice, referring to the id selector
+ in HTML and CSS. You can easily change that using a css rule in your
+ document. For example, to add a \href{https://codepoints.net/U+1F517}{link
+ symbol} \if{html}{\out{(&#x1F517;&#xFE0E;)}} instead:
+ \preformatted{
+   a.anchor-section::before {
+     content: '\\01F517\\00FE0E';
+ }}
+ You can remove \samp{\\00FE0E} to get a more complex link pictogram
+ \if{html}{\out{(&#x1F517;)}}.
+}
+
 \section{Navigation Bars}{
 
 


### PR DESCRIPTION
@yihui as discussed, here is the PR for the upcoming patch release. 

I cherry picked the relevant commit in #1964 to only set `anchor_sections` to FALSE by default, and document better how to customize.

This will be enough for now and we'll then can merge #1964 once finished in a new feature release, after the next CRAN release.

it will close #1946 better as #1964 is rather adding feature. 