### PR TITLE
Add a GHA workflow to generate rmarkdown CITATION.cff file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^docs$
 ^reference$
 ^vignettes/articles$
+^CITATION\.cff$

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::cffr, any::v8, local::.
+          extra-packages: any::cffr, any::V8, local::.
 
       - name: Update CITATION.cff
         run: |

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -1,0 +1,51 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# The action runs when:
+# - A new release is published
+# - The DESCRIPTION or inst/CITATION are modified
+# - Can be run manually
+# For customizing the triggers, visit https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+  release:
+    types: [published]
+  push:
+    paths:
+      - DESCRIPTION
+      - inst/CITATION
+  workflow_dispatch:
+
+name: Update CITATION.cff
+
+jobs:
+  update-citation-cff:
+    runs-on: macos-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::cffr, any::v8, local::.
+
+      - name: Update CITATION.cff
+        run: |
+          library(cffr)
+          # Customize with your own code
+          # See https://docs.ropensci.org/cffr/articles/cffr.html
+          # Write your own keys
+          mykeys <- list()
+          # Create your CITATION.cff file
+          cff_write("rmarkdown", keys = mykeys)
+        shell: Rscript {0}
+
+      - name: Commit results
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add CITATION.cff
+          git commit -m 'Update CITATION.cff' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,113 @@
+# -----------------------------------------------------------
+# CITATION file created with {cffr} R package, v0.1.1
+# See also: https://docs.ropensci.org/cffr/
+# -----------------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "rmarkdown" in publications use:'
+type: software
+license: GPL-3.0-only
+title: 'rmarkdown: Dynamic Documents for R'
+version: 2.11.4
+abstract: Convert R Markdown documents into a variety of formats.
+authors:
+- family-names: Allaire
+  given-names: JJ
+  email: jj@rstudio.com
+- family-names: Xie
+  given-names: Yihui
+  email: xie@yihui.name
+  orcid: https://orcid.org/0000-0003-0645-5666
+- family-names: McPherson
+  given-names: Jonathan
+  email: jonathan@rstudio.com
+- family-names: Luraschi
+  given-names: Javier
+  email: javier@rstudio.com
+- family-names: Ushey
+  given-names: Kevin
+  email: kevin@rstudio.com
+- family-names: Atkins
+  given-names: Aron
+  email: aron@rstudio.com
+- family-names: Wickham
+  given-names: Hadley
+  email: hadley@rstudio.com
+- family-names: Cheng
+  given-names: Joe
+  email: joe@rstudio.com
+- family-names: Chang
+  given-names: Winston
+  email: winston@rstudio.com
+- family-names: Iannone
+  given-names: Richard
+  email: rich@rstudio.com
+  orcid: https://orcid.org/0000-0003-3925-190X
+preferred-citation:
+  type: manual
+  title: 'rmarkdown: Dynamic Documents for R'
+  authors:
+  - family-names: Allaire
+    given-names: JJ
+  - family-names: Xie
+    given-names: Yihui
+  - family-names: McPherson
+    given-names: Jonathan
+  - family-names: Luraschi
+    given-names: Javier
+  - family-names: Ushey
+    given-names: Kevin
+  - family-names: Atkins
+    given-names: Aron
+  - family-names: Wickham
+    given-names: Hadley
+  - family-names: Cheng
+    given-names: Joe
+  - family-names: Chang
+    given-names: Winston
+  - family-names: Iannone
+    given-names: Richard
+  year: '2021'
+  url: https://github.com/rstudio/rmarkdown
+repository: https://CRAN.R-project.org/package=rmarkdown
+repository-code: https://github.com/rstudio/rmarkdown
+url: https://pkgs.rstudio.com/rmarkdown/
+contact:
+- family-names: Xie
+  given-names: Yihui
+  email: xie@yihui.name
+  orcid: https://orcid.org/0000-0003-0645-5666
+keywords:
+- literate-programming
+- markdown
+- pandoc
+- r
+- r-package
+- rmarkdown
+references:
+- type: book
+  title: 'R Markdown: The Definitive Guide'
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+  - family-names: Allaire
+    given-names: J.J.
+  - family-names: Grolemund
+    given-names: Garrett
+  publisher:
+    name: Chapman and Hall/CRC
+  year: '2018'
+  url: https://bookdown.org/yihui/rmarkdown
+- type: book
+  title: R Markdown Cookbook
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+  - family-names: Dervieux
+    given-names: Christophe
+  - family-names: Riederer
+    given-names: Emily
+  publisher:
+    name: Chapman and Hall/CRC
+  year: '2020'
+  url: https://bookdown.org/yihui/rmarkdown-cookbook

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.3
+Version: 2.11.4
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),


### PR DESCRIPTION
close #2210

This is a first try to add an action for this. 

Using https://docs.ropensci.org/cffr/reference/cff_gha_update.html and small tweak. **rmarkdown** CITATION files works best on installed version due to the code in `inst/CITATION` using `meta$Authors` and not note `meta$Author@R` 