### PR TITLE
Warn that cropping is disabled if pdfcrop or ghostscript are not found.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ rmarkdown 2.7
 
 - Do not force `options(htmltools.preserve.raw = TRUE)` when this option has been set, otherwise it is impossible for other packages to turn this option off, e.g., yihui/xaringan#293.
 
+- `knitr_options_pdf()` will now throw a warning when `fig_crop = TRUE` but is disabled because required tools _pdfcrop_ and/or _ghostscript_ are missing. (thanks, @netique, #2016)
 
 rmarkdown 2.6
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ rmarkdown 2.7
 
 - Do not force `options(htmltools.preserve.raw = TRUE)` when this option has been set, otherwise it is impossible for other packages to turn this option off, e.g., yihui/xaringan#293.
 
-- `knitr_options_pdf()` will now throw a warning when `fig_crop = TRUE` but is disabled because required tools _pdfcrop_ and/or _ghostscript_ are missing. (thanks, @netique, #2016)
+- `knitr_options_pdf()` will now throw a warning when `fig_crop = TRUE` but is disabled because required tools `pdfcrop` and/or `ghostscript` are missing (thanks, @netique, #2016).
 
 rmarkdown 2.6
 ================================================================================

--- a/R/output_format.R
+++ b/R/output_format.R
@@ -262,7 +262,7 @@ knitr_options_pdf <- function(fig_width,
   knit_hooks <- NULL
 
   # apply cropping if requested and we have pdfcrop and ghostscript
-  crop <- fig_crop && find_program("pdfcrop") != '' && tools::find_gs_cmd() != ''
+  crop <- fig_crop && has_crop_tools()
   if (crop) {
     knit_hooks = list(crop = knitr::hook_pdfcrop)
     opts_chunk$crop = TRUE

--- a/R/util.R
+++ b/R/util.R
@@ -313,20 +313,18 @@ find_program <- function(program) {
 }
 
 has_crop_tools <- function() {
-  tools <- list(
+  tools <- c(
     pdfcrop = find_program("pdfcrop"),
     ghostcript = tools::find_gs_cmd()
   )
   missing <- tools[tools == ""]
-  if (length(missing) > 0) {
-    x <- paste0(names(missing), collapse = ", ")
-    warning(
-      sprintf("\nTool(s) not installed or not in PATH: %s", x),
-      "\n-> As a result, cropping will be disabled."
-    )
-    return(FALSE)
-  }
-  TRUE
+  if (length(missing) == 0) return(TRUE)
+  x <- paste0(names(missing), collapse = ", ")
+  warning(
+    sprintf("\nTool(s) not installed or not in PATH: %s", x),
+    "\n-> As a result, figure cropping will be disabled."
+  )
+  FALSE
 }
 
 # given a string, escape the regex metacharacters it contains:

--- a/R/util.R
+++ b/R/util.R
@@ -312,6 +312,23 @@ find_program <- function(program) {
   }
 }
 
+has_crop_tools <- function() {
+  tools <- list(
+    pdfcrop = find_program("pdfcrop"),
+    ghostcript = tools::find_gs_cmd()
+  )
+  missing <- tools[tools == ""]
+  if (length(missing) > 0) {
+    x <- paste0(names(missing), collapse = ", ")
+    warning(
+      c(sprintf("Tool(s) not installed or not in PATH: %s", x),
+        "\n -> As a result, cropping will be disabled."
+        ))
+    return(FALSE)
+  }
+  TRUE
+}
+
 # given a string, escape the regex metacharacters it contains:
 # regex metas are these,
 #   . \ | ( ) [ { ^ $ * + ?

--- a/R/util.R
+++ b/R/util.R
@@ -321,9 +321,9 @@ has_crop_tools <- function() {
   if (length(missing) > 0) {
     x <- paste0(names(missing), collapse = ", ")
     warning(
-      c(sprintf("Tool(s) not installed or not in PATH: %s", x),
-        "\n -> As a result, cropping will be disabled."
-        ))
+      sprintf("\nTool(s) not installed or not in PATH: %s", x),
+      "\n-> As a result, cropping will be disabled."
+    )
     return(FALSE)
   }
   TRUE


### PR DESCRIPTION
here is a proposal to do that on **rmarkdown** side.

It is oriented specifically toward cropping tools for which we want the warning. I had the idea to make it more generic but we don't need it for now so I stop myself from doing it.

Other solutions could be by adapting `find_program()` so that it warns, or using (exporting ?) `knitr:::has_utility()` but the logic is not exactly the same as `find_program()` (which deals with OSX a specific way). Opportunity to refactor ? 

Anyway, here is a PR to have you thoughts before merging.
