### PR TITLE
exclude renv folder from render_site() copied resources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.6.0003
+Version: 2.6.4
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ rmarkdown 2.7
 
 - Add `output_format_filter` function to `default_site_generator()`. Enables custom site generators to customize or even entirely replace the output format right before rendering of each page.
 
+- Automatically ignore renv directory for render_site
 
 rmarkdown 2.6
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ rmarkdown 2.7
 
 - Add `output_format_filter` function to `default_site_generator()`. Enables custom site generators to customize or even entirely replace the output format right before rendering of each page.
 
-- Automatically ignore renv directory for render_site
+- Automatically exclude renv directory for `render_site()` (thanks, @jmbuhr, #1996)
 
 rmarkdown 2.6
 ================================================================================

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -30,7 +30,7 @@
 #'       \item{Files beginning with "_"}
 #'       \item{Files known to contain R source code (e.g. ".R", ".s", ".Rmd"), R
 #'       data (e.g. ".RData", ".rds"), or configuration data (e.g. ".Rproj",
-#'       "rsconnect")).}
+#'       "rsconnect", "renv")).}
 #'     }
 #'     Note that you can override which files are included or excluded via
 #'     settings in "_site.yml" (described below).}
@@ -584,7 +584,7 @@ site_resources <- function(site_dir, include = NULL, exclude = NULL, recursive =
   # excludes:
   #   - known source/data extensions
   #   - anything that starts w/ '.' or '_'
-  #   - rsconnect and packrat directories
+  #   - rsconnect, renv and packrat directories
   #   - user excludes
   extensions <- c("R", "r", "S", "s",
                   "Rmd", "rmd", "md", "Rmarkdown", "rmarkdown",

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -591,7 +591,7 @@ site_resources <- function(site_dir, include = NULL, exclude = NULL, recursive =
                   "Rproj", "rproj",
                   "RData", "rdata", "rds")
   extensions_regex <- utils::glob2rx(paste0("*.", extensions))
-  excludes <- c("^rsconnect$", "^packrat$", "^\\..*$", "^_.*$", "^.*_cache$",
+  excludes <- c("^rsconnect$", "^packrat$", "^renv$", "^\\..*$", "^_.*$", "^.*_cache$",
                 extensions_regex,
                 utils::glob2rx(exclude))
   files <- all_files

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -29,8 +29,9 @@
 #'       \item{Files beginning with "." (hidden files).}
 #'       \item{Files beginning with "_"}
 #'       \item{Files known to contain R source code (e.g. ".R", ".s", ".Rmd"), R
-#'       data (e.g. ".RData", ".rds"), or configuration data (e.g. ".Rproj",
-#'       "rsconnect", "renv")).}
+#'       data (e.g. ".RData", ".rds"), configuration data (e.g. ".Rproj",
+#'       "rsconnect") or package project management data (e.g.
+#'       "packrat", "renv").}
 #'     }
 #'     Note that you can override which files are included or excluded via
 #'     settings in "_site.yml" (described below).}

--- a/man/render_site.Rd
+++ b/man/render_site.Rd
@@ -84,8 +84,9 @@ rendered in the following fashion:
       \item{Files beginning with "." (hidden files).}
       \item{Files beginning with "_"}
       \item{Files known to contain R source code (e.g. ".R", ".s", ".Rmd"), R
-      data (e.g. ".RData", ".rds"), or configuration data (e.g. ".Rproj",
-      "rsconnect", "renv")).}
+      data (e.g. ".RData", ".rds"), configuration data (e.g. ".Rproj",
+      "rsconnect") or package project management data (e.g.
+      "packrat", "renv").}
     }
     Note that you can override which files are included or excluded via
     settings in "_site.yml" (described below).}

--- a/man/render_site.Rd
+++ b/man/render_site.Rd
@@ -85,7 +85,7 @@ rendered in the following fashion:
       \item{Files beginning with "_"}
       \item{Files known to contain R source code (e.g. ".R", ".s", ".Rmd"), R
       data (e.g. ".RData", ".rds"), or configuration data (e.g. ".Rproj",
-      "rsconnect")).}
+      "rsconnect", "renv")).}
     }
     Note that you can override which files are included or excluded via
     settings in "_site.yml" (described below).}


### PR DESCRIPTION
This makes sure it follows the same behavior as e.g. for `packrat` and `rsconnect`.