### PR TITLE
Add `output_format_filter` function to `default_site_generator()`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.6.0002
+Version: 2.6.0003
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ rmarkdown 2.7
 
 - Accept `latex="{options}"`, `latex=1`, or `latex=true` for Latex Divs.
 
+- Add `output_format_filter` function to `default_site_generator()`. Enables custom site generators to customize or even entirely replace the output format right before rendering of each page.
+
+
 rmarkdown 2.6
 ================================================================================
 

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -337,9 +337,12 @@ site_config <- function(input = ".", encoding = "UTF-8") {
 # default site implementation (can be overridden by custom site generators)
 
 #' @rdname render_site
+#' @param output_format_filter An optional function which is passed the
+#'  input file and the output format, and which returns a (potentially
+#'  modified) output format.
 #' @param ... Currently unused.
 #' @export
-default_site_generator <- default_site <- function(input, ...) {
+default_site_generator <- default_site <- function(input, output_format_filter = NULL, ...) {
 
   # get the site config
   config <- site_config(input)
@@ -395,8 +398,14 @@ default_site_generator <- default_site <- function(input, ...) {
       # log the file being rendered
       if (!quiet) message("\nRendering: ", x)
 
+      # optionally customize the output format via filter
+      file_output_format <- output_format
+      if (!is.null(output_format_filter)) {
+        file_output_format <- output_format_filter(x, output_format)
+      }
+
       output <- render_one(input = x,
-                           output_format = output_format,
+                           output_format = file_output_format,
                            output_options = list(lib_dir = "site_libs",
                                                  self_contained = FALSE),
                            envir = envir,

--- a/man/render_site.Rd
+++ b/man/render_site.Rd
@@ -22,7 +22,7 @@ site_generator(input = ".", output_format = NULL)
 
 site_config(input = ".", encoding = "UTF-8")
 
-default_site_generator(input, ...)
+default_site_generator(input, output_format_filter = NULL, ...)
 }
 \arguments{
 \item{input}{Website directory (or the name of a file within the directory).}
@@ -39,6 +39,10 @@ environment).}
 
 \item{preview}{Whether to list the files to be removed rather than actually
 removing them. Defaulting to TRUE to prevent removing without notice.}
+
+\item{output_format_filter}{An optional function which is passed the
+input file and the output format, and which returns a (potentially
+modified) output format.}
 
 \item{...}{Currently unused.}
 }


### PR DESCRIPTION
Enables custom site generators to customize or even entirely replace the output format right before rendering of each page.

Motivation is to enable inclusion of pages generated w/ alternate output formats to Distill websites.
