### PR TITLE
Add tabsets in ToC (closes #1336)

### DIFF
--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -67,7 +67,7 @@ html_dependency_tocify <- function() {
     name = "tocify",
     version = "1.9.1",
     src = pkg_file("rmd/h/tocify"),
-    script = "jquery.tocify.js",
+    script = c("jquery.tocify.js", "tabset.tocify.js"),
     stylesheet = "jquery.tocify.css")
 }
 

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -232,6 +232,7 @@ html_document <- function(toc = FALSE,
 
   # build pandoc args
   args <- c("--standalone")
+  lua_filters <- character(0L)
 
   # use section divs
   if (section_divs)
@@ -266,6 +267,9 @@ html_document <- function(toc = FALSE,
 
     # flag for template
     args <- c(args, pandoc_variable_arg("toc_float", "1"))
+
+    # Lua filter
+    lua_filters <- c(lua_filters, pkg_file_lua("tocify-tabset.lua"))
 
     # selectors
     selectors <- paste0("h", seq(1, toc_depth), collapse = ",")
@@ -465,7 +469,8 @@ html_document <- function(toc = FALSE,
     knitr = knitr_options_html(fig_width, fig_height, fig_retina, keep_md, dev),
     pandoc = pandoc_options(to = "html",
                             from = from_rmarkdown(fig_caption, md_extensions),
-                            args = args),
+                            args = args,
+                            lua_filters = lua_filters),
     keep_md = keep_md,
     clean_supporting = self_contained,
     df_print = df_print,

--- a/inst/rmarkdown/lua/tocify-tabset.lua
+++ b/inst/rmarkdown/lua/tocify-tabset.lua
@@ -1,0 +1,38 @@
+local tabset_level = 100
+local tab_level = 101
+local flag = false
+local stringify = pandoc.utils.stringify
+
+function is_tabset(classes)
+
+  local res = false
+
+  for _,v in ipairs(classes) do
+    res = res or (v == "tabset")
+  end
+
+  return res
+end
+
+function Block(block)
+  if block.tag == "Header" then
+    local level = block.level
+    if level <= tabset_level then
+      flag = is_tabset(block.classes)
+      tabset_level = flag and level or 100
+      tab_level = tabset_level + 1
+    elseif level == tab_level then
+      local id = block.identifier
+      block.identifier = id .. "-tab"
+      return {
+        block,
+        pandoc.RawBlock(
+          "html",
+          "<h" .. level .. " style='visibility: hidden'>" ..
+          stringify(block) ..
+          "</h" .. level .. ">"
+        )
+      }
+    end
+  end
+end

--- a/inst/rmd/h/tocify/tabset.tocify.js
+++ b/inst/rmd/h/tocify/tabset.tocify.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const anchors = Array.from(document.querySelectorAll("ul.nav.nav-tabs li a")).
+    filter(a => a.attributes.role.value === "tab").
+    reduce((hash, a) => {
+      hash["#" + a.innerText.replace(/ /, "_")] = a;
+      return hash;
+    }, {});
+  window.addEventListener('hashchange', function() {
+    const anchor = anchors[location.hash];
+    if (anchor !== undefined) {
+      anchor.click();
+    }
+  });
+});


### PR DESCRIPTION
This PR aims to solve #1336.
Currently, I find two problems that needs someone's help

- [ ] Support navigation to inactive tabs
    - Otherwise, users have to click the ToC twice. Evaluating `anchor.click()` twice does not help.
- [ ] Support navigation to tabs with duplicated names

<details><summary>Example Rmd</summary>

````
---
title: "ToC and Tabset"
output:
  html_document:
    toc: true
    toc_float: true
---

# A {.tabset}


## tab A-1

content A-1

## tab A-2

content A-2

# B {.tabset}

## tab B-1

content B-1

## tab B-2

content B-2

# B2 {.tabset}

## tab B-1

content B-1

## tab B-2

content B-2

````
</details>