### PR TITLE
Fix for lost encoding in shiny_prerendered_html.

### DIFF
--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -172,6 +172,7 @@ shiny_prerendered_html <- function(input_rmd, render_args) {
       html_with_deps,
       fixed = TRUE,
       useBytes = TRUE)
+    Encoding(html_with_deps) <- "UTF-8"
   }
   html_with_deps
 }


### PR DESCRIPTION
This provides a fix to shiny_prerendered_html that causes Encoding issues on windows.  This can be demonstrated with a simple learnr::tutorial style document which triggers the affected code.

``````rmd
---
title: "Bad Quotes"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
knitr::opts_chunk$set(echo = TRUE)
```

Single quotes 'text' do not display correctly
``````

This triggers the head replacement code found on [shiny_prerendered.R:168-177](https://github.com/rstudio/rmarkdown/blob/master/R/shiny_prerendered.R#L168-L177).  When sub is called with `useBytes=TRUE` encoding on the string is lost and must be restored which is what the new line Accomplishes.

```r
Encoding(html_with_deps) <- "UTF-8"
```

Without this the line `Single quotes 'text' do not display correctly` is reinterpreted as a Windows native code and when converted back into UTF-8 for output is rendered as  `Single quotes â€˜textâ€™ do not display correctly`.  With this fix the line is correctly rendered.