### PR TITLE
add insert image rstudio addins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -81,7 +81,9 @@ Suggests:
     tibble,
     tufte,
     vctrs,
-    withr (>= 2.4.2)
+    withr (>= 2.4.2),
+    rstudioapi,
+    miniUI
 VignetteBuilder: knitr
 Config/Needs/website: rstudio/quillt, pkgdown
 Encoding: UTF-8

--- a/R/addins.R
+++ b/R/addins.R
@@ -1,0 +1,12 @@
+# execute code in the site root dir
+pkg_file = function(..., mustWork = TRUE) {
+  system.file(..., package = 'rmarkdown', mustWork = mustWork)
+}
+
+in_root = function(expr) xfun::in_dir(getwd(), expr)
+
+source_addin = function(file) in_root(sys.source(
+  pkg_file('scripts', file), envir = new.env(parent = globalenv()),
+  keep.source = FALSE
+))
+insert_image_addin = function() source_addin('insert_image.R')

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,4 @@
+Name: Insert Image
+Description: Insert an external image into a R Markdown document.
+Binding: insert_image_addin
+Interactive: true

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -11,6 +11,8 @@ path = xfun::relative_path(path)
 # check blogdown
 blogdown <- try(blogdown:::site_root(),TRUE)
 if(class(blogdown) %in% 'try-error'){
+  imgdir = file.path('images')
+}else{
   imgdir = if (bundle <- blogdown:::bundle_index(path)) {
     file.path(dirname(path), 'images')
   } else {
@@ -19,8 +21,6 @@ if(class(blogdown) %in% 'try-error'){
       paste0(xfun::sans_ext(basename(path)), '_files')
     )
   }
-}else{
-  imgdir = file.path('images')
 }
 
 shiny::runGadget(
@@ -90,7 +90,15 @@ shiny::runGadget(
         })
       }
       image_code = function() {
-        s = target
+        s = if(class(blogdown) %in% 'try-error'){
+          if (bundle) substring(target, nchar(dirname(path)) + 2) else paste0(
+            ifelse(getOption('blogdown.insertimage.usebaseurl', FALSE),
+                   blogdown:::load_config()$baseurl, '/'),
+            gsub('^static/', '', target)
+          )
+        }else{
+          target
+        }
         w = input$w; h = input$h; alt = input$alt
         if (w == '' && h == '') {
           paste0('![', alt, '](', s, ')')
@@ -117,4 +125,3 @@ shiny::runGadget(
   stopOnCancel = FALSE,
   viewer = shiny::dialogViewer('Add external image to a R Markdown document', height = 380)
 )
-

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -1,0 +1,99 @@
+txt_input = function(..., width = '100%') shiny::textInput(..., width = width)
+
+ctx = rstudioapi::getSourceEditorContext()
+if (ctx$path == '') stop(
+  'Please select the source file before using this addin', call. = FALSE
+)
+ctx_ext = tolower(xfun::file_ext(ctx$path))
+
+path = xfun::normalize_path(ctx$path)
+path = xfun::relative_path(path)
+
+imgdir = file.path('images')
+
+shiny::runGadget(
+  miniUI::miniPage(miniUI::miniContentPanel(
+    shiny::fillRow(
+      shiny::fileInput('newimg', 'Image', placeholder = 'Select external image'),
+      shiny::column(width = 6, offset = 2, shiny::uiOutput('overbutton')),
+      height = '90px'
+    ),
+    shiny::fillRow(
+      txt_input('w', 'Width', '', '(optional) e.g., 400px or 80%'),
+      txt_input('h', 'Height', '', '(optional) e.g., 200px'),
+      height = '70px'
+    ),
+    shiny::fillRow(
+      txt_input('alt', 'Alternative text', '', '(optional but recommended) e.g., awesome screenshot'),
+      height = '70px'
+    ),
+    shiny::fillRow(
+      txt_input('target', 'Target file path', '', '(optional) customize if necessary'),
+      height = '70px'
+    ),
+    miniUI::gadgetTitleBar(NULL)
+  )),
+  server = function(input, output, session) {
+    shiny::observeEvent(input$newimg, {
+      shiny::updateTextInput(session, 'target', value = file.path(imgdir, input$newimg$name))
+    })
+    shiny::observeEvent(input$target, {
+      output$overbutton = shiny::renderUI(if (file.exists(input$target))
+        shiny::radioButtons(
+          'overwrite', 'Target image exists. Overwrite it?',
+          inline = TRUE, c('Yes' = TRUE, 'No' = FALSE), selected = FALSE
+        )
+      )
+    })
+    shiny::observeEvent(input$done, {
+      if (is.null(input$newimg)) return(warning('You have to choose an image!',call. = FALSE))
+      target = input$target
+      if (file.exists(target)) {
+        if (!as.logical(input$overwrite)) warning(
+          'The image already exists and you chose not to overwrite it! ',
+          'Linking to the previous version of the image.', call. = FALSE
+        )
+      }
+      xfun:::dir_create(dirname(target))
+      copy_check = file.copy(
+        input$newimg$datapath, target,
+        overwrite = if (is.null(input$overwrite)) FALSE else as.logical(input$overwrite)
+      )
+      if (copy_check) message('Successfully copied the image to ', target)
+
+      validate_css_unit = function(x) {
+        if (x == '') return(x)
+        tryCatch(htmltools::validateCssUnit(x), error = function(e) {
+          warning(e$message,call. = FALSE)
+          x
+        })
+      }
+      image_code = function() {
+        s = target
+        w = input$w; h = input$h; alt = input$alt
+        if (w == '' && h == '') {
+          paste0('![', alt, '](', s, ')')
+        } else {
+          w = validate_css_unit(w); h = validate_css_unit(h)
+          if (ctx_ext == 'rmd') paste0(
+            '![', alt, '](', s, '){',
+            if (w != '') paste0('width=', w),
+            if (h != '') paste0(' height=', h),
+            '}'
+          ) else shiny::img(
+            src = s, alt = alt, width = if (w != '') w, height = if (h != '') h
+          )
+        }
+      }
+
+      rstudioapi::insertText(as.character(image_code()), id = ctx$id)
+      shiny::stopApp()
+    })
+    shiny::observeEvent(input$cancel, {
+      shiny::stopApp()
+    })
+  },
+  stopOnCancel = FALSE,
+  viewer = shiny::dialogViewer('Add external image to a R Markdown document', height = 380)
+)
+

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -60,6 +60,7 @@ shiny::runGadget(
     shiny::observeEvent(input$done, {
       if (is.null(input$newimg)) return(warning('You have to choose an image!',call. = FALSE))
       target = input$target
+      if(!class(blogdown) %in% 'try-error'){
       if (bundle) {
         if (!startsWith(target, dirname(path))) return(warning(
           "The target file path must be under the directory '", dirname(path), "'.", call. = FALSE
@@ -69,6 +70,8 @@ shiny::runGadget(
           "The target file path must start with 'static/'.", call. = FALSE
         ))
       }
+    }
+
       if (file.exists(target)) {
         if (!as.logical(input$overwrite)) warning(
           'The image already exists and you chose not to overwrite it! ',

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -94,13 +94,13 @@ shiny::runGadget(
       }
       image_code = function() {
         s = if(class(blogdown) %in% 'try-error'){
+          target
+        }else{
           if (bundle) substring(target, nchar(dirname(path)) + 2) else paste0(
             ifelse(getOption('blogdown.insertimage.usebaseurl', FALSE),
                    blogdown:::load_config()$baseurl, '/'),
             gsub('^static/', '', target)
           )
-        }else{
-          target
         }
         w = input$w; h = input$h; alt = input$alt
         if (w == '' && h == '') {


### PR DESCRIPTION
#2280 The original idea and code is copied and modified from `blogdown` package's rstudio [addins](https://github.com/rstudio/blogdown/blob/6ed98d75017f095c9273532de18d712b60af424c/inst/rstudio/addins.dcf). It will introduce two extra suggest packages (`rstudioapi` and `miniUI`).