### PR TITLE
use GHA runner's temp directory as R temp dir

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,6 +33,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      TMPDIR: ${{ runner.temp }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,7 +33,6 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      TMPDIR: ${{ runner.temp }}
 
     steps:
       - uses: actions/checkout@v2
@@ -106,6 +105,7 @@ jobs:
         env:
           _R_CHECK_CRAN_INCOMING_: false
           _R_CHECK_TESTS_NLINES_: 0
+          TMPDIR: ${{ runner.temp }}
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -75,16 +75,6 @@ test_that(
 
 test_that("pdf_document can correctly keep tex file if required", {
   rmd_file <- "test-formats.Rmd"
-  # Input in current dir
-  output_file <- tempfile()
-  texfile <- xfun::with_ext(basename(output_file), "tex")
-  render(test_path(rmd_file), pdf_document(keep_tex = FALSE),
-         output_file = output_file, quiet = TRUE)
-  expect_false(file.exists(file.path(dirname(output_file), texfile)))
-  render(test_path(rmd_file), pdf_document(keep_tex = TRUE),
-         output_file = output_file, quiet = TRUE)
-  expect_true(file.exists(file.path(dirname(output_file), texfile)))
-  unlink(c(texfile, output_file))
   # input in another dir
   dir.create(tmpdir <- tempfile())
   file.copy(test_path(rmd_file), tmpdir)

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -3,7 +3,7 @@ context("formats")
 test_that("formats successfully produce a document", {
 
   testFormat <- function(output_format, df_print = NULL) {
-    output_file <- I(basename(tempfile(tmpdir = '.')))
+    output_file <- I(tempfile())
     render(test_path("test-formats.Rmd"),
            output_format = output_format,
            output_file = output_file,


### PR DESCRIPTION
This will fix the issue (https://github.com/rstudio/rmarkdown/commit/9635483451dc4f357b0fe220bf482c450d8dd42c#r44719348)  and all subsequent potential ones regarding the use of `tempfile()` on Windows and LaTeX rendering.

By changing the temp directory, we insure that there will be no space in the filename, so no short path created which makes latex failed to compile. (BTW I can now reproduce this issue locally with the ~ in filename) - not sure why it happens because it seems it should have been resolved (https://tug.org/pipermail/tex-live/2014-June/035507.html)

This will also avoid to deal with this issue directly in our test (like in https://github.com/rstudio/rmarkdown/commit/8cc31e5e48658cca2f590474cdc9ec783a72ac03)

I wonder if `r-lib/actions/setup-r` should consider setting the R temp directory to GHA $RUNNER_TEMP. It is already where the R library is set ([example](https://github.com/cderv/rmarkdown/runs/1499096453?check_suite_focus=true#step:8:10)) 🤔 