### PR TITLE
Add an option to opt-out using header-attrs HTML dependency in `html_document_base()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.12
 ================================================================================
 
-- Added an option `rmarkdown.html_dependency.header_attr`, `TRUE` by default. It can be set to `FALSE` to opt-out using `html_dependency_header_attrs()` HTML dependency in document based on `html_document_base()` which is used by default when Pandoc 2.9 and above is used (thanks, @salim-b, rstudio/bookdown#865, @maelle, r-lib/downlit#1538).
+- Added a global option `rmarkdown.html_dependency.header_attr` (`TRUE` by default). It can be set to `FALSE` to opt-out the HTML dependency `html_dependency_header_attrs()` in documents based on `html_document_base()` (thanks, @salim-b rstudio/bookdown#865, @maelle r-lib/downlit#1538).
 
 - `draft()` now works with `devtools::load_all()` and **testthat** when used in other packages. 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.12
 ================================================================================
 
+- Added an option `rmarkdown.html_dependency.header_attr`, `TRUE` by default. It can be set to `FALSE` to opt-out using `html_dependency_header_attrs()` HTML dependency in document based on `html_document_base()` which is used by default when Pandoc 2.9 and above is used (thanks, @salim-b, rstudio/bookdown#865, @maelle, r-lib/downlit#1538).
+
 - `draft()` now works with `devtools::load_all()` and **testthat** when used in other packages. 
 
 rmarkdown 2.11

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -455,12 +455,14 @@ html_dependency_rsiframe <- function() {
 # Pandoc 2.9 adds attributes on both headers and their parent divs. We remove
 # the ones on headers since they are unnecessary (#1723).
 html_dependency_header_attrs <- function() {
-  if (pandoc_available('2.9')) list(
-    htmlDependency(
-      "header-attrs",
-      version = packageVersion("rmarkdown"),
-      src = pkg_file("rmd/h/pandoc"),
-      script = "header-attrs.js"
+  if (getOption('rmarkdown.html_dependency.header_attr', TRUE) && pandoc_available('2.9')) {
+    list(
+      htmlDependency(
+        "header-attrs",
+        version = packageVersion("rmarkdown"),
+        src = pkg_file("rmd/h/pandoc"),
+        script = "header-attrs.js"
+      )
     )
-  )
+  }
 }

--- a/tests/testthat/test-html_dependencies.R
+++ b/tests/testthat/test-html_dependencies.R
@@ -196,3 +196,8 @@ test_that("html_dependencies_fonts loads the correct fonts dep", {
   expect_identical(html_dependencies_fonts(FALSE, TRUE), list(io))
   expect_identical(html_dependencies_fonts(TRUE, TRUE), list(fa, io))
 })
+
+test_that("header-attr can be opt-out", {
+  withr::local_options(list(rmarkdown.html_dependency.header_attr = FALSE))
+  expect_null(html_dependency_header_attrs())
+})


### PR DESCRIPTION
Currently we use a JS script in a custom `html_dependency_header_attrs()` so that we can "fix" breaking pandoc behavior from change in 2.8. We do that when Pandoc 2.9+ is used. 

With **rmarkdown** we currently use pandoc's `--section-div` flag by default. This will create a `<div>` to encapsulate header. When attributes are added on header, they are moved to this section div. Behavior changed in Pandoc 2.8

* Text to convert using `pandoc --to html4 --section-div`
  ```markdown
  # hello {.anchor #id attr='val'}
  ```

* With Pandoc 2.7.3 - nothing added on header itself - all move to section div
  ```html
  <div id="id" class="section level1 anchor" lang="en">
  <h1>hello</h1>
  </div>
  ```

* With Pandoc 2.8 - **breaking change** - class is not moved anymore 
  ```html
  <div id="id" class="section level1">
  <h1 class="anchor" lang="en">hello</h1>
  </div>
  ```

* With Pandoc 2.9 to 2.13 - only id is moved now.
  ```html
  <div id="id" class="section level1 anchor" lang="en">
  <h1 class="anchor" lang="en">hello</h1>
  </div>
  ```

The change of Pandoc regarding class was breaking some tools (rstudio/rmarkdown#1723, rstudio/rmarkdown#1732) and so it was added a JS script to remove the class on header. 


This could no be desired always like rstudio/bookdown#865 and r-lib/pkgdown#1538. 

So this PR adds an option to opt-out including the HTML dependency. This would solve the two issue above IMO


