### PR TITLE
Fix the syntax highlighting of |> in LaTeX/PDF output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmarkdown
 Type: Package
 Title: Dynamic Documents for R
-Version: 2.11.2
+Version: 2.11.3
 Authors@R: c(
   person("JJ", "Allaire", role = "aut", email = "jj@rstudio.com"),
   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -188,6 +188,17 @@ pdf_document <- function(toc = FALSE,
                       output_dir)
   }
 
+  post_processor <- function(metadata, input_file, output_file, clean, verbose) {
+    # TODO: remove this temporary fix after the syntax highlighting problem is
+    # fixed in Pandoc https://github.com/rstudio/bookdown/issues/1157
+    x <- read_utf8(output_file)
+    s <- '\\SpecialCharTok{|}\\ErrorTok{\\textgreater{}}'
+    if (length(grep(s, x, fixed = TRUE)) == 0) return(output_file)
+    x <- gsub(s, '\\SpecialCharTok{|\\textgreater{}}', x, fixed = TRUE)
+    write_utf8(x, output_file)
+    output_file
+  }
+
   intermediates_generator <- function(...) {
     general_intermediates_generator(saved_files_dir, ...)
   }
@@ -207,6 +218,7 @@ pdf_document <- function(toc = FALSE,
     keep_md = keep_md,
     df_print = df_print,
     pre_processor = pre_processor,
+    post_processor = post_processor,
     intermediates_generator = intermediates_generator
   )
 }


### PR DESCRIPTION
See https://github.com/rstudio/bookdown/issues/1157#issuecomment-932776299

Again, this is just a temporary fix, and may be removed in the future after #2196 is fixed.