### PR TITLE
Use a predictable file name within a temp folder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@ rmarkdown 2.8
 
 - `rmarkdown::tufte_handout` has been deprecated and will be removed in the future from this package. It has been moved to the **tufte** package since **rmarkdown** 0.9.5 (released on 2016-02-22). Please use `tufte::tufte_handout` instead.
 
+- When rendering a `runtime: shiny` document, an extra temp folder will be used in the output path. With the extra temp random folder in the path, predictable output file names may be used. (#2137)
+
 
 rmarkdown 2.7
 ================================================================================

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -450,8 +450,10 @@ rmd_cached_output <- function(input) {
     }
   } else {
     # It's not cacheable, and should be rendered to a session-specific temporary
-    # file
-    output_dest <- tempfile(fileext = ".html")
+    # directory, but with a predictable file name.
+    tmp_dir <- tempfile()
+    output_dest_name <- paste0(xfun::sans_ext(basename(input)), ".html")
+    output_dest <- file.path(tmp_dir, output_dest_name)
   }
   list(
     cacheable = cacheable,

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -452,7 +452,7 @@ rmd_cached_output <- function(input) {
     # It's not cacheable, and should be rendered to a session-specific temporary
     # directory, but with a predictable file name.
     tmp_dir <- tempfile()
-    output_dest_name <- paste0(xfun::sans_ext(basename(input)), ".html")
+    output_dest_name <- xfun::with_ext(basename(input), ".html")
     output_dest <- file.path(tmp_dir, output_dest_name)
   }
   list(


### PR DESCRIPTION
## Issue

When rendering `runtime: shiny` documents through `shinytest`, any plot figures are put into a `*_files` folder that is random every time a test is run.

This is problematic as the `html` field of the dynamic UI produced in https://github.com/rstudio/rmarkdown/blob/c88635f10ae672115baf6697bc235ce3c41012f0/R/shiny.R#L304-L318

If a plot is produced, `value$html` will contain something similar to 
```html
<p><img src="file847d61950236_files/figure-html/unnamed-chunk-12-1.png" width="960" data-figure-id=fig1 /></p>
```

The problem comes from the random name of `file847d61950236_files`, as it is random every time the rmarkdown document is rendered.
https://github.com/rstudio/rmarkdown/blob/c88635f10ae672115baf6697bc235ce3c41012f0/R/shiny.R#L452-L454

`tempfile()`s do not listen to the `set.seed()` value.

```r
> set.seed(1234); tempfile()
#> [1] "/var/folders/0k/bxg5lhr92sq74mb1d446ql540000gp/T//RtmpTi0WqW/filee5b3219c1a8f"
> set.seed(1234); tempfile()
#> [1] "/var/folders/0k/bxg5lhr92sq74mb1d446ql540000gp/T//RtmpTi0WqW/filee5b3f93b386"
```

Given the random output file name, the `*_files` directory is created from it.
https://github.com/rstudio/rmarkdown/blob/c88635f10ae672115baf6697bc235ce3c41012f0/R/shiny.R#L240-L241

-------------------------


# Fix 

If rmarkdown rendered inside a temp folder within the R session temp folder, then names could be predictable and would not need to worry about clashing.

Ex: Looking at the same `<img>` tag as above when running `rmarkdown::run("index.Rmd")` :
```html
<p><img src="index_files/figure-html/unnamed-chunk-12-1.png" width="960" data-figure-id=fig1></p>
```

`index_files` is a consistent name, but because there was another temp folder used, then there is no clashing.

--------------------

Cautions:

* The temp folder is not deleted until the R session is stopped. (A slow memory leak.)