### PR TITLE
clean_site default to preview = TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,7 +101,8 @@ Suggests:
     vctrs,
     tibble,
     fs,
-    rsconnect
+    rsconnect,
+    withr (>= 2.3.0)
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org
 URL: https://github.com/rstudio/rmarkdown
 BugReports: https://github.com/rstudio/rmarkdown/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.6
 ================================================================================
 
-- `clean_site()` now default to `preview = TRUE` and will no more remove files without notice. This change will affect the 'Clean All' button in the 'Build' pane for website project. `clean_site(preview = FALSE)` must be run to effectively remove files.
+- `clean_site()` now default to `preview = TRUE` and will no more remove files without notice. This change will affect the "Clean All" button in the "Build" pane for website project. `clean_site(preview = FALSE)` must be run to effectively remove files (#1973).
 
 - The intermediate `.tex` file is now correctly deleted if `keep_tex = FALSE` when the R Markdown document is not rendered from the working directory (thanks, @vqv, #1308).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.6
 ================================================================================
 
+- `clean_site()` now default to `preview = TRUE` and will no more remove files without notice. This change will affect the 'Clean All' button in the 'Build' pane for website project. `clean_site(preview = FALSE)` must be run to effectively remove files.
+
 - The intermediate `.tex` file is now correctly deleted if `keep_tex = FALSE` when the R Markdown document is not rendered from the working directory (thanks, @vqv, #1308).
 
 - Fix a bug causing certain resources files to be deleted as intermediate files when `intermediates_dir` is the same as the input (thanks, @bellma-lilly, #1248). 

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -220,7 +220,6 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
   # get the files to be cleaned
   files <- generator$clean()
 
-  length(files) == 0
 
   if (length(files) == 0) {
     if (preview || !quiet) cat("Nothing to removed. All clean !\n")

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -245,8 +245,8 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
 
 # TODO: Move to xfun - bookdown use it too.
 mark_dirs <- function(files) {
-  i = file_test("-d", files) & !grepl("/$", files)
-  files[i] = paste0(files[i], "/")
+  i <- file_test("-d", files) & !grepl("/$", files)
+  files[i] <- paste0(files[i], "/")
   files
 }
 

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -230,13 +230,13 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
   # actually remove the files
   if (preview) {
     cat("These files and folders can probably be removed:\n",
-        paste0("* ", mark_dirs(files, input)),
+        paste0("* ", mark_dirs(files)),
         "\nUse `rmarkdown::clean_site(preview = FALSE)` to remove them.",
         sep = "\n")
   } else {
     if (!quiet) {
       cat("Removing files: \n",
-          paste0("* ", mark_dirs(files, input)),
+          paste0("* ", mark_dirs(files)),
           sep = "\n")
     }
     unlink(file.path(input, files), recursive = TRUE)
@@ -244,10 +244,7 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
 }
 
 # TODO: Move to xfun - bookdown use it too.
-mark_dirs <- function(files, dir) {
-  if (!missing(dir)) {
-    owd = setwd(dir); on.exit(setwd(owd))
-  }
+mark_dirs <- function(files) {
   i = file_test("-d", files) & !grepl("/$", files)
   files[i] = paste0(files[i], "/")
   files

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -222,15 +222,33 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
 
   # if it's just a preview then return the files, otherwise
   # actually remove the files
-  if (preview)
-    files
-  else {
+  if (preview) {
+    if (length(files) == 0) {
+      cat("Nothing to removed. All clean !\n")
+    } else {
+      cat("These files and folders can probably be removed:\n",
+          paste0("* ", mark_dirs(files, input)),
+          "\nUse `rmarkdown::clean_site(preview = FALSE)` to remove them.",
+          sep = "\n")
+    }
+  } else {
     if (!quiet) {
-      cat("Removing files: \n")
-      cat(paste0(" ", files), sep = "\n")
+      cat("Removing files: \n",
+          paste0("* ", mark_dirs(files, input)),
+          sep = "\n")
     }
     unlink(file.path(input, files), recursive = TRUE)
   }
+}
+
+# TODO: Move to xfun - bookdown use it too.
+mark_dirs <- function(files, dir) {
+  if (!missing(dir)) {
+    owd = setwd(dir); on.exit(setwd(owd))
+  }
+  i = file_test("-d", files) & !grepl("/$", files)
+  files[i] = paste0(files[i], "/")
+  files
 }
 
 #' @rdname render_site

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -220,17 +220,20 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
   # get the files to be cleaned
   files <- generator$clean()
 
+  length(files) == 0
+
+  if (length(files) == 0) {
+    if (preview || !quiet) cat("Nothing to removed. All clean !\n")
+    return(invisible(NULL))
+  }
+
   # if it's just a preview then return the files, otherwise
   # actually remove the files
   if (preview) {
-    if (length(files) == 0) {
-      cat("Nothing to removed. All clean !\n")
-    } else {
-      cat("These files and folders can probably be removed:\n",
-          paste0("* ", mark_dirs(files, input)),
-          "\nUse `rmarkdown::clean_site(preview = FALSE)` to remove them.",
-          sep = "\n")
-    }
+    cat("These files and folders can probably be removed:\n",
+        paste0("* ", mark_dirs(files, input)),
+        "\nUse `rmarkdown::clean_site(preview = FALSE)` to remove them.",
+        sep = "\n")
   } else {
     if (!quiet) {
       cat("Removing files: \n",

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -204,9 +204,9 @@ render_site <- function(input = ".",
 
 #' @rdname render_site
 #' @param preview Whether to list the files to be removed rather than actually
-#'   removing them.
+#'   removing them. Defaulting to TRUE to prevent removing without notice.
 #' @export
-clean_site <- function(input = ".", preview = FALSE, quiet = FALSE,
+clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
                        encoding = "UTF-8") {
 
   # normalize to a directory

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -231,7 +231,7 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
   if (preview) {
     cat("These files and folders can probably be removed:\n",
         paste0("* ", mark_dirs(files)),
-        "\nUse `rmarkdown::clean_site(preview = FALSE)` to remove them.",
+        "\nUse rmarkdown::clean_site(preview = FALSE) to remove them.",
         sep = "\n")
   } else {
     if (!quiet) {

--- a/R/util.R
+++ b/R/util.R
@@ -155,6 +155,7 @@ clean_tmpfiles <- function() {
   ))
 }
 
+# test if all paths in x are directories
 dir_exists <- function(x) {
   length(x) > 0 && utils::file_test('-d', x)
 }

--- a/man/render_site.Rd
+++ b/man/render_site.Rd
@@ -16,7 +16,7 @@ render_site(
   encoding = "UTF-8"
 )
 
-clean_site(input = ".", preview = FALSE, quiet = FALSE, encoding = "UTF-8")
+clean_site(input = ".", preview = TRUE, quiet = FALSE, encoding = "UTF-8")
 
 site_generator(input = ".", output_format = NULL)
 
@@ -38,7 +38,7 @@ environment).}
 \item{encoding}{Ignored. The encoding is always assumed to be UTF-8.}
 
 \item{preview}{Whether to list the files to be removed rather than actually
-removing them.}
+removing them. Defaulting to TRUE to prevent removing without notice.}
 
 \item{...}{Currently unused.}
 }

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -77,4 +77,5 @@ test_that("clean_site gives notices before removing", {
   expect_output(clean_site(), "removed.*_site")
   expect_true(dir.exists("_site"))
   expect_silent(clean_site(preview = FALSE, quiet = TRUE))
+  expect_output(clean_site(preview = FALSE, quiet = FALSE), "Nothing")
 })

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -69,3 +69,12 @@ test_that("render_site respects 'new_session' in the config", {
   expect_match(a, "library(stringr)", fixed = TRUE, all = FALSE)
   expect_false(any(grepl("stringr", b, fixed = TRUE)))
 })
+
+test_that("clean_site gives notices before removing", {
+  site_dir <- local_create_site()
+  render_site(site_dir, quiet = TRUE)
+  withr::local_dir(site_dir)
+  expect_output(clean_site(), "removed.*_site")
+  expect_true(dir.exists("_site"))
+  expect_silent(clean_site(preview = FALSE, quiet = TRUE))
+})

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -1,14 +1,22 @@
 context("site")
 
+# copy part of our demo site to a tempdir
+local_create_site <- function(files, env = parent.frame()) {
+  site_dir <- tempfile()
+  dir.create(site_dir, recursive = TRUE)
+  withr::defer(unlink(site_dir, recursive = TRUE), envir = env)
+  # by default copy all files
+  if (missing(files)) files <- c("_site.yml", "index.Rmd", "PageA.Rmd",
+                        "PageB.rmd", "PageC.md", "PageD.R", "styles.css",
+                        "script.R", "docs.txt")
+  file.copy(test_path("site", files), site_dir, recursive = TRUE)
+  site_dir
+}
+
 test_that("render_site", {
 
   # copy our demo site to a tempdir
-  site_dir <- tempfile()
-  dir.create(site_dir)
-  files <- c("_site.yml", "index.Rmd", "PageA.Rmd",
-             "PageB.rmd", "PageC.md", "PageD.R", "styles.css",
-             "script.R", "docs.txt")
-  file.copy(file.path("site", files), site_dir, recursive = TRUE)
+  site_dir <- local_create_site()
 
   # render it
   capture.output(render_site(site_dir))
@@ -38,10 +46,8 @@ test_that("render_site respects 'new_session' in the config", {
   skip_if_not_installed("xfun", "0.13")
 
   # copy parts of our demo site to a tempdir
-  site_dir <- tempfile()
-  dir.create(site_dir)
   files <- c("_site.yml", "index.Rmd", "PageA.Rmd", "PageB.rmd", "PageD.R")
-  file.copy(file.path("site", files), site_dir, recursive = TRUE)
+  site_dir <- local_create_site(files)
 
   # default behaviour --> new_session: false
   render_site(site_dir, quiet = TRUE)


### PR DESCRIPTION
This will close #1971 

* `preview = TRUE` by default now - this will affect the behavior of Clean All button in website project Build pane
* A message is output to console to inform about the file that could be removed. 
* `clean_site(preview = FALSE)` will effectively remove those files
* Nothing is done if no file returned by the generator clean function
* if `quiet = FALSE` and `preview = FALSE`, a message is also output to console - useful for knowing what happens in the Build pane

I also 

* refactored tests and add some for better coverage. 
    * Added **withr** as Suggests because it is really useful for clean test helper.
* adapted `mark_dirs` from **bookdown** - will do a PR in **xfun**

One question remaining: 

* Should `clean_site()` check for existence of the files and directories mentioned in message ? 
* Or should the `generator$clean()` function only return filepath that exists ? 

I think the latter would be best but currently it does not - for example **blogdown**: 
```r
==> rmarkdown::clean_site()

These files and folders can probably be removed:

* blogdown
* public/
* content/_index.markdown
* content/post/2015-07-23-r-rmarkdown/index.html
* static/rmarkdown-libs

Use `rmarkdown::clean_site(preview = FALSE)` to remove them.
```

`blogdown` folder does not exist, `static/rmarkdown-libs` neither (because page bundle I think). I find it puzzling that it is output in the message

What do you think ? 

