### PR TITLE
Add dir variable to HTML templates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.5
+Version: 2.11.6
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ rmarkdown 2.12
         depth: 2 # max depth to apply anchor on (default to max which is 6)
   ```
   Customizing using a css rule is still possible. Detailed explanation and examples have been added in `?html_document`.
+  
+- Added support for Pandoc's `dir` variable in HTML templates. This is the second [Language Variables](https://pandoc.org/MANUAL.html#language-variables) after `lang`. 
 
 rmarkdown 2.11
 ================================================================================

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
+<html$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 
 <head>
 

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
+<html$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 <head>
   <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
 

--- a/inst/rmd/slidy/default.html
+++ b/inst/rmd/slidy/default.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />


### PR DESCRIPTION
This closes #2063 by adding the variable to the different templates using a if clause. 

doc about this attribute: https://developer.mozilla.org/fr/docs/Web/HTML/Global_attributes/dir