### PR TITLE
Minimal example of server-side math in rmarkdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,6 +101,7 @@ Suggests:
     tibble,
     fs,
     rsconnect,
+    katex (>= 1.3.0),
     withr (>= 2.4.2),
     bslib (>= 0.2.5.1),
     sass (>= 0.4.0)

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -63,6 +63,8 @@
 #'  MathJax CDN. The "local" option uses a local version of MathJax (which is
 #'  copied into the output directory). You can pass an alternate URL or pass
 #'  \code{NULL} to exclude MathJax entirely.
+#'@param katex if \code{TRUE} math is rendered server-side using the katex package,
+#' such that mathjax is not needed in the html. This implies \code{mathjax = FALSE}.
 #'@param section_divs Wrap sections in \code{<div>} tags, and attach identifiers to the
 #'  enclosing \code{<div>} rather than the header itself.
 #'@param template Pandoc template to use for rendering. Pass "default" to use
@@ -231,6 +233,7 @@ html_document <- function(toc = FALSE,
                           highlight = "default",
                           mathjax = "default",
                           template = "default",
+                          katex = FALSE,
                           extra_dependencies = NULL,
                           css = NULL,
                           includes = NULL,
@@ -468,6 +471,13 @@ html_document <- function(toc = FALSE,
     args
   }
 
+  post_processor <- if(isTRUE(katex)){
+    mathjax <- FALSE
+    function(metadata, input_file, output_file, clean, verbose) {
+      katex::render_math_in_html(output_file, output = output_file)
+    }
+  }
+
   # return format
   output_format(
     knitr = knitr_options_html(fig_width, fig_height, fig_retina, keep_md, dev),
@@ -480,6 +490,7 @@ html_document <- function(toc = FALSE,
     pre_knit = pre_knit,
     post_knit = post_knit,
     pre_processor = pre_processor,
+    post_processor = post_processor,
     on_exit = on_exit,
     base_format = html_document_base(theme = theme,
                                      self_contained = self_contained,

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -24,6 +24,7 @@ html_document(
   highlight = "default",
   mathjax = "default",
   template = "default",
+  katex = FALSE,
   extra_dependencies = NULL,
   css = NULL,
   includes = NULL,
@@ -125,6 +126,9 @@ built-in template; pass a path to use a custom template that you've created.
 Note that if you don't use the "default" template then some features of
 \code{html_document} won't be available (see the Templates section below for
 more details).}
+
+\item{katex}{if \code{TRUE} math is rendered server-side using the katex package,
+such that mathjax is not needed in the html. This implies \code{mathjax = FALSE}.}
 
 \item{extra_dependencies, ...}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link{html_document_base}}}


### PR DESCRIPTION
This is mostly to test right now (it uses a feature in the katex package that is not yet on CRAN).

Here is a minimal example of what server-side math rendering could look like. I used this example [math.Rmd](https://gist.github.com/jeroen/32b8d15c7a0d373ab29714c4e5b479fe#file-math-rmd). In the front-matter you can flip `katex: true` to compare the mathjax output vs katex output.

I'd be interested to hear if this seems to work as expected.

