### PR TITLE
Use Pandoc's default for --email-obfuscation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,15 @@ rmarkdown 2.6
 
 - `anchor_sections` in `html_documents()` now defaults to `FALSE`. It was introduced in previous version with a default to `TRUE`, but it is reverted now after hearing feedbacks from the community (thank you!). The `#` is still used as the character for the anchor but you can easily change that using CSS rules. Examples have been added to the help page `?html_document`.
 
+- Using Pandoc's default for `--email-obfuscation` now. Previously, it was set to `none` explicitly, which is the default for Pandoc 1.17.2+ anyway. Only users with a Pandoc version before 1.17.2 may see a change in the content of the html source file produced if the document contains email addresses. This change allows to pass the Pandoc's command line flag if you want to set it to another value  (thanks,@seankross, #1969). 
+
+  ````yaml
+  output:
+    html_document: 
+      pandoc_args: ["--email-obfuscation", "javascript"]
+  ````
+
+  See [Pandoc's manual](https://pandoc.org/MANUAL.html#option--email-obfuscation) for the meaning of this option. 
 
 rmarkdown 2.5
 ================================================================================

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -72,7 +72,6 @@ github_document <- function(toc = FALSE,
         "--template", pkg_file_arg(
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
-        "--email-obfuscation", "none", # no email obfuscation
         if (pandoc2) c("--metadata", "pagetitle=PREVIEW")  # HTML5 requirement
       )
 

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -72,10 +72,8 @@ github_document <- function(toc = FALSE,
         "--template", pkg_file_arg(
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
-        # no email obfuscation
-        if (!pandoc_available("1.17.2")) c("--email-obfuscation", "none"),
-        # HTML5 requirement
-        if (pandoc2) c("--metadata", "pagetitle=PREVIEW")
+        "--email-obfuscation", "none", # no email obfuscation
+        if (pandoc2) c("--metadata", "pagetitle=PREVIEW")  # HTML5 requirement
       )
 
       # run pandoc

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -72,8 +72,10 @@ github_document <- function(toc = FALSE,
         "--template", pkg_file_arg(
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
-        "--email-obfuscation", "none", # no email obfuscation
-        if (pandoc2) c("--metadata", "pagetitle=PREVIEW")  # HTML5 requirement
+        # no email obfuscation
+        if (!pandoc_available("1.17.2")) c("--email-obfuscation", "none"),
+        # HTML5 requirement
+        if (pandoc2) c("--metadata", "pagetitle=PREVIEW")
       )
 
       # run pandoc

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -34,9 +34,6 @@ html_document_base <- function(theme = NULL,
 
   args <- c()
 
-  # no email obfuscation
-  args <- c(args, "--email-obfuscation", "none")
-
   # self contained document
   if (self_contained) {
     if (copy_resources)

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -34,8 +34,10 @@ html_document_base <- function(theme = NULL,
 
   args <- c()
 
-  # no email obfuscation
-  args <- c(args, "--email-obfuscation", "none")
+  # no email obfuscation - the default for Pandoc 1.17.2+
+  if (!pandoc_available("1.17.2")) {
+    args <- c(args, "--email-obfuscation", "none")
+  }
 
   # self contained document
   if (self_contained) {

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -34,10 +34,8 @@ html_document_base <- function(theme = NULL,
 
   args <- c()
 
-  # no email obfuscation - the default for Pandoc 1.17.2+
-  if (!pandoc_available("1.17.2")) {
-    args <- c(args, "--email-obfuscation", "none")
-  }
+  # no email obfuscation
+  args <- c(args, "--email-obfuscation", "none")
 
   # self contained document
   if (self_contained) {

--- a/tests/testthat/test-html_document_base.R
+++ b/tests/testthat/test-html_document_base.R
@@ -1,5 +1,4 @@
 test_that("default email obfuscation parameter is used", {
   skip_if_not(pandoc_available("1.17.2"))
-  args <- html_document_base()$pandoc$args
-  expect_false("--email-obfuscation" %in% args)
+  expect_false("--email-obfuscation" %in% html_document_base()$pandoc$args)
 })

--- a/tests/testthat/test-html_document_base.R
+++ b/tests/testthat/test-html_document_base.R
@@ -1,4 +1,0 @@
-test_that("default email obfuscation parameter is used", {
-  skip_if_not(pandoc_available("1.17.2"))
-  expect_false("--email-obfuscation" %in% html_document_base()$pandoc$args)
-})

--- a/tests/testthat/test-html_document_base.R
+++ b/tests/testthat/test-html_document_base.R
@@ -1,0 +1,5 @@
+test_that("default email obfuscation parameter is used", {
+  skip_if_not(pandoc_available("1.17.2"))
+  args <- html_document_base()$pandoc$args
+  expect_false("--email-obfuscation" %in% args)
+})


### PR DESCRIPTION
closes #1969 

Currently, `--email-obfuscation none` is set by `html_document_base()` for Pandoc. However, it can take different value and not only `none`

This is not needed per-se because this works already as last command line flag in Pandoc overwrites previous ones.
```r
  html_document: 
    pandoc_args: ["--email-obfuscation", "javascript"]
```

But it will be cleaner to not have `--email-obfuscation none` as it is the default for Pandoc 1.17.2+

@yihui if you're ok, we could add that for next patch release with no harm

Also, just added a small test to keep the habit of having a good test coverage.