### PR TITLE
Improvements to latex-div

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.6.0001
+Version: 2.6.0002
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.7
 
 - Fix an issue with line numbering in code chunks when `.numberlines` with Pandoc's highlighting (thanks, @aosavi, #1876)
 
+- Accept `latex="{options}"`, `latex=1`, or `latex=true` for Latex Divs.
+
 rmarkdown 2.6
 ================================================================================
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -5,28 +5,40 @@
 --]]
 
 Div = function (div)
-  local options = div.attributes['data-latex']
-  if options == nil then return nil end
+  -- look for 'latex' or 'data-latex' and at least 1 class
+  local options = div.attributes['latex']
+  if not options then
+    options = div.attributes['data-latex']
+  end
+  if not options or #div.attr.classes == 0 then
+    return nil
+  end
 
-  -- if the output format is not latex, remove the data-latex attr and return
+  -- if the output format is not latex, remove the attr and return
   if FORMAT ~= 'latex' and FORMAT ~= 'beamer' then
+    div.attributes['latex'] = nil
     div.attributes['data-latex'] = nil
     return div
   end
 
-  local env = div.classes[1]
-  -- if the div has no class, the object is left unchanged
-  if not env then return nil end
+  -- if it's "1" or "true" then just set it to empty string
+  if options == "1" or options == "true" then
+    options = ""
+  end
 
-  -- insert raw latex before content
-  table.insert(
-    div.content, 1,
-    pandoc.RawBlock('tex', '\\begin' .. '{' .. env .. '}' .. options)
-  )
-  -- insert raw latex after content
-  table.insert(
-    div.content,
-    pandoc.RawBlock('tex', '\\end{' .. env .. '}')
-  )
+  -- environment begin/end
+  local env = div.classes[1]
+  local beginEnv = '\\begin' .. '{' .. env .. '}' .. options
+  local endEnv = '\n\\end{' .. env .. '}'
+
+  -- if the first and last div blocks are paragraphs then we can
+  -- bring the environment begin/end closer to the content
+  if div.content[1].t == "Para" and div.content[#div.content].t == "Para" then
+    table.insert(div.content[1].content, 1, pandoc.RawInline('tex', beginEnv .. "\n"))
+    table.insert(div.content[#div.content].content, pandoc.RawInline('tex', "\n" .. endEnv))
+  else
+    table.insert(div.content, 1, pandoc.RawBlock('tex', beginEnv))
+    table.insert(div.content, pandoc.RawBlock('tex', endEnv))
+  end
   return div
 end

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -4,6 +4,8 @@
      License: Public domain
 --]]
 
+text = require 'text'
+
 Div = function (div)
   -- look for 'latex' or 'data-latex' and at least 1 class
   local options = div.attributes['latex']
@@ -22,7 +24,7 @@ Div = function (div)
   end
 
   -- if it's "1" or "true" then just set it to empty string
-  if options == "1" or options == "true" then
+  if options == "1" or text.lower(options) == "true" then
     options = ""
   end
 


### PR DESCRIPTION
- Allow "latex" attribute (as alternative to "data-latex"). Note that the "data-" prefix is an HTML convention and Pandoc already automatically adds a "data-" prefix to HTML attributes it doesn't recognize. Net: for markdown syntax like this we don't need to use "data-" prefixes.

- Allow slightly more intuitive syntax for a latex div with no options: `latex=true` or `latex=1`

- If the leading and trailing blocks in the div are paragraphs than write the environment begin/end flush up to the block text (the extra lines added when inserting raw blocks can make a difference for some environment implementations)