### PR TITLE
Update news for v2.7 blog post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ inst/doc
 doc
 Meta
 docs
+reference

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -50,6 +50,8 @@ navbar:
           href: news/index.html
         - text: "------------------"
         - text: "Blog posts"
+        - text: "Version 2.7"
+          href: hhttps://blog.rstudio.com/2021/04/15/2021-spring-rmd-news/
         - text: "Version 2.6"
           href: https://blog.rstudio.com/2020/12/21/rmd-news
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -51,7 +51,7 @@ navbar:
         - text: "------------------"
         - text: "Blog posts"
         - text: "Version 2.7"
-          href: hhttps://blog.rstudio.com/2021/04/15/2021-spring-rmd-news/
+          href: https://blog.rstudio.com/2021/04/15/2021-spring-rmd-news/
         - text: "Version 2.6"
           href: https://blog.rstudio.com/2020/12/21/rmd-news
 


### PR DESCRIPTION
Also updates the `.gitignore` file to include the pkgdown output directory, which is `reference/`