### PR TITLE
Prerender shiny rmd in separate environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ rmarkdown 2.11
 
 - `pandoc_citeproc_convert()` now handles correctly bib file containing specific UTF-8 characters on non default UTF-8 systems like Windows (thanks, @mitchelloharawild, #2195).
 
+- Shiny prerendered documents are now pre-rendered in a child environment to avoid allowing the results of static code chunks to exist in the Shiny app environment (@gadenbuie, #2203).
+
 
 rmarkdown 2.10
 ================================================================================

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -120,7 +120,7 @@ shiny_prerendered_html <- function(input_rmd, render_args) {
     args <- merge_lists(list(input = input_rmd), render_args)
     # force prerender to execute in separate environment to ensure that
     # running w/ prerender step is equivalent to running the prerendered app
-    args$envir <- new.env(parent = args$envir)
+    args$envir <- new.env(parent = args$envir %||% globalenv())
 
     # execute the render
     rendered_html <- do.call(render, args)

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -117,9 +117,12 @@ shiny_prerendered_html <- function(input_rmd, render_args) {
 
   # prerender if necessary
   if (prerender) {
+    args <- merge_lists(list(input = input_rmd), render_args)
+    # force prerender to execute in separate environment to ensure that
+    # running w/ prerender step is equivalent to running the prerendered app
+    args$envir <- new.env(parent = args$envir)
 
     # execute the render
-    args <- merge_lists(list(input = input_rmd), render_args)
     rendered_html <- do.call(render, args)
   }
 


### PR DESCRIPTION
When running an rmarkdown document with `runtime: shinyrmd` or `shiny_prerendered`, if the document has not yet been pre-rendered or if the pre-render is out of date, `rmarkdown::run()` will first call `render()` on the document.

Because the document rendering happens in the same environment as the subsequent `run()` step, code chunks that should be pre-render only are leaked into the shiny app, for the first run only. On subsequent runs of the same document, objects created by normal R chunks will not be available to the shiny app.

This is particularly important for learnr, where we expect that code and functions written in standard R chunks are not made available to exercises — in other words the results of static R chunks should not be accessible from the running shiny app. 

In the following example, we expect that submitting `local` in the exercise should always return `base::local`, but on the first `rmarkdown::run()` call it will be masked by the `local` defined in the presumed static R chunk `local-only`.

````
---
title: "Tutorial"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)
knitr::opts_chunk$set(echo = FALSE)
global <- "hello, global"
```

## Topic 1

### Exercise 

```{r local-only}
local <- "hello, local"
```

```{r two-plus-two, exercise=TRUE}
local
```
````

This PR addresses the above problem by using a separate environment for rendering the shinyrmd document. To avoid surprises, the pre-render environment is a child of the requested rendering environment EDIT: unless that environment is `NULL`, in which case we use a child of the global env.