### PR TITLE
Insure UTF-8 for the result of tools::vignetteInfo()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.6
 ================================================================================
 
+- Encoding is correctly handled now in `html_vignette` when checking for identical title and vignette index entry (thanks, @py-b, #1978).
+
 - `clean_site()` now default to `preview = TRUE` and will no more remove files without notice. This change will affect the "Clean All" button in the "Build" pane for website project. `clean_site(preview = FALSE)` must be run to effectively remove files (#1973).
 
 - The intermediate `.tex` file is now correctly deleted if `keep_tex = FALSE` when the R Markdown document is not rendered from the working directory (thanks, @vqv, #1308).

--- a/R/html_vignette.R
+++ b/R/html_vignette.R
@@ -84,6 +84,10 @@ vignette_pre_processor <- function(input_file, metadata = yaml_front_matter(inpu
     return()
   title1 <- metadata[['title']]
   title2 <- tools::vignetteInfo(input_file)[['title']]
+  # rmarkdown assumes UTF-8 only - tools::vignetteInfo uses readLines with
+  # default OS encoding so issue on Windows for example
+  # https://github.com/rstudio/rmarkdown/issues/1978
+  Encoding(title2) <- "UTF-8"
   if (!identical(title1, title2)) warning(
     'The vignette title specified in \\VignetteIndexEntry{} is different from ',
     'the title in the YAML metadata. The former is "', title2, '", and the ',

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -1,7 +1,8 @@
 context("html_vignette format")
 
 .generate_temp_vignette <- function(title = NULL,
-                                    indexentry = NULL) {
+                                    indexentry = NULL,
+                                    envir = parent.frame()) {
   tmp_rmd <- tempfile("vignette-", fileext = ".Rmd")
   xfun::write_utf8(
     c("---",
@@ -16,13 +17,13 @@ context("html_vignette format")
       "---",
       "\n# This is a vignette"),
     tmp_rmd)
+  withr::defer(unlink(tmp_rmd), envir = envir)
   tmp_rmd
 }
 
 # https://github.com/rstudio/rmarkdown/pull/1789#issuecomment-616908700
 test_that("vignette_pre_processor warns against differences in vignette index entry and title", {
-  opts <- options(rmarkdown.html_vignette.check_title = TRUE)
-  on.exit(options(opts), add = TRUE)
+  withr::local_options(list(rmarkdown.html_vignette.check_title = TRUE))
   input_file <- .generate_temp_vignette('document title', 'vignette title')
   # only warns for R 3.6 and later
   if (getRversion() >= 3.6) {
@@ -30,5 +31,10 @@ test_that("vignette_pre_processor warns against differences in vignette index en
   } else {
     expect_null(vignette_pre_processor(input_file))
   }
-  unlink(input_file)
+})
+
+test_that("vignette_pre_processor correctly handles encoding", {
+  withr::local_options(list(rmarkdown.html_vignette.check_title = TRUE))
+  input_file <- .generate_temp_vignette('Données', 'Données')
+  expect_null(vignette_pre_processor(input_file))
 })

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -33,6 +33,7 @@ test_that("vignette_pre_processor warns against differences in vignette index en
   }
 })
 
+# https://github.com/rstudio/rmarkdown/issues/1978
 test_that("vignette_pre_processor correctly handles encoding", {
   withr::local_options(list(rmarkdown.html_vignette.check_title = TRUE))
   input_file <- .generate_temp_vignette('Données', 'Données')


### PR DESCRIPTION
This will fix #1978 

`tools::vignetteInfo()` uses `readLines` with default `encoding`. On Windows, it does not default to UTF-8. That means the vignette index entry from a UTF-8 `.Rmd` file won't be correctly imported. 

As **rmarkdown** assumes UTF-8 for all input, we can insure that the result of `tools::vignetteInfo` is UTF-8

@yihui do you think this is the best way to go ? 

Other way would be to parse ourself the vignette index entry after reading the Rmd file using `xunf::read_utf8`. 

