### PR TITLE
Add an option to opt-out the special message for RStudio preview

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.7.5
+Version: 2.7.6
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,9 @@ rmarkdown 2.8
 
 - Added `tectonic` as a supported LaTeX engine for generating PDF output (thanks, @dpryan79, #2078). You can specify to use this by adding `engine: "tectonic"` to your output format in YAML, such as `pdf_document`.
 
-- When no `output_format` is provided in any way but an `output_file` is provided in `render()`, the default format will be determined based on the extension: `"pdf_document"` for `.pdf`, or `"word_document"` for `.docx`. Otherwise, it will be `"html_document"` as previous version. (thanks, @pearsonca, #1569)  
+- When no `output_format` is provided in any way but an `output_file` is provided in `render()`, the default format will be determined based on the extension: `"pdf_document"` for `.pdf`, or `"word_document"` for `.docx`. Otherwise, it will be `"html_document"` as previous version. (thanks, @pearsonca, #1569) 
+
+- Added a new global option `rmarkdown.rstudio.preview`. When set `FALSE`, `render()` will not output the message starting by `Output created: ` allowing RStudio IDE to open a preview of the document. This is useful for package developers that would need to emit there own output message for there custom format. See `?render_site` for more info on this special message.
 
 rmarkdown 2.7
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,9 +9,9 @@ rmarkdown 2.8
 
 - Added `tectonic` as a supported LaTeX engine for generating PDF output (thanks, @dpryan79, #2078). You can specify to use this by adding `engine: "tectonic"` to your output format in YAML, such as `pdf_document`.
 
-- When no `output_format` is provided in any way but an `output_file` is provided in `render()`, the default format will be determined based on the extension: `"pdf_document"` for `.pdf`, or `"word_document"` for `.docx`. Otherwise, it will be `"html_document"` as previous version. (thanks, @pearsonca, #1569) 
+- When no `output_format` is provided in any way but an `output_file` is provided in `render()`, the default format will be determined based on the extension: `"pdf_document"` for `.pdf`, or `"word_document"` for `.docx`. Otherwise, it will be `"html_document"` as previous version (thanks, @pearsonca, #1569).
 
-- Added a new global option `rmarkdown.render.message`. When set `FALSE`, `render()` will not output the message starting by `Output created: ` allowing RStudio IDE to open a preview of the document. This is useful for package developers that would need to emit there own output message for there custom format. See `?render_site` for more info on this special message.
+- Added a new global option `rmarkdown.render.message`. When set `FALSE`, `render()` will not output the message starting by `Output created: ` allowing RStudio IDE to open a preview of the document. This is useful for package developers that would need to emit there own output message for there custom format. See `?render_site` for more info on this special message (#2092).
 
 rmarkdown 2.7
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ rmarkdown 2.8
 
 - When no `output_format` is provided in any way but an `output_file` is provided in `render()`, the default format will be determined based on the extension: `"pdf_document"` for `.pdf`, or `"word_document"` for `.docx`. Otherwise, it will be `"html_document"` as previous version. (thanks, @pearsonca, #1569) 
 
-- Added a new global option `rmarkdown.rstudio.preview`. When set `FALSE`, `render()` will not output the message starting by `Output created: ` allowing RStudio IDE to open a preview of the document. This is useful for package developers that would need to emit there own output message for there custom format. See `?render_site` for more info on this special message.
+- Added a new global option `rmarkdown.render.message`. When set `FALSE`, `render()` will not output the message starting by `Output created: ` allowing RStudio IDE to open a preview of the document. This is useful for package developers that would need to emit there own output message for there custom format. See `?render_site` for more info on this special message.
 
 rmarkdown 2.7
 ================================================================================

--- a/R/render.R
+++ b/R/render.R
@@ -215,7 +215,7 @@ NULL
 #' output.
 #' @param quiet An option to suppress printing during rendering from knitr,
 #'   pandoc command line and others. To only suppress printing of the last
-#'   "Output created: " message, you can set \code{rmarkdown.rstudio.preview} to
+#'   "Output created: " message, you can set \code{rmarkdown.render.message} to
 #'   \code{FALSE}
 #' @param encoding Ignored. The encoding is always assumed to be UTF-8.
 #' @return
@@ -1005,7 +1005,7 @@ render <- function(input,
                                                   clean,
                                                   !quiet)
 
-    if (!quiet && getOption('rmarkdown.rstudio.preview', TRUE)) {
+    if (!quiet && getOption('rmarkdown.render.message', TRUE)) {
       message("\nOutput created: ", relative_to(oldwd, output_file))
     }
 

--- a/R/render.R
+++ b/R/render.R
@@ -213,7 +213,10 @@ NULL
 #' environment).
 #' @param run_pandoc An option for whether to run pandoc to convert Markdown
 #' output.
-#' @param quiet An option to suppress printing of the pandoc command line.
+#' @param quiet An option to suppress printing during rendering from knitr,
+#'   pandoc command line and others. To only suppress printing of the last
+#'   "Output created: " message, you can set \code{rmarkdown.rstudio.preview} to
+#'   \code{FALSE}
 #' @param encoding Ignored. The encoding is always assumed to be UTF-8.
 #' @return
 #'   When \code{run_pandoc = TRUE}, the compiled document is written into
@@ -1002,7 +1005,7 @@ render <- function(input,
                                                   clean,
                                                   !quiet)
 
-    if (!quiet) {
+    if (!quiet && getOption('rmarkdown.rstudio.preview', TRUE)) {
       message("\nOutput created: ", relative_to(oldwd, output_file))
     }
 

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -103,7 +103,10 @@ environment).}
 \item{run_pandoc}{An option for whether to run pandoc to convert Markdown
 output.}
 
-\item{quiet}{An option to suppress printing of the pandoc command line.}
+\item{quiet}{An option to suppress printing during rendering from knitr,
+pandoc command line and others. To only suppress printing of the last
+"Output created: " message, you can set \code{rmarkdown.rstudio.preview} to
+\code{FALSE}}
 
 \item{encoding}{Ignored. The encoding is always assumed to be UTF-8.}
 }

--- a/man/render.Rd
+++ b/man/render.Rd
@@ -105,7 +105,7 @@ output.}
 
 \item{quiet}{An option to suppress printing during rendering from knitr,
 pandoc command line and others. To only suppress printing of the last
-"Output created: " message, you can set \code{rmarkdown.rstudio.preview} to
+"Output created: " message, you can set \code{rmarkdown.render.message} to
 \code{FALSE}}
 
 \item{encoding}{Ignored. The encoding is always assumed to be UTF-8.}


### PR DESCRIPTION
This will allow to deactivate printing of this message from other packages before calling rmarkdown::render().