### PR TITLE
Add support for number_offset metadata with number-sections.lua

### DIFF
--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -21,6 +21,13 @@ if FORMAT == "docx" then -- to be consistent with Pandoc >= 2.10.1
   separator = pandoc.Str("\t")
 end
 
+function Meta(meta)
+  if meta.number_offset then
+      section_number_table[1] = tonumber(
+        pandoc.utils.stringify(meta.number_offset)) - 1
+  end
+end
+
 function Header(elem)
   -- If unnumbered
   if (elem.classes:find("unnumbered")) then

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -22,9 +22,11 @@ if FORMAT == "docx" then -- to be consistent with Pandoc >= 2.10.1
 end
 
 function Meta(meta)
-  if meta.number_offset then
-      section_number_table[1] = tonumber(
-        pandoc.utils.stringify(meta.number_offset)) - 1
+  local offset = meta.number_offset
+  if offset then
+    section_number_table[1] = tonumber(
+        (type(offset) == "table") and (pandoc.utils.stringify(offset)) or offset
+      ) - 1
   end
 end
 
@@ -58,3 +60,8 @@ function Header(elem)
 
   return elem
 end
+
+return {
+  {Meta = Meta},
+  {Header = Header}
+}

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -27,14 +27,28 @@ test_that("pagebreak Lua filters works", {
 })
 
 test_that("number_sections Lua filter works", {
-  numbers <- c("1", "1.1", "2", "2.1")
-  headers <- c("#", "##", "#", "##")
-  rmd <- paste0(headers, " ", numbers, "\n\n")
-  result <- .generate_md_and_convert(rmd, md_document(number_sections = TRUE))
-  expected <- paste(numbers, numbers)
-  # pandoc 2.11.2 default to atx headers
-  if (pandoc_available("2.11.2")) expected <- paste(headers, expected)
-  expect_identical(result[result %in% expected], expected)
+  test_number_sections <- function(number_offset = 1L) {
+      numbers <- paste0(
+        c(0L, 0L, 1L, 1L) + number_offset,
+        c("", ".1", "", ".1")
+      )
+      headers <- c("#", "##", "#", "##")
+      result <- .generate_md_and_convert(
+        paste0(headers, " ", numbers, "\n\n"),
+        md_document(
+          number_sections = TRUE,
+          pandoc_args = if (number_offset > 1) {
+            sprintf("--metadata=number_offset:%s", number_offset)
+          }
+        )
+      )
+      expected <- paste(numbers, numbers)
+      # pandoc 2.11.2 default to atx headers
+      if (pandoc_available("2.11.2")) expected <- paste(headers, expected)
+      expect_identical(result[result %in% expected], expected)
+  }
+  test_number_sections(1L)
+  test_number_sections(2L)
 })
 
 test_that("formats have the expected Lua filter", {


### PR DESCRIPTION
`number-sections.lua` enables numbering sections for formats without it.
However, current implementation lacks the support for `--number-offset`.
Unfortunately, there is no way to tell Lua filter the value of `--number-offset`.
Thus, this PR reads `number-offset` metadata as an alternative.

Reprex:

```
---
output:
  md_document:
    pandoc_args:
      - "--lua-filter=inst/rmarkdown/lua/number-sections.lua"
number_offset: 3
---

# foo

```