### PR TITLE
Cache should work on Windows with recent version of R

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,7 +69,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        if: runner.os != 'Windows'
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}


### PR DESCRIPTION
Which we use. 

With older version, we need to fix the PATH for using a non Rtools tar (https://github.com/r-lib/actions/issues/21)