### PR TITLE
Add a forced mode to use bslib for bootstrap

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,6 +7,7 @@
 ^tests/testthat/site/_site/
 ^tests/testthat/site/lib/
 ^tests/testthat/site/.*_files/
+^tests/manual/
 ^\.github$
 ^pkgdown$
 ^doc$

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -41,6 +41,8 @@ html_dependency_jqueryui <- function() {
 #' @export
 html_dependency_bootstrap <- function(theme) {
   theme <- resolve_theme(theme)
+
+  # Bootstrap with bslib package
   if (is_bs_theme(theme)) {
     # TODO: would it make sense for these additional rules to come as a part of
     # bslib::bs_theme_dependencies() (for consistency sake)?
@@ -53,6 +55,8 @@ html_dependency_bootstrap <- function(theme) {
     )
     return(bslib::bs_theme_dependencies(theme))
   }
+
+  # Rmarkdown own BS3 dependency
   htmlDependency(
     name = "bootstrap",
     version = "3.3.5",
@@ -87,17 +91,38 @@ bootstrap_dependencies <- function(theme) {
 
 resolve_theme <- function(theme) {
   # theme = NULL means no Bootstrap
-  if (is.null(theme)) return(theme)
+  if (is.null(theme)) {
+    return(theme)
+  }
+
   # Bootstrap/Bootswatch 3 names (backwards-compatibility)
   if (is.character(theme)) {
     if (length(theme) != 1) {
       stop2("`theme` must be character vector of length 1.")
     }
-    if (theme %in% c("bootstrap", "default")) {
-      return("bootstrap")
+    if (identical(theme, "default")) {
+      theme <- "bootstrap"
     }
+
+    # special handling triggered when bootstrap folder removed from installation folder
+    # In this case, bslib is used as default.
+    bslib_forced_mode <- getOption("rmarkdown.bslib_forced_mode", FALSE)
+    if (bslib_forced_mode || !dir.exists(pkg_file("rmd/h/bootstrap"))) {
+      # we are in special bslib default mode, theme is tweaked to be a list
+      if (!is_available("bslib")) {
+        stop2(
+          "bslib package is required and must be installed",
+          if (bslib_forced_mode) " when in special bslib forced mode",
+          "."
+        )
+      }
+      return(bslib::bs_theme(version = 3, bootswatch = theme))
+    }
+
     return(match.arg(theme, themes()))
   }
+
+  # Bootstrap theme handled by bslib package
   if (is.list(theme)) {
     if (!is_available("bslib")) {
       stop2("Providing a list to `theme` requires the bslib package.")
@@ -131,11 +156,8 @@ is_bs_theme <- function(theme) {
 }
 
 theme_version <- function(theme) {
-  if (is_bs_theme(theme)) {
-    bslib::theme_version(theme)
-  } else {
-    substr(html_dependency_bootstrap("default")$version, 1, 1)
-  }
+  if (is_bs_theme(theme)) return(bslib::theme_version(theme))
+  substr(html_dependency_bootstrap("default")$version, 1, 1)
 }
 
 

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -91,9 +91,7 @@ bootstrap_dependencies <- function(theme) {
 
 resolve_theme <- function(theme) {
   # theme = NULL means no Bootstrap
-  if (is.null(theme)) {
-    return(theme)
-  }
+  if (is.null(theme)) return(theme)
 
   # Bootstrap/Bootswatch 3 names (backwards-compatibility)
   if (is.character(theme)) {

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -521,20 +521,22 @@ knitr_options_html <- function(fig_width,
   knitr_options(opts_chunk = opts_chunk)
 }
 
+# CSS files in inst/rmd/h/bootstrap/css
 themes <- function() {
-  c("default",
+  c("default", # keep for backward compatibility reason, changed to 'bootstrap' internally
+    "bootstrap",
     "cerulean",
-    "journal",
-    "flatly",
-    "darkly",
-    "readable",
-    "spacelab",
-    "united",
     "cosmo",
+    "darkly",
+    "flatly",
+    "journal",
     "lumen",
     "paper",
+    "readable",
     "sandstone",
     "simplex",
+    "spacelab",
+    "united",
     "yeti")
 }
 

--- a/tests/manual/bslib-forced-mode/.gitignore
+++ b/tests/manual/bslib-forced-mode/.gitignore
@@ -1,0 +1,2 @@
+*_files/
+*.html

--- a/tests/manual/bslib-forced-mode/render.R
+++ b/tests/manual/bslib-forced-mode/render.R
@@ -1,0 +1,26 @@
+# TO RUN IN A CLEAN SESSION
+# install packages in a temp lib
+withr::local_temp_libpaths(action = "replace")
+.libPaths()
+# In RStudio IDE, answer no if asked to restart R
+install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
+pak::local_install_dev_deps(".")
+
+# remove bootstrap folder
+bs_folder <- system.file("rmd/h/bootstrap", package = "rmarkdown", lib.loc = .libPaths()[1])
+dir.exists(bs_folder)
+unlink(bs_folder, recursive = TRUE)
+dir.exists(bs_folder)
+
+# check bslib is used and not internal bootstrap
+library(rmarkdown,lib.loc = .libPaths()[1])
+withr::local_dir("tests/manual/bslib-forced-mode/")
+file <- "test.Rmd"
+render(file, html_document(self_contained = FALSE))
+render(file, html_document(self_contained = FALSE, toc = TRUE, toc_float = TRUE))
+render(file, html_document(self_contained = FALSE, code_download = TRUE))
+render(file, html_document(self_contained = FALSE, code_folding = "hide"))
+render(file, html_document(self_contained = FALSE, theme = "cerulean"))
+
+# reset the environment
+withr::deferred_run()

--- a/tests/manual/bslib-forced-mode/test.Rmd
+++ b/tests/manual/bslib-forced-mode/test.Rmd
@@ -1,0 +1,52 @@
+---
+title: "Example 1"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+# About R Markdown
+
+This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
+
+When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
+
+```{r cars}
+summary(cars)
+```
+
+## Including Plots
+
+You can also embed plots, for example:
+
+```{r pressure, echo=FALSE}
+plot(pressure)
+```
+
+Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code that generated the plot.
+
+## Some tabs {.tabset}
+
+### Tab 1
+
+Content 1
+
+### Tab 2
+
+Content 2
+
+## Other features 
+
+### Some math
+
+$$
+z = x/y + \alpha
+$$
+
+### Buttons 
+
+```{r, echo = FALSE}
+htmltools::tags$button(type = "button", class = "btn btn-primary", "Primary")
+```


### PR DESCRIPTION
Use bslib package for boostrap HTML dependency instead of rmarkdown internal hard HTML dependency

This PR adds an opt-in mode to force the use of **bslib** for bootstrap dependency

- Either opt-in by using setting option `rmarkdown.bslib_forced_mode` to TRUE
- Or either when `rmd/h/bootstrap` folder is not more present in installed directory in local library

When doing that, this will force the use of Boostrap using **bslib**. Currently version 3 will be used, and any string theme will be used as `boostwatch` theme. This means that when forced mode is ON this 

````yaml
output:
  html_document:
    theme: cerulean
````

will use `bslib::bs_theme(version = 3, theme = "cerulean")`

Without forced mode, it would have been 

```yaml
output:
  html_document:
    theme: 
    version: 3
      bootswatch: cerulean
```

This PR can be merged safely I believe for next version as it will only have effet when activated. 

This PR is the first step to try using **bslib** as a default for **rmarkdown** 

cc @apreshill @yihui 