### PR TITLE
use only the TinyTeX-1 version in CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: r-lib/actions/setup-tinytex@5f1c134
         env:
           # install full prebuilt version
-          TINYTEX_INSTALLER: TinyTeX
+          TINYTEX_INSTALLER: TinyTeX-1
 
       - name: Add some R options for later steps
         run: |


### PR DESCRIPTION
maybe a lighter binary will be less prone to errors to fix #1986 