### PR TITLE
Fix for knit_print.data.frame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ rmarkdown 2.7
 
 - `github_document()` will produce a working TOC even if some headers start with number (#2039)
 
+- Fix and issue with `knit_print.data.frame`. The `...` are no more passed to `print()` to avoid passing `knit_print()` arguments `options` and `encoding` to custom `print()` methods. (#2047) 
+
 rmarkdown 2.6
 ================================================================================
 

--- a/R/knit_print.R
+++ b/R/knit_print.R
@@ -27,7 +27,7 @@ knit_print.data.frame <- function(x, ...) {
       context$df_print(x)
     }
   } else {
-    print(x, ...)
+    print(x)
   }
 }
 

--- a/tests/testthat/test-knit_print.R
+++ b/tests/testthat/test-knit_print.R
@@ -1,0 +1,8 @@
+test_that("knit_print.data.frame default to print without error", {
+  df <- data.frame(a = 10)
+  class(df) <- c("df", class(df))
+  print.df <- function(x) {cat("Nb row:", nrow(x)) }
+  expect_output(knit_print.data.frame(df), "Nb row:")
+  expect_error(knit_print.data.frame(df, inline = TRUE), NA)
+  expect_output(knit_print.data.frame(df, inline = TRUE), "Nb row:")
+})

--- a/tests/testthat/test-knit_print.R
+++ b/tests/testthat/test-knit_print.R
@@ -1,8 +1,4 @@
 test_that("knit_print.data.frame default to print without error", {
   df <- data.frame(a = 10)
-  class(df) <- c("df", class(df))
-  print.df <- function(x) {cat("Nb row:", nrow(x)) }
-  expect_output(knit_print.data.frame(df), "Nb row:")
   expect_error(knit_print.data.frame(df, inline = TRUE), NA)
-  expect_output(knit_print.data.frame(df, inline = TRUE), "Nb row:")
 })


### PR DESCRIPTION
This should fix #2047 

it will insure to not pass `...` to `print()` methods. `knit_print()` accepts `...` but only for `options` and `inline` that can be used by `knit_print` method. 

This two arguments should not be passed to underlying `print()` method. Some of them won't deal with `...` and an `unused argument` error will be thrown. 

