### PR TITLE
use yaml_metadata_block for preserve_yaml feature when possible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.9.3
+Version: 2.9.5
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 rmarkdown 2.10
 ================================================================================
 
+- `md_document()` will now handle correctly `preserve_yaml` value for all variants and all pandoc versions (#2190). 
+  * with `preserve_yaml = TRUE`, markdown output will keep the YAML metadata block from the Rmd file.
+  * with `preserve_yaml = FALSE`, markdown output will have no YAML metadata block.
+  
+  This fixes a breaking change in Pandoc 2.13 regarding `gfm`, `commonmark` and `commonmark_x` which now supports `yaml_metadata_block` by default (#2118).  
+
 - New supported syntax for Shiny prerendered documents: you can now  use `server: shiny` or `server: type: shiny`.
 
 - Ability to inject additional functions into Shiny prerendered server scope using the "server-extras" context.

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -118,7 +118,7 @@ adapt_md_variant <- function(variant, preserve_yaml) {
       } else {
         variant_extensions
       }
-    }
+    },
     markdown =,
     markdown_phpextra =,
     markdown_github =,

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -50,7 +50,7 @@ md_document <- function(variant = "markdown_strict",
 
 
   # base pandoc options for all markdown output
-  args <- c("--standalone")
+  args <- c(if (preserve_yaml) "--standalone")
 
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -11,11 +11,11 @@
 #' see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 #' @inheritParams html_document
 #' @param variant Markdown variant to produce (defaults to "markdown_strict").
-#'   Other valid values are "commonmark", "markdown_github", "markdown_mmd",
-#'   markdown_phpextra", or even "markdown" (which produces pandoc markdown).
-#'   You can also compose custom markdown variants, see the
-#'   \href{https://pandoc.org/MANUAL.html}{pandoc online documentation}
-#'   for details.
+#'   Other valid values are "commonmark", "gfm", "commonmark_x", "markdown_mmd",
+#'   markdown_phpextra", "markdown_github", or even "markdown" (which produces
+#'   pandoc markdown). You can also compose custom markdown variants, see the
+#'   \href{https://pandoc.org/MANUAL.html}{pandoc online documentation} for
+#'   details.
 #' @param preserve_yaml Preserve YAML front matter in final document.
 #' @param fig_retina Scaling to perform for retina displays. Defaults to
 #'   \code{NULL} which performs no scaling. A setting of 2 will work for all

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown-meta.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown-meta.md
@@ -1,0 +1,5 @@
+---
+title: test
+---
+
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown.md
@@ -1,0 +1,1 @@
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_github-meta.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_github-meta.md
@@ -1,0 +1,5 @@
+---
+title: test
+---
+
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_github.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_github.md
@@ -1,0 +1,1 @@
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_mmd-meta.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_mmd-meta.md
@@ -1,0 +1,5 @@
+---
+title: test
+---
+
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_mmd.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_mmd.md
@@ -1,0 +1,1 @@
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_phpextra-meta.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_phpextra-meta.md
@@ -1,0 +1,5 @@
+---
+title: test
+---
+
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_phpextra.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_phpextra.md
@@ -1,0 +1,1 @@
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_strict-meta.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_strict-meta.md
@@ -1,0 +1,5 @@
+---
+title: test
+---
+
+content

--- a/tests/testthat/_snaps/md_document/yaml-block-markdown_strict.md
+++ b/tests/testthat/_snaps/md_document/yaml-block-markdown_strict.md
@@ -1,0 +1,1 @@
+content

--- a/tests/testthat/test-md_document.R
+++ b/tests/testthat/test-md_document.R
@@ -59,7 +59,7 @@ test_that("md_document() can preserve yaml", {
   expect_snapshot_md <- function(variant, preserve_yaml) {
     rmd <- local_rmd_file(c("---", "title: test", "---", "", "content"))
     res <- render(rmd, md_document(variant, preserve_yaml = preserve_yaml), quiet = TRUE)
-    expect_snapshot_file(res, sprintf("yaml-block-%s%s.md", variant, if(preserve_yaml) "-meta" else ""))
+    expect_snapshot_file(res, sprintf("yaml-block-%s%s.md", variant, if (preserve_yaml) "-meta" else ""))
   }
   expect_snapshot_md("markdown", preserve_yaml = FALSE)
   expect_snapshot_md("markdown_phpextra", preserve_yaml = FALSE)

--- a/tests/testthat/test-md_document.R
+++ b/tests/testthat/test-md_document.R
@@ -1,0 +1,75 @@
+local_edition(3)
+
+test_that("adapt_md_variant() adds extensions to markdown variants", {
+  expect_identical(adapt_md_variant("markdown", TRUE), "markdown+yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_phpextra", TRUE), "markdown_phpextra+yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_mmd", TRUE), "markdown_mmd+yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_strict", TRUE), "markdown_strict+yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_github", TRUE), "markdown_github+yaml_metadata_block")
+
+  expect_identical(adapt_md_variant("markdown", FALSE), "markdown-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_phpextra", FALSE), "markdown_phpextra-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_mmd", FALSE), "markdown_mmd-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_strict", FALSE), "markdown_strict-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_github", FALSE), "markdown_github-yaml_metadata_block")
+
+  expect_identical(adapt_md_variant("markdown+yaml_metadata_block", TRUE), "markdown+yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown-yaml_metadata_block", TRUE), "markdown-yaml_metadata_block+yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown+yaml_metadata_block", FALSE), "markdown+yaml_metadata_block-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown-yaml_metadata_block", FALSE), "markdown-yaml_metadata_block")
+
+  # ignore correctly unsupported variants
+  expect_identical(adapt_md_variant("markdown_new", TRUE), "markdown_new")
+  expect_identical(adapt_md_variant("markdown_new", FALSE), "markdown_new")
+})
+
+test_that("adapt_md_variant() ignored unknown variants", {
+  expect_identical(adapt_md_variant("markdown_new", TRUE), "markdown_new")
+  expect_identical(adapt_md_variant("markdown_new", FALSE), "markdown_new")
+})
+
+test_that("adapt_md_variant() with special variants (pandoc >= 2.13)", {
+  skip_if_not_pandoc('2.13')
+  expect_identical(adapt_md_variant("commonmark", TRUE), "commonmark+yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm", TRUE), "gfm+yaml_metadata_block")
+  expect_identical(adapt_md_variant("commonmark_x", TRUE), "commonmark_x+yaml_metadata_block")
+  expect_identical(adapt_md_variant("commonmark", FALSE), "commonmark-yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm", FALSE), "gfm-yaml_metadata_block")
+  expect_identical(adapt_md_variant("commonmark_x", FALSE), "commonmark_x-yaml_metadata_block")
+
+  expect_identical(adapt_md_variant("gfm+yaml_metadata_block", TRUE), "gfm+yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm-yaml_metadata_block", TRUE), "gfm-yaml_metadata_block+yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm+yaml_metadata_block", FALSE), "gfm+yaml_metadata_block-yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm-yaml_metadata_block", FALSE), "gfm-yaml_metadata_block")
+
+})
+
+test_that("adapt_md_variant() with special variants (pandoc < 2.13)", {
+  skip_if_pandoc('2.13')
+  expect_identical(adapt_md_variant("commonmark", TRUE), "commonmark")
+  expect_identical(adapt_md_variant("gfm", TRUE), "gfm")
+  expect_identical(adapt_md_variant("commonmark_x", TRUE), "commonmark_x")
+  expect_identical(adapt_md_variant("commonmark", FALSE), "commonmark")
+  expect_identical(adapt_md_variant("gfm", FALSE), "gfm")
+  expect_identical(adapt_md_variant("commonmark_x", FALSE), "commonmark_x")
+})
+
+test_that("md_document() can preserve yaml", {
+  skip_on_cran() # avoid pandoc issue on CRAN
+  expect_snapshot_md <- function(variant, preserve_yaml) {
+    rmd <- local_rmd_file(c("---", "title: test", "---", "", "content"))
+    res <- render(rmd, md_document(variant, preserve_yaml = preserve_yaml), quiet = TRUE)
+    expect_snapshot_file(res, sprintf("yaml-block-%s%s.md", variant, if(preserve_yaml) "-meta" else ""))
+  }
+  expect_snapshot_md("markdown", preserve_yaml = FALSE)
+  expect_snapshot_md("markdown_phpextra", preserve_yaml = FALSE)
+  expect_snapshot_md("markdown_mmd", preserve_yaml = FALSE)
+  expect_snapshot_md("markdown_strict", preserve_yaml = FALSE)
+  expect_snapshot_md("markdown_github", preserve_yaml = FALSE)
+  expect_snapshot_md("markdown", preserve_yaml = TRUE)
+  expect_snapshot_md("markdown_phpextra", preserve_yaml = TRUE)
+  expect_snapshot_md("markdown_mmd", preserve_yaml = TRUE)
+  expect_snapshot_md("markdown_strict", preserve_yaml = TRUE)
+  expect_snapshot_md("markdown_github", preserve_yaml = TRUE)
+})
+


### PR DESCRIPTION
This will fix #2118 and modify a bit how `md_document()` is working internally

* We use a standalone (`--standalone`) document if `preserve_yaml = TRUE`
* We try to add / remove the extension `yaml_metadata_block` depending on the value of `variant` and `preserve_yaml`. This is because some formats have the extension set or unset by default, and also depending of the pandoc version. 
* We add some mechanism to handle parsing and setting those extensions. They could be externalize at some point to be used in other functions. 

Doing this should handle correctly most of the case. Let's add that `--standalone` flag will produce this header, and that some format will have special header if not yaml: 
* `markdown` will have a [`pandoc_title_block`](https://pandoc.org/MANUAL.html#extension-pandoc_title_block) if not a YAML block
* `markdown_mmd` will have `mmd_title_block` if YAML block is unset. 

For now, this is the behavior we apply for all variants: 
* `md_document(preserve_yaml = TRUE)` will always produce a YAML block. 
* `md_document(preserve_yaml = FALSE)` will always produce no YAML block.

And this is currently not working which is the main issue of #2118

Should we do something simpler or does it seems like a right thing to do ? 