### PR TITLE
Improve Pandoc versions handling in Lua Filters

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,7 +28,8 @@ jobs:
       matrix:
         config:
           # testing R release with last shipped pandoc version in RStudio IDE
-          - {os: windows-latest, pandoc: '2.11.4',  r: 'release'}
+          # TODO: issue on windows with pandoc 2.11.4 - change when fixed
+          - {os: windows-latest, pandoc: '2.7.3',  r: 'release'}
           - {os: macOS-latest,   pandoc: '2.11.4',  r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.11.4',  r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           # testing older pandoc versions

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,14 +27,17 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, pandoc: '2.7.3',   r: 'release'}
-          - {os: macOS-latest,   pandoc: '2.7.3',   r: 'release'}
-          - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
-          - {os: ubuntu-18.04,   pandoc: '2.0.0.1',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          # testing R release with last shipped pandoc version in RStudio IDE
+          - {os: windows-latest, pandoc: '2.11.4',  r: 'release'}
+          - {os: macOS-latest,   pandoc: '2.11.4',  r: 'release'}
+          - {os: ubuntu-18.04,   pandoc: '2.11.4',  r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          # testing older pandoc versions
           - {os: ubuntu-18.04,   pandoc: '2.7.3',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   pandoc: '2.11.3.1',  r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   pandoc: 'devel',   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   pandoc: '2.5',     r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   pandoc: '2.0.0.1', r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          # testing other R versions
+          - {os: ubuntu-18.04,   pandoc: '2.11.4',  r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   pandoc: '2.11.4',  r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -4,14 +4,42 @@
      License: Public domain
 --]]
 
+-- COMMON PART ACROSS LUA FILTERS
+
+--[[
+  This function tests the pandoc version againt a target version
+  For Pandoc 2.7.3, PANDOC_VERSION >= "2.8" would be enough but before 2.7.3
+  it is a table object
+]]
+local function pandocAvailable(target)
+  -- this function only work for Pandoc 2.1 and above. It returns false is not
+  if not PANDOC_VERSION then return false end
+  if not target then error("No target version specified in pandocAvailable.") end
+  -- checking major version
+  if target[1] and (not PANDOC_VERSION[1] or PANDOC_VERSION[1] < target[1]) then
+    return false
+  end
+  -- checking minor version
+  if target[2] and (not PANDOC_VERSION[2] or PANDOC_VERSION[2] < target[2]) then
+    return false
+  end
+  -- checking patch version
+  if target[3] and (not PANDOC_VERSION[3] or PANDOC_VERSION[3] < target[3]) then
+    return false
+  end
+  return true
+end
+
 --[[
   About the requirement:
   * PANDOC_VERSION -> 2.1
 ]]
-if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
+if (not pandocAvailable {2,1}) then
     io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
     return {}
 end
+
+-- START OF THE FILTER'S FUNCTIONS
 
 text = require 'text'
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -15,17 +15,13 @@ local function pandocAvailable(target)
   -- this function only work for Pandoc 2.1 and above. It returns false is not
   if not PANDOC_VERSION then return false end
   if not target then error("No target version specified in pandocAvailable.") end
-  -- checking major version
-  if target[1] and (not PANDOC_VERSION[1] or PANDOC_VERSION[1] < target[1]) then
-    return false
-  end
-  -- checking minor version
-  if target[2] and (not PANDOC_VERSION[2] or PANDOC_VERSION[2] < target[2]) then
-    return false
-  end
-  -- checking patch version
-  if target[3] and (not PANDOC_VERSION[3] or PANDOC_VERSION[3] < target[3]) then
-    return false
+  -- checking each version number
+  for i = 1,3 do
+    -- some versions do not have 3 numbers
+    if not PANDOC_VERSION[i] then break end
+    if target[i] and PANDOC_VERSION[i] < target[i] then
+      return false
+    end
   end
   return true
 end

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -25,17 +25,13 @@ local function pandocAvailable(target)
   -- this function only work for Pandoc 2.1 and above. It returns false is not
   if not PANDOC_VERSION then return false end
   if not target then error("No target version specified in pandocAvailable.") end
-  -- checking major version
-  if target[1] and (not PANDOC_VERSION[1] or PANDOC_VERSION[1] < target[1]) then
-    return false
-  end
-  -- checking minor version
-  if target[2] and (not PANDOC_VERSION[2] or PANDOC_VERSION[2] < target[2]) then
-    return false
-  end
-  -- checking patch version
-  if target[3] and (not PANDOC_VERSION[3] or PANDOC_VERSION[3] < target[3]) then
-    return false
+  -- checking each version number
+  for i = 1,3 do
+    -- some versions do not have 3 numbers
+    if not PANDOC_VERSION[i] then break end
+    if target[i] and PANDOC_VERSION[i] < target[i] then
+      return false
+    end
   end
   return true
 end

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -14,14 +14,42 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 ]]
 
+-- COMMON PART ACROSS LUA FILTERS
+
+--[[
+  This function tests the pandoc version againt a target version
+  For Pandoc 2.7.3, PANDOC_VERSION >= "2.8" would be enough but before 2.7.3
+  it is a table object
+]]
+local function pandocAvailable(target)
+  -- this function only work for Pandoc 2.1 and above. It returns false is not
+  if not PANDOC_VERSION then return false end
+  if not target then error("No target version specified in pandocAvailable.") end
+  -- checking major version
+  if target[1] and (not PANDOC_VERSION[1] or PANDOC_VERSION[1] < target[1]) then
+    return false
+  end
+  -- checking minor version
+  if target[2] and (not PANDOC_VERSION[2] or PANDOC_VERSION[2] < target[2]) then
+    return false
+  end
+  -- checking patch version
+  if target[3] and (not PANDOC_VERSION[3] or PANDOC_VERSION[3] < target[3]) then
+    return false
+  end
+  return true
+end
+
 --[[
   About the requirement:
   * PANDOC_VERSION -> 2.1
 ]]
-if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
+if (not pandocAvailable {2,1}) then
   io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
   return {}
 end
+
+-- START OF THE FILTER'S FUNCTIONS
 
 local section_number_table = {0, 0, 0, 0, 0, 0, 0, 0, 0}
 local n_section_number_table = #section_number_table

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -28,21 +28,16 @@ local function pandocAvailable(target)
   -- this function only work for Pandoc 2.1 and above. It returns false is not
   if not PANDOC_VERSION then return false end
   if not target then error("No target version specified in pandocAvailable.") end
-  -- checking major version
-  if target[1] and (not PANDOC_VERSION[1] or PANDOC_VERSION[1] < target[1]) then
-    return false
-  end
-  -- checking minor version
-  if target[2] and (not PANDOC_VERSION[2] or PANDOC_VERSION[2] < target[2]) then
-    return false
-  end
-  -- checking patch version
-  if target[3] and (not PANDOC_VERSION[3] or PANDOC_VERSION[3] < target[3]) then
-    return false
+  -- checking each version number
+  for i = 1,3 do
+    -- some versions do not have 3 numbers
+    if not PANDOC_VERSION[i] then break end
+    if target[i] and PANDOC_VERSION[i] < target[i] then
+      return false
+    end
   end
   return true
 end
-
 
 --[[
   About the requirement:

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -17,15 +17,44 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
+-- COMMON PART ACROSS LUA FILTERS
+
+--[[
+  This function tests the pandoc version againt a target version
+  For Pandoc 2.7.3, PANDOC_VERSION >= "2.8" would be enough but before 2.7.3
+  it is a table object
+]]
+local function pandocAvailable(target)
+  -- this function only work for Pandoc 2.1 and above. It returns false is not
+  if not PANDOC_VERSION then return false end
+  if not target then error("No target version specified in pandocAvailable.") end
+  -- checking major version
+  if target[1] and (not PANDOC_VERSION[1] or PANDOC_VERSION[1] < target[1]) then
+    return false
+  end
+  -- checking minor version
+  if target[2] and (not PANDOC_VERSION[2] or PANDOC_VERSION[2] < target[2]) then
+    return false
+  end
+  -- checking patch version
+  if target[3] and (not PANDOC_VERSION[3] or PANDOC_VERSION[3] < target[3]) then
+    return false
+  end
+  return true
+end
+
+
 --[[
   About the requirement:
   * PANDOC_VERSION -> 2.1
   * pandoc.utils -> 2.1
 ]]
-if (not PANDOC_VERSION) or (PANDOC_VERSION < "2.1") then
+if (not pandocAvailable {2,1}) then
   io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
   return {}
 end
+
+-- START OF THE FILTER'S FUNCTIONS
 
 local stringify_orig = (require 'pandoc.utils').stringify
 


### PR DESCRIPTION
fixes #2099 and will close #2100 

This modifies the CI to check one more pandoc version. it also now test 2.11.4 (last RStudio 1.4.1106 shipped version) and organize the testing matrix. We test 2.7.3, 2.5 and 2.0.0.1 for now. 