### PR TITLE
use `pandoc_to` directly to determine output type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.7.10
+Version: 2.7.11
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.8
 ================================================================================
 
+- Fix an issue with `citation_package` having no effect when using `.md` file as input to `render()` with latex and PDF output formats (thanks, @andrewheiss, #2113).
+
 - A new internal option `rmarkdown.knit.ext` has been added to control the extension of the intermediary knit output during a rendering. It defaults to `md` to produce `*.knit.md`. Only useful for very advanced usage (#2098).
 
 - `render()` won't produce any `*.utf8.md` intermediary file anymore. This was a leftover from previous versions of **rmarkdown**. Since **knitr** 1.24 and **rmarkdown** 2.0, only UTF-8 input files are allowed. (#2098).

--- a/R/render.R
+++ b/R/render.R
@@ -964,7 +964,7 @@ render <- function(input,
     # if the output format is LaTeX, first convert .md to .tex, and then convert
     # .tex to .pdf via latexmk() if PDF output is requested (in rmarkdown <=
     # v1.8, we used to call Pandoc to convert .md to .tex and .pdf separately)
-    if (output_format$pandoc$keep_tex || knitr::is_latex_output() || pandoc_to %in% c("latex", "beamer")) {
+    if (output_format$pandoc$keep_tex || pandoc_to %in% c("latex", "beamer")) {
       # do not use pandoc-citeproc if needs to build bibliography
       convert(texfile, run_citeproc && !need_bibtex)
       # patch the .tex output generated from the default Pandoc LaTeX template

--- a/R/render.R
+++ b/R/render.R
@@ -964,7 +964,7 @@ render <- function(input,
     # if the output format is LaTeX, first convert .md to .tex, and then convert
     # .tex to .pdf via latexmk() if PDF output is requested (in rmarkdown <=
     # v1.8, we used to call Pandoc to convert .md to .tex and .pdf separately)
-    if (output_format$pandoc$keep_tex || knitr::is_latex_output()) {
+    if (output_format$pandoc$keep_tex || knitr::is_latex_output() || pandoc_to %in% c("latex", "beamer")) {
       # do not use pandoc-citeproc if needs to build bibliography
       convert(texfile, run_citeproc && !need_bibtex)
       # patch the .tex output generated from the default Pandoc LaTeX template


### PR DESCRIPTION

This fixes #2113 

When `.md` file is used instead of `.Rmd` file, **knitr** is not used and so **knitr** option are not set. This means that `knitr::is_latex_output()` will be FALSE. We need to test directly the `pandoc_to` variable retrieved from `output_formats$pandoc$to`. 

This is a quick fix for #2113 but basically we could also replace `knitr::is_latex_output()` as it will do the same when as `knitr::opts$get("rmarkdown.pandoc.to")` will be set to `pandoc_to`. Using `pandoc_to` directly would work.

```diff
diff --git a/R/render.R b/R/render.R
index 9e296cd5..3e933147 100644
--- a/R/render.R
+++ b/R/render.R
@@ -964,7 +964,7 @@ render <- function(input,
     # if the output format is LaTeX, first convert .md to .tex, and then convert
     # .tex to .pdf via latexmk() if PDF output is requested (in rmarkdown <=
     # v1.8, we used to call Pandoc to convert .md to .tex and .pdf separately)
-    if (output_format$pandoc$keep_tex || knitr::is_latex_output()
|| pandoc_to %in% c("latex", "beamer")) {
+    if (output_format$pandoc$keep_tex || pandoc_to %in% c("latex", "beamer")) {
       # do not use pandoc-citeproc if needs to build bibliography
       convert(texfile, run_citeproc && !need_bibtex)
       # patch the .tex output generated from the default Pandoc LaTeX template
```

We could also add a fallback value to `knitr::is_latex_output(fallback)` to internalize this 
This function would 
* checks `knitr::opts$set("out.format")`
* if FALSE, checks `knitr::opts$get("rmarkdown.pandoc.to")`
* if FALSE, checks the fallback format provided.

````r
is_latex_output <- function(fallback) {
    out_format("latex") || pandoc_to(c("latex", "beamer")) || fallback %in% c("latex", "beamer")
}
````

This is required if we want to indeed support `.md` file using `output:` key in the YAML header which is R Markdown thing in the first place - which suppose `.Rmd` extension usually.
