### PR TITLE
file.path.ci is too loose with file matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -96,7 +96,7 @@ Imports:
 Suggests:
     shiny (>= 0.11),
     tufte,
-    testthat (>= 2.0.0),
+    testthat (>= 3.0.0),
     digest,
     dygraphs,
     vctrs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rmarkdown 2.7
 
 - Fix an issue with line numbering in code chunks when `.numberlines` with Pandoc's highlighting (thanks, @aosavi, #1876)
 
+- Fix an issue with shiny runtime and `global.R` (thanks, @liaojiahui-r, rstudio/flexdashboard#298)
+
 - Accept `latex="{options}"`, `latex=1`, or `latex=true` for Latex Divs.
 
 - Add `output_format_filter` function to `default_site_generator()`. Enables custom site generators to customize or even entirely replace the output format right before rendering of each page.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -485,8 +485,10 @@ file.path.ci <- function(dir, name) {
 
   matches <- list.files(dir, name, ignore.case = TRUE, full.names = TRUE,
                         include.dirs = TRUE)
-  if (length(matches) == 0)
-    return(default)
+  # name is used as a pattern above and can match other files
+  # so we need to filter as if it was literal string
+  matches <- matches[tolower(name) == tolower(basename(matches))]
+  if (length(matches) == 0) return(default)
   return(matches[[1]])
 }
 

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -1,0 +1,17 @@
+test_that("file.path.ci returns correctly no matter the case", {
+  # TODO: added for new tests - to remove when switching the package to edition 3
+  local_edition(3)
+  tmp_dir <- withr::local_tempdir()
+  expect_equal(file.path.ci(tmp_dir, "global.R"), file.path(tmp_dir, "global.R"))
+
+  withr::local_dir(tmp_dir)
+  expect_equal_file <- function(file, tmp_dir, default = file) {
+    withr::local_file(file); xfun::write_utf8("#dummy", file)
+    expect_equal(file.path.ci(!!tmp_dir, "global.R"), file.path(!!tmp_dir, !!default))
+  }
+  expect_equal_file("global.R", tmp_dir)
+  # on windows case in filename does not matter
+  if (!xfun::is_windows()) expect_equal_file("global.r", tmp_dir)
+  expect_equal_file("global.R", "donotexist")
+  expect_equal_file("global.Rmd", tmp_dir, "global.R")
+})

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -11,7 +11,8 @@ test_that("file.path.ci returns correctly no matter the case", {
   }
   expect_equal_file("global.R", tmp_dir)
   # on windows case in filename does not matter
-  if (!xfun::is_windows()) expect_equal_file("global.r", tmp_dir)
+  # & MacOs in GHA is case insensitive
+  if (xfun::is_linux()) expect_equal_file("global.r", tmp_dir)
   expect_equal_file("global.R", "donotexist")
   expect_equal_file("global.Rmd", tmp_dir, "global.R")
 })


### PR DESCRIPTION
because the `pattern` argument in `list.files` is a regexp and not literal string.

This fixes rstudio/flexdashboard#298