### PR TITLE
Fix "Invalid cross-device link" with `render()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.8
 ================================================================================
 
+- Fix an `Invalid cross-device link` error when `tempdir()` is used for `intermediates_dir` in `render()` (thanks, @gorgitko, PR #2096).
+
 - Fix a regression in HTML default template with floating toc incorrectly placed on small size window (thanks, @grimbough, #2071)
 
 - Provided a `runtime: shiny` fix for output formats that pass a modified `bslib::bs_theme()` object to `html_document_base()`'s `theme` (thanks, @cpsievert, #2049).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.8
 ================================================================================
 
-- Fix an `Invalid cross-device link` error when `tempdir()` is used for `intermediates_dir` in `render()` (thanks, @gorgitko, PR #2096).
+- Fix an `Invalid cross-device link` error when `tempdir()` is used for `intermediates_dir` in `render()` (thanks, @gorgitko, #2096).
 
 - Fix a regression in HTML default template with floating toc incorrectly placed on small size window (thanks, @grimbough, #2071)
 

--- a/R/render.R
+++ b/R/render.R
@@ -989,7 +989,7 @@ render <- function(input,
     if (!is.null(intermediates_dir)) {
       intermediate_output <- file.path(intermediates_dir, basename(output_file))
       if (file.exists(intermediate_output)) {
-        file.copy(intermediate_output, output_file) && unlink(intermediate_output)
+        move_dir(intermediate_output, output_file)
       }
     }
 


### PR DESCRIPTION
When `tempdir()` is used for `intermediates_dir`, this error can occur on Linux systems.