### PR TITLE
Only keep the first url in citation 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -107,7 +107,7 @@ Suggests:
     bslib,
     sass
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org
-URL: https://rmarkdown.rstudio.com/docs/, https://github.com/rstudio/rmarkdown
+URL: https://github.com/rstudio/rmarkdown, https://rmarkdown.rstudio.com/docs/
 BugReports: https://github.com/rstudio/rmarkdown/issues
 License: GPL-3
 RoxygenNote: 7.1.1

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,7 +11,7 @@ citEntry(
   author = auth,
   year = year,
   note = vers,
-  url = strsplit(meta$URL,',')[[1]][1],
+  url = strsplit(meta$URL, ',')[[1]][1],
   textVersion = paste0(
     paste(auth, collapse = ' and '), ' (', year, '). rmarkdown: ', meta$Title, '. ', vers, '.',
     ' URL https://rmarkdown.rstudio.com.'

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,7 +11,7 @@ citEntry(
   author = auth,
   year = year,
   note = vers,
-  url = meta$URL,
+  url = strsplit(meta$URL,',')[[1]][1],
   textVersion = paste0(
     paste(auth, collapse = ' and '), ' (', year, '). rmarkdown: ', meta$Title, '. ', vers, '.',
     ' URL https://rmarkdown.rstudio.com.'


### PR DESCRIPTION
This should allow #1843 while keeping only one url in citation. 

With this PR, in a clean session we correctly get only one url

```r
> meta = packageDescription("rmarkdown")
> meta$URL
[1] "https://github.com/rstudio/rmarkdown, https://rmarkdown.rstudio.com/docs/"
> toBibtex(readCitationFile("inst/CITATION", meta))
@Manual{,
  title = {rmarkdown: Dynamic Documents for R},
  year = {2021},
  note = {R package version 2.6.6},
  url = {https://github.com/rstudio/rmarkdown},
}

@Book{,
  title = {R Markdown: The Definitive Guide},
  author = {Yihui Xie and J.J. Allaire and Garrett Grolemund},
  publisher = {Chapman and Hall/CRC},
  address = {Boca Raton, Florida},
  year = {2018},
  note = {ISBN 9781138359338},
  url = {https://bookdown.org/yihui/rmarkdown},
}

@Book{,
  title = {R Markdown Cookbook},
  author = {Yihui Xie and Christophe Dervieux and Emily Riederer},
  publisher = {Chapman and Hall/CRC},
  address = {Boca Raton, Florida},
  year = {2020},
  note = {ISBN 9780367563837},
  url = {https://bookdown.org/yihui/rmarkdown-cookbook},
}
```

We could adjust the order in DESCRIPTION and select the second. Or use the CRAN url in CITATION as it is the default for other package : `https://CRAN.R-project.org/package=rmarkdown`

@yihui is it interesting to make this change ? 