### PR TITLE
Add Pandoc version requirement in Lua Filters

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,6 +31,7 @@ jobs:
           - {os: macOS-latest,   pandoc: '2.7.3',   r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
+          - {os: ubuntu-18.04,   pandoc: '2.0.1',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.11.3.1',  r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: 'devel',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,8 @@ jobs:
           - {os: macOS-latest,   pandoc: '2.7.3',   r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
-          - {os: ubuntu-18.04,   pandoc: '2.0.1',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   pandoc: '2.0',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   pandoc: '2.0.0.1',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.11.3.1',  r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: 'devel',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,6 @@ jobs:
           - {os: macOS-latest,   pandoc: '2.7.3',   r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
-          - {os: ubuntu-18.04,   pandoc: '2.0',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.0.0.1',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   pandoc: '2.11.3.1',  r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.7.6
+Version: 2.7.7
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ rmarkdown 2.8
 
 - Added `tectonic` as a supported LaTeX engine for generating PDF output (thanks, @dpryan79, #2078). You can specify to use this by adding `engine: "tectonic"` to your output format in YAML, such as `pdf_document`.
 
-- Lua filters checks `PANDOC_VERSION` and skip if the requirement is unmet. Minimal version is 2.1 because `PANDOC_VERSION` is available from that version (thanks, @atusy, #2088).
+- Lua filters check the global variable, `PANDOC_VERSION`, and skip if the requirement is unmet. Minimal version is 2.1 because `PANDOC_VERSION` is available from that version (thanks, @atusy, #2088).
 
 rmarkdown 2.7
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ rmarkdown 2.8
 
 - Added `tectonic` as a supported LaTeX engine for generating PDF output (thanks, @dpryan79, #2078). You can specify to use this by adding `engine: "tectonic"` to your output format in YAML, such as `pdf_document`.
 
-- Skip the `pagebreak.lua` lua filter when pandoc is older than 2.0.6 (thanks, @atusy, #2088)
+- Lua filters checks `PANDOC_VERSION` and skip if the requirement is unmet. Minimal version is 2.1 because `PANDOC_VERSION` is available from that version (thanks, @atusy, #2088).
 
 rmarkdown 2.7
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ rmarkdown 2.8
 
 - Added `tectonic` as a supported LaTeX engine for generating PDF output (thanks, @dpryan79, #2078). You can specify to use this by adding `engine: "tectonic"` to your output format in YAML, such as `pdf_document`.
 
+- Skip the `pagebreak.lua` lua filter when pandoc is older than 2.0.6 (thanks, @atusy, #2088)
+
 rmarkdown 2.7
 ================================================================================
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ rmarkdown 2.8
 
 - Added a new global option `rmarkdown.render.message`. When set `FALSE`, `render()` will not output the message starting by `Output created: ` allowing RStudio IDE to open a preview of the document. This is useful for package developers that would need to emit there own output message for there custom format. See `?render_site` for more info on this special message (#2092).
 
-- Lua filters check the global variable, `PANDOC_VERSION`, and skip if the requirement is unmet. Minimal version is 2.1 because `PANDOC_VERSION` is available from that version (thanks, @atusy, #2088).
+- Lua filters have now an explicit Pandoc version minimal requirement. A filter will be skipped with a warning printed by the Lua filter if this requirement is not met. For now, all filters work for Pandoc 2.1 and above (thanks, @atusy, #2088).
 
 rmarkdown 2.7
 ================================================================================

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -5,7 +5,7 @@
      Depends: Pandoc > 2.0.0
 --]]
 
-text = require 'text'
+tolower = text.lower or string.lower
 
 Div = function (div)
   -- look for 'latex' or 'data-latex' and at least 1 class
@@ -25,7 +25,7 @@ Div = function (div)
   end
 
   -- if it's "1" or "true" then just set it to empty string
-  if options == "1" or text.lower(options) == "true" then
+  if options == "1" or tolower(options) == "true" then
     options = ""
   end
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -2,6 +2,7 @@
      A Pandoc 2 Lua filter converting Pandoc native divs to LaTeX environments
      Author: Romain Lesur, Christophe Dervieux, and Yihui Xie
      License: Public domain
+     Depends: Pandoc > 2.0.0
 --]]
 
 text = require 'text'

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -5,7 +5,7 @@
 --]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-    print("latex-div.lua requires Pandoc > 2.1")
+    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1")
     return {}
 end
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -4,8 +4,12 @@
      License: Public domain
 --]]
 
+--[[
+  About the requirement:
+  * PANDOC_VERSION -> 2.1
+]]
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1. Lua Filter skipped")
+    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
     return {}
 end
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -2,10 +2,14 @@
      A Pandoc 2 Lua filter converting Pandoc native divs to LaTeX environments
      Author: Romain Lesur, Christophe Dervieux, and Yihui Xie
      License: Public domain
-     Depends: Pandoc > 2.0.0
 --]]
 
-tolower = text.lower or string.lower
+if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
+    print("latex-div.lua requires Pandoc > 2.1")
+    return {}
+end
+
+text = require 'text'
 
 Div = function (div)
   -- look for 'latex' or 'data-latex' and at least 1 class
@@ -25,7 +29,7 @@ Div = function (div)
   end
 
   -- if it's "1" or "true" then just set it to empty string
-  if options == "1" or tolower(options) == "true" then
+  if options == "1" or text.lower(options) == "true" then
     options = ""
   end
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -5,7 +5,7 @@
 --]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1")
+    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1. Lua Filter skipped")
     return {}
 end
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -1,6 +1,6 @@
 --[[
      A Pandoc 2 Lua filter converting Pandoc native divs to LaTeX environments
-     Author: Romain Lesur, Christophe Dervieux, and Yihui Xie
+     Author: Romain Lesur, Christophe Dervieux, Atsushi Yasumoto and Yihui Xie
      License: Public domain
 --]]
 

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -15,7 +15,7 @@ https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 ]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-  print("number-sections.lua requires Pandoc > 2.1")
+  io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1")
   return {}
 end
 

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -1,8 +1,6 @@
 --[[
 number-sections - Number sections like the --number-sections option
 
-depends on pandoc >= 2.0.6
-
 # MIT License
 
 Copyright (c) 2020 Atsushi Yasumoto
@@ -15,6 +13,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 ]]
+
+if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
+  print("number-sections.lua requires Pandoc > 2.1")
+  return {}
+end
+
 local section_number_table = {0, 0, 0, 0, 0, 0, 0, 0, 0}
 local n_section_number_table = #section_number_table
 local previous_header_level = 0

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -15,7 +15,7 @@ https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 ]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-  io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1")
+  io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1. Lua Filter skipped")
   return {}
 end
 

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -14,6 +14,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 ]]
 
+--[[
+  About the requirement:
+  * PANDOC_VERSION -> 2.1
+]]
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
   io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
   return {}

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -15,7 +15,7 @@ https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 ]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-  io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1. Lua Filter skipped")
+  io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
   return {}
 end
 

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -1,6 +1,8 @@
 --[[
 number-sections - Number sections like the --number-sections option
 
+depends on pandoc >= 2.0.6
+
 # MIT License
 
 Copyright (c) 2020 Atsushi Yasumoto

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -16,6 +16,11 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
+--[[
+  About the requirement:
+  * PANDOC_VERSION -> 2.1
+  * pandoc.utils -> 2.1
+]]
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
   io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
   return {}

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -17,7 +17,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-  io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1. Lua Filter skipped")
+  io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
   return {}
 end
 

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -17,7 +17,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-  print("pagebreak.lua requires Pandoc > 2.1")
+  io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1")
   return {}
 end
 

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -1,8 +1,6 @@
 --[[
 pagebreak – convert raw LaTeX page breaks to other formats
 
-depends on pandoc >= 2.0.6
-
 Copyright © 2017-2019 Benct Philip Jonsson, Albert Krewinkel
 
 Permission to use, copy, modify, and/or distribute this software for any
@@ -17,8 +15,9 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
-if not pandoc.utils then
-  print('pagebreak.lua requires pandoc >= 2.0.6')
+
+if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
+  print("pagebreak.lua requires Pandoc > 2.1")
   return {}
 end
 

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -2,6 +2,7 @@
 pagebreak – convert raw LaTeX page breaks to other formats
 
 Copyright © 2017-2019 Benct Philip Jonsson, Albert Krewinkel
+Copyright © 2019-2021 Christophe Dervieux, Romain Lesur, Atsushi Yasumoto
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -17,7 +17,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
 if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
-  io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1")
+  io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1. Lua Filter skipped")
   return {}
 end
 

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -1,6 +1,8 @@
 --[[
 pagebreak – convert raw LaTeX page breaks to other formats
 
+depends on pandoc >= 2.0.6
+
 Copyright © 2017-2019 Benct Philip Jonsson, Albert Krewinkel
 
 Permission to use, copy, modify, and/or distribute this software for any
@@ -15,6 +17,11 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
+if not pandoc.utils then
+  print('pagebreak.lua requires pandoc >= 2.0.6')
+  return {}
+end
+
 local stringify_orig = (require 'pandoc.utils').stringify
 
 local function stringify(x)

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -3,12 +3,23 @@
   .render_and_read(input_file, output_format = output_format)
 }
 
-# Lua filters exists only since pandoc 2.0
-skip_if_not_pandoc("2.0.0")
+# rmarkdown requires pandoc >= 2.1 to support Lua filters
+skip_if_not_pandoc("2.1")
 
-test_that("lua file are correctly found", {
-  expect_match(basename(pkg_file_lua()),  ".*[.]lua$")
-  expect_match(basename(pkg_file_lua("number-sections.lua")),  "^number-sections.lua$")
+test_that("pagebreak Lua filters works", {
+  rmd <- "# HEADER 1\n\\newpage\n# HEADER 2\n\\pagebreak\n# HEADER 3"
+  res <- .generate_md_and_convert(rmd, "html_document")
+  expect_match(res[grep("HEADER 1", res)+1], "<div style=\"page-break-after: always;\"></div>")
+  expect_match(res[grep("HEADER 2", res)+1], "<div style=\"page-break-after: always;\"></div>")
+  # add a class instead of inline style
+  rmd2 <- paste0("---\nnewpage_html_class: page-break\n---\n", rmd)
+  res <- .generate_md_and_convert(rmd2, "html_document")
+  expect_match(res[grep("HEADER 1", res)+1], "<div class=\"page-break\"></div>")
+  expect_match(res[grep("HEADER 2", res)+1], "<div class=\"page-break\"></div>")
+  # For tex document this is unchanged
+  res <- .generate_md_and_convert(rmd, "latex_document")
+  expect_match(res[grep("HEADER 1", res)+2], "\\newpage", fixed = TRUE)
+  expect_match(res[grep("HEADER 2", res)+2], "\\pagebreak", fixed = TRUE)
 })
 
 test_that("number_sections Lua filter works", {
@@ -55,21 +66,7 @@ test_that("formats have the expected Lua filter", {
     c("pagebreak", if (!pandoc_available("2.10.1")) "number-sections"))
 })
 
-# pagebreak requires pandoc.utils which is added by pandoc 2.0.6
-skip_if_not_pandoc("2.0.6")
-
-test_that("pagebreak Lua filters works", {
-  rmd <- "# HEADER 1\n\\newpage\n# HEADER 2\n\\pagebreak\n# HEADER 3"
-  res <- .generate_md_and_convert(rmd, "html_document")
-  expect_match(res[grep("HEADER 1", res)+1], "<div style=\"page-break-after: always;\"></div>")
-  expect_match(res[grep("HEADER 2", res)+1], "<div style=\"page-break-after: always;\"></div>")
-  # add a class instead of inline style
-  rmd2 <- paste0("---\nnewpage_html_class: page-break\n---\n", rmd)
-  res <- .generate_md_and_convert(rmd2, "html_document")
-  expect_match(res[grep("HEADER 1", res)+1], "<div class=\"page-break\"></div>")
-  expect_match(res[grep("HEADER 2", res)+1], "<div class=\"page-break\"></div>")
-  # For tex document this is unchanged
-  res <- .generate_md_and_convert(rmd, "latex_document")
-  expect_match(res[grep("HEADER 1", res)+2], "\\newpage", fixed = TRUE)
-  expect_match(res[grep("HEADER 2", res)+2], "\\pagebreak", fixed = TRUE)
+test_that("lua file are correctly found", {
+  expect_match(basename(pkg_file_lua()),  ".*[.]lua$")
+  expect_match(basename(pkg_file_lua("number-sections.lua")),  "^number-sections.lua$")
 })

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -4,22 +4,11 @@
 }
 
 # Lua filters exists only since pandoc 2.0
-skip_if_not_pandoc("2.0")
+skip_if_not_pandoc("2.0.0")
 
-test_that("pagebreak Lua filters works", {
-  rmd <- "# HEADER 1\n\\newpage\n# HEADER 2\n\\pagebreak\n# HEADER 3"
-  res <- .generate_md_and_convert(rmd, "html_document")
-  expect_match(res[grep("HEADER 1", res)+1], "<div style=\"page-break-after: always;\"></div>")
-  expect_match(res[grep("HEADER 2", res)+1], "<div style=\"page-break-after: always;\"></div>")
-  # add a class instead of inline style
-  rmd2 <- paste0("---\nnewpage_html_class: page-break\n---\n", rmd)
-  res <- .generate_md_and_convert(rmd2, "html_document")
-  expect_match(res[grep("HEADER 1", res)+1], "<div class=\"page-break\"></div>")
-  expect_match(res[grep("HEADER 2", res)+1], "<div class=\"page-break\"></div>")
-  # For tex document this is unchanged
-  res <- .generate_md_and_convert(rmd, "latex_document")
-  expect_match(res[grep("HEADER 1", res)+2], "\\newpage", fixed = TRUE)
-  expect_match(res[grep("HEADER 2", res)+2], "\\pagebreak", fixed = TRUE)
+test_that("lua file are correctly found", {
+  expect_match(basename(pkg_file_lua()),  ".*[.]lua$")
+  expect_match(basename(pkg_file_lua("number-sections.lua")),  "^number-sections.lua$")
 })
 
 test_that("number_sections Lua filter works", {
@@ -66,7 +55,21 @@ test_that("formats have the expected Lua filter", {
     c("pagebreak", if (!pandoc_available("2.10.1")) "number-sections"))
 })
 
-test_that("lua file are correctly found", {
-  expect_match(basename(pkg_file_lua()),  ".*[.]lua$")
-  expect_match(basename(pkg_file_lua("number-sections.lua")),  "^number-sections.lua$")
+# pagebreak requires pandoc.utils which is added by pandoc 2.0.6
+skip_if_not_pandoc("2.0.6")
+
+test_that("pagebreak Lua filters works", {
+  rmd <- "# HEADER 1\n\\newpage\n# HEADER 2\n\\pagebreak\n# HEADER 3"
+  res <- .generate_md_and_convert(rmd, "html_document")
+  expect_match(res[grep("HEADER 1", res)+1], "<div style=\"page-break-after: always;\"></div>")
+  expect_match(res[grep("HEADER 2", res)+1], "<div style=\"page-break-after: always;\"></div>")
+  # add a class instead of inline style
+  rmd2 <- paste0("---\nnewpage_html_class: page-break\n---\n", rmd)
+  res <- .generate_md_and_convert(rmd2, "html_document")
+  expect_match(res[grep("HEADER 1", res)+1], "<div class=\"page-break\"></div>")
+  expect_match(res[grep("HEADER 2", res)+1], "<div class=\"page-break\"></div>")
+  # For tex document this is unchanged
+  res <- .generate_md_and_convert(rmd, "latex_document")
+  expect_match(res[grep("HEADER 1", res)+2], "\\newpage", fixed = TRUE)
+  expect_match(res[grep("HEADER 2", res)+2], "\\pagebreak", fixed = TRUE)
 })

--- a/vignettes/lua-filters.Rmd
+++ b/vignettes/lua-filters.Rmd
@@ -14,13 +14,17 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignettes gives some detailled information regarding the Lua filter including in the **rmarkdown** package. To know more about Lua filter, you can jump directly to [last section](#lua-filter)
+This vignettes gives some detailed information regarding the Lua filters including in the **rmarkdown** package. You don't have to do anything to use them usually as they just works usaully. This document presents the features they power.
+
+To know more about Lua filters in general, you can jump directly to [last section](#lua-filter)
 
 ## Pagebreaks
 
+This filter is available since **rmarkdown** 1.15 and works with Pandoc 2.1+ (shipped in RStudio >= 1.2).
+
 Adding a pagebreak in document was always possible using custom output specific syntax in a rmarkdown file but one drawback was the compatibility with several output format.
 
-Since rmarkdown >= 1.15 and with RStudio >= 1.2 (or with pandoc >= 2.0), it is possible to add a `\newpage` or `\pagebreak` command in a new line to include a pagebreak in any of these formats: `pdf_document()`, `html_document()`, `word_document()` and `odt_document()`. 
+With this Lua filter, it is possible to add a `\newpage` or `\pagebreak` command in a new line to include a pagebreak in any of these formats: `pdf_document()`, `html_document()`, `word_document()` and `odt_document()`. 
 
 ```md
 # Header 1
@@ -147,6 +151,8 @@ output:
 
 ## Number sections
 
+This filter is available since **rmarkdown** 2.4 and works with Pandoc 2.1+ (shipped in RStudio >= 1.2).
+
 Numbering sections are supported by Pandoc for limited formats (e.g., html and pdf).
 The rmarkdown package adds `number_sections.lua` to support this feature in other formats (e.g., docx, odt, and so on).
 Users do not have to know which formats use the Pandoc's feature or the Lua filter.
@@ -172,7 +178,37 @@ In general, numbers and titles of sections are separated by a space.
 An exception is the `word_document` function, which separates them by a tab in order to be consistent with Pandoc's number sections for docx format in Pandoc >= 2.10.1.
 If one wants to have fine controls on the format of section numbers, prepare customized docx file and specify it to the `reference_docx` argument of the `word_document` function.
 
+## Custom environment for LaTeX 
 
+This filter is available since **rmarkdown** 1.15 and works with Pandoc 2.1+ (shipped in RStudio >= 1.2).
+
+Pandoc supports a syntax called [Fenced Divs](https://pandoc.org/MANUAL.html#divs-and-spans) that allows to create `<div>` in HTML. For example, the syntax is 
+
+```markdown
+::: {#special .sidebar}
+Here is a paragraph.
+
+And another.
+:::
+```
+By default, this special syntax will be ignored in LaTeX conversion for PDF output and the content of the block will be used as-is. However, this syntax could be used to create LaTeX environment. 
+
+That is why **rmarkdown** uses a custom Lua filter to allow any Fenced Divs to be converted as a LaTeX environment (`\begin{env}` ... `\end{env}`) when desired by adding a special attribute.
+
+```markdown
+::: {.verbatim data-latex=""}
+We show some _verbatim_ text here.
+:::
+```
+Its LaTeX output will be:
+
+```latex
+\begin{verbatim}
+We show some \emph{verbatim} text here.
+\end{verbatim}
+```
+
+This feature we call _Custom blocks_ is documented in details in the [R Markdown Cookbook](https://bookdown.org/yihui/rmarkdown-cookbook/custom-blocks.html)
 
 ## About Lua filters {#lua-filter}
 


### PR DESCRIPTION
This PR requires Lua filters to be run on Pandoc >= 2.1.
The filters are skipped if requirements are unmet.


<details><summary>outdated initial comment</summary>
There are currently 3 filters available in **rmarkdown**

1. `latex-div.lua`
2. `number-sections.lua`
3. `pagebreak.lua`

As far as I understand, 1 and 2 requires Pandoc 2.0.0 and 3 requires Pandoc 2.0.6.
However, there are no way to check the version in Lua filter Pandoc < 2.1.0.
I decided to comment minimal requested version in the filters.
I also tweaked `pagebreak.lua` so that it does nothing when `pandoc.utils` is missing.
</details>