### PR TITLE
set gfm_auto_identifiers to input format if toc is TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ rmarkdown 2.7
 
 - Eliminated the unnecessary padding in code blocks in the `html_document` output with Bootstrap 4 themes (thanks, @atusy, #2019).
 
+- `github_document()` will produce a working TOC even if some headers start with number (#2039)
+
 rmarkdown 2.6
 ================================================================================
 

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -52,6 +52,10 @@ github_document <- function(toc = FALSE,
     "--atx-headers", pandoc_args
   )
 
+  if (toc && !isTRUE(grepl("gfm_auto_identifiers", md_extensions))) {
+    md_extensions <- c(md_extensions, "+gfm_auto_identifiers")
+  }
+
   format <- md_document(
     variant = variant, toc = toc, toc_depth = toc_depth,
     number_sections = number_sections, fig_width = fig_width,

--- a/tests/testthat/_snaps/github_document/github-atx.md
+++ b/tests/testthat/_snaps/github_document/github-atx.md
@@ -1,0 +1,10 @@
+
+# title 1
+
+## title 2
+
+### title 3
+
+#### title 4
+
+##### title 5

--- a/tests/testthat/_snaps/github_document/github-toc.md
+++ b/tests/testthat/_snaps/github_document/github-toc.md
@@ -1,6 +1,11 @@
 
 -   [10 Section](#10-section)
+-   [Header](#header)
 
 # 10 Section
 
 Sentence.
+
+# Header
+
+Sentence

--- a/tests/testthat/_snaps/github_document/github-toc.md
+++ b/tests/testthat/_snaps/github_document/github-toc.md
@@ -1,0 +1,6 @@
+
+-   [10 Section](#10-section)
+
+# 10 Section
+
+Sentence.

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,5 @@
+local_rmd_file <- function(..., .env = parent.frame()) {
+  path <- withr::local_tempfile(envir = .env, fileext = ".Rmd")
+  xfun::write_utf8(c(...), path)
+  path
+}

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -3,3 +3,15 @@ local_rmd_file <- function(..., .env = parent.frame()) {
   xfun::write_utf8(c(...), path)
   path
 }
+
+skip_if_not_pandoc <- function(ver) {
+  if (!pandoc_available(ver)) {
+    skip(sprintf("Version of Pandoc is lower than %s.", ver))
+  }
+}
+
+skip_if_pandoc <- function(ver) {
+  if (pandoc_available(ver)) {
+    skip(sprintf("Version of Pandoc is greater than %s.", ver))
+  }
+}

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -2,23 +2,20 @@
 test_that("toc has correct identifier", {
   local_edition(3)
   skip_on_cran() # avoid pandoc issue on CRAN
-  tmp_file <- withr::local_tempfile()
-  xfun::write_utf8(
-    c("# 10 Section","","Sentence.","", "# Header","","Sentence "),
-    tmp_file)
+  skip_if_not(pandoc_available("2.10.1"))
+  tmp_file <- local_rmd_file(
+    c("# 10 Section","","Sentence.","", "# Header","","Sentence ")
+  )
   res <- render(tmp_file, github_document(toc = TRUE, html_preview = FALSE))
-  if (pandoc_available("2.10.1")) {
-    expect_snapshot_file(res, "github-toc.md", binary = FALSE)
-  }
+  expect_snapshot_file(res, "github-toc.md", binary = FALSE)
 })
 
 
 test_that("github_document produces atx-header", {
   local_edition(3)
   skip_on_cran() # avoid pandoc issue on CRAN
-  tmp_file <- withr::local_tempfile()
   h <- paste0(Reduce(paste0, rep("#", 5), accumulate = TRUE), " title ", 1:5, "\n\n")
-  xfun::write_utf8(h, tmp_file)
+  tmp_file <- local_rmd_file(h)
   res <- render(tmp_file, github_document(html_preview = FALSE))
   expect_snapshot_file(res, "github-atx.md", binary = FALSE)
 })

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -1,18 +1,20 @@
 
-local_edition(3)
-
 test_that("toc has correct identifier", {
+  local_edition(3)
   skip_on_cran() # avoid pandoc issue on CRAN
   tmp_file <- withr::local_tempfile()
   xfun::write_utf8(
     c("# 10 Section","","Sentence.","", "# Header","","Sentence "),
     tmp_file)
   res <- render(tmp_file, github_document(toc = TRUE, html_preview = FALSE))
-  expect_snapshot_file(res, "github-toc.md", binary = FALSE)
+  if (pandoc_available("2.10.1")) {
+    expect_snapshot_file(res, "github-toc.md", binary = FALSE)
+  }
 })
 
 
 test_that("github_document produces atx-header", {
+  local_edition(3)
   skip_on_cran() # avoid pandoc issue on CRAN
   tmp_file <- withr::local_tempfile()
   h <- paste0(Reduce(paste0, rep("#", 5), accumulate = TRUE), " title ", 1:5, "\n\n")

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -2,7 +2,7 @@
 test_that("toc has correct identifier", {
   local_edition(3)
   skip_on_cran() # avoid pandoc issue on CRAN
-  skip_if_not(pandoc_available("2.10.1"))
+  skip_if_not_pandoc("2.10.1") # changes in gfm writer break this test for earlier versions
   tmp_file <- local_rmd_file(
     c("# 10 Section","","Sentence.","", "# Header","","Sentence ")
   )

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -4,10 +4,9 @@ local_edition(3)
 test_that("toc has correct identifier", {
   skip_on_cran() # avoid pandoc issue on CRAN
   tmp_file <- withr::local_tempfile()
-  xfun::write_utf8(c(
-  "# 10 Section",
-  "",
-  "Sentence."), tmp_file)
+  xfun::write_utf8(
+    c("# 10 Section","","Sentence.","", "# Header","","Sentence "),
+    tmp_file)
   res <- render(tmp_file, github_document(toc = TRUE, html_preview = FALSE))
   expect_snapshot_file(res, "github-toc.md", binary = FALSE)
 })

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -1,0 +1,25 @@
+
+local_edition(3)
+
+test_that("toc has correct identifier", {
+  skip_on_cran() # avoid pandoc issue on CRAN
+  tmp_file <- withr::local_tempfile()
+  xfun::write_utf8(c(
+  "# 10 Section",
+  "",
+  "Sentence."), tmp_file)
+  res <- render(tmp_file, github_document(toc = TRUE, html_preview = FALSE))
+  expect_snapshot_file(res, "github-toc.md", binary = FALSE)
+})
+
+
+test_that("github_document produces atx-header", {
+  skip_on_cran() # avoid pandoc issue on CRAN
+  tmp_file <- withr::local_tempfile()
+  h <- paste0(Reduce(paste0, rep("#", 5), accumulate = TRUE), " title ", 1:5, "\n\n")
+  xfun::write_utf8(h, tmp_file)
+  res <- render(tmp_file, github_document(html_preview = FALSE))
+  expect_snapshot_file(res, "github-atx.md", binary = FALSE)
+})
+
+

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -6,7 +6,7 @@
 }
 
 # Lua filters exists only since pandoc 2.0
-skip_if_not(rmarkdown::pandoc_available("2.0"))
+skip_if_not_pandoc("2.0")
 
 test_that("pagebreak Lua filters works", {
   rmd <- "# HEADER 1\n\\newpage\n# HEADER 2\n\\pagebreak\n# HEADER 3"

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -1,8 +1,6 @@
 .generate_md_and_convert <- function(content, output_format) {
-  input_file <- tempfile(fileext = ".Rmd")
-  output_file <- tempfile()
-  on.exit(unlink(c(input_file, output_file)), add = TRUE)
-  xfun::write_utf8(c("---\ntitle: Test\n---\n", content), input_file)
+  input_file <- local_rmd_file(c("---\ntitle: Test\n---\n", content))
+  output_file <- withr::local_tempfile()
   res <- rmarkdown::render(input_file, output_format = output_format, output_file = output_file, quiet = TRUE)
   xfun::read_utf8(res)
 }


### PR DESCRIPTION
This is required to have the correct identifier in the TOC corresponding to the link Github will create. 

This will fix #2039 