### PR TITLE
Add shiny to remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,4 +113,6 @@ License: GPL-3
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 VignetteBuilder: knitr
-Remotes: rstudio/bslib
+Remotes: 
+  rstudio/bslib,
+  rstudio/shiny

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -697,8 +697,7 @@ shiny_bootstrap_lib <- function(theme) {
   }
   if (!is_available("shiny", "1.5.0.9007")) {
     stop(
-      "Using a {bslib} theme with `runtime: shiny` requires shiny v1.6 or higher.",
-      "Please try updating with `install.packages('shiny')`"
+      "Using a {bslib} theme with `runtime: shiny` requires shiny 1.5.0.9007 or higher."
     )
   }
   shiny::bootstrapLib(theme)


### PR DESCRIPTION
In #1706, I was hoping that `bslib`&`shiny` would both be on CRAN by today, but that's highly unlikely (it might not be until next week that both are on CRAN).