### PR TITLE
Insure fontawesome V4 compatibility in navbar to avoid breaking change

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -141,7 +141,7 @@ navbar_icon_dependencies <- function(navbar) {
   source <- read_utf8(navbar)
 
   # find icon references
-  res <- regexec('<(span|i) +class *= *("|\') *(fa\\w fa|ion ion)-', source)
+  res <- regexec('<(span|i) +class *= *("|\') *(fa\\w? fa|ion ion)-', source)
   matches <- regmatches(source, res)
   libs <- c()
   for (match in matches) {
@@ -151,7 +151,7 @@ navbar_icon_dependencies <- function(navbar) {
   libs <- unique(libs)
 
   # return their dependencies
-  any_fa <- any(grepl("fa\\w fa", libs))
+  any_fa <- any(grepl("fa\\w? fa", libs))
   any_ion <- any(grepl("ion ion", libs))
   html_dependencies_fonts(any_fa, any_ion)
 }

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -672,15 +672,18 @@ navbar_link_text <- function(x, ...) {
       iconset <- split[[1]][[1]]
     else
       iconset <- ""
-    # check if a full class is passed for fontawesome
-    # use default 'fas' otherwise
+    # check if a full class is passed for fontawesome = V5
+    # Add fa deprecated fa prefix otherwise = V4 compatibility
     # https://github.com/rstudio/rmarkdown/issues/1554
-    class = if (grepl("^fa\\w fa", iconset)) {
+    class = if (grepl("^fa\\w? fa", iconset)) {
+      # Fontawesome 5 - full new prefix + name must be passed
+      # if old fa prefix is passed - keep it for compatibility
       x$icon
     } else if (iconset == "fa") {
-      paste("fas", x$icon)
+      # Fontawesome 4 compatibility - Add deprecated fa prefix
+      paste("fa", x$icon)
     } else {
-      # should be other than FontAwesome
+      # Other Icon sets
       paste(iconset, x$icon)
     }
     tagList(tags$span(class = class), " ", x$text, ...)


### PR DESCRIPTION
This aims to fix #1991. The issue is that `fas` is now the default prefix instead of deprecated `fa` prefix, so we used that in #1967. However, **rmarkdown** was previously taking care of adding `fa` prefix to icon in navbar.
And it was working because fontawesome as shims for V4 compatibility (in v4-shims.css). For example, this was working: 

```yaml
navbar;
  right:
  - icon: fa-github
    href: https://github.com/xxx/yyy
```
because `fa` was added leading to `fa fa-github` which is taking care of by the V4 shims compatibility layer. 
Our change would lead to add `fas` in this case, leading to `fas fa-github` which is wrong as it should be `fab fa-github`

As we don't really have a way to know if `fas` or `fab` should be added without parsing the list of icons, I think it is enough we no more add any prefix in icon in navbar for fontawesome 5. 

This means : 
 * prefix + name needs to be passed for fontawesome 5 icons, like for new brand icons `fab fa-r-project` (original issue in #1554) 
 * `fa-<iconname>` will always be prefixed with `fa` (`fa fa-<iconname>`) not `fas`. This will insure V4 compatibility. All the more because it seems that in V5, `fa` can still be used even if the default is `fas` now.
 * If for some reason some pass `fa fa-<iconname>` directly, don't duplicate the prefix and keep it that way. 

I think this should be good now.