### PR TITLE
render_args passed to run() can contain theme in output_options

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -133,14 +133,16 @@ run <- function(file = "index.Rmd", dir = dirname(file), default_file = NULL,
   target_file <- file %||% file.path(dir, default_file)
   yaml_front <- if (length(target_file)) yaml_front_matter(target_file)
   runtime <- yaml_front$runtime
-  theme <- render_args$output_options$theme
   # Let shiny::getCurrentTheme() know about the yaml's theme, so
   # things like `bslib::bs_themer()` can work with prerendered documents.
   # Also note that we add the actual shiny::bootstrapLib() dependency
   # inside the document's pre-processing hook so the 'last' version of
   # the theme wins out
   if (length(target_file)) {
-    format <- output_format_from_yaml_front_matter(read_utf8(target_file))
+    format <- output_format_from_yaml_front_matter(
+      input_lines = read_utf8(target_file),
+      output_options = render_args$output_options
+    )
     set_current_theme(resolve_theme(format$options$theme))
   }
 


### PR DESCRIPTION
This takes into account https://github.com/rstudio/rmarkdown/pull/2049/files#r586431698 with @cpsievert 

I believe this is needed in case someone run 
```r
rmarkdown::run("my.Rmd", render_args = list(output_options = list(theme = bslib::bs_theme(bootswatch = "minty"))))
```
because it would overwrite any theme option set in the YAML header.

This may not be the only missed behavior - see coment below.