### PR TITLE
Support custom highlight theme in other formats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.7
+Version: 2.11.8
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 rmarkdown 2.12
 ================================================================================
 
-- Improved the highlighting mechanism for HTML outputs: 
+- Improved the highlighting mechanism in formats that supports `highlight` argument: 
   * It is now possible to pass a custom theme file `.theme` in `highlight` argument for customizing the [syntax highlighting style used by Pandoc](https://pandoc.org/MANUAL.html#syntax-highlighting). 
   * In addition to Pandoc's own supported themes, two more themes are bundled in the package:  `highlight: arrow` a theme [optimized for accessibility and color constrast](https://www.a11yproject.com/) (thanks to @apreshill), and `highlight: rstudio` to mimic the RStudio editor theme.
-  * Added optional [downlit](https://downlit.r-lib.org/) support in `html_document()` for R syntax highlighting and autolinking. Use `highlight_downlit = TRUE` to activate it (same argument as in **distill**). This features require the **downlit** package. 
+  * For HTML output only, added optional [downlit](https://downlit.r-lib.org/) support in `html_document()` for R syntax highlighting and autolinking. Use `highlight_downlit = TRUE` to activate it (same argument as in **distill**). This features require the **downlit** package. 
 
 - Added a global option `rmarkdown.html_dependency.header_attr` (`TRUE` by default). It can be set to `FALSE` to opt-out the HTML dependency `html_dependency_header_attrs()` in documents based on `html_document_base()` (thanks, @salim-b rstudio/bookdown#865, @maelle r-lib/downlit#1538).
 

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -106,8 +106,7 @@ beamer_presentation <- function(toc = FALSE,
     args <- c(args, pandoc_variable_arg("fonttheme", fonttheme))
 
   # highlighting
-  if (!is.null(highlight))
-    highlight <- match.arg(highlight, highlighters())
+  if (!is.null(highlight)) highlight <- resolve_highlight(highlight, highlighters())
   args <- c(args, pandoc_highlight_args(highlight))
 
   # latex engine

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -64,15 +64,15 @@
 #'  "default" (and "textmate") will use highlightjs as syntax highlighting
 #'  engine instead of Pandoc.
 #'
-#'  Any other value will be passed to Pandoc's
-#'  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{highlighting
-#'  style}. Pandoc's built-in styles include "tango", "pygments", "kate",
-#'  "monochrome", "espresso", "zenburn", "haddock" and "breezedark".
+#'  Any other value will be passed as Pandoc's highlighting style. Pandoc's
+#'  built-in styles include "tango", "pygments", "kate", "monochrome",
+#'  "espresso", "zenburn", "haddock" and "breezedark".
 #'
 #'  Two custom styles are also included, "arrow", an accessible color scheme,
 #'  and "rstudio", which mimics the default IDE theme. Alternatively, supply a
-#'  path to a \samp{.theme} to use a custom Pandoc style. Note that custom theme
-#'  requires Pandoc 2.0+.
+#'  path to a \samp{.theme} to use
+#'  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+#'  style}. Note that custom theme requires Pandoc 2.0+.
 #'
 #'  Pass \code{NULL} to prevent syntax highlighting.
 #'

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -606,13 +606,9 @@ is_highlightjs <- function(highlight) {
 }
 
 resolve_highlight <- function(highlight, supported = highlighters()) {
-  is_supported <- TRUE
   # for backward compatibility, partial match still need to work
-  highlight <- tryCatch(
-    error = function(e) { is_supported <<- FALSE; highlight },
-    match.arg(highlight, supported)
-  )
-  if (is_supported) return(highlight)
+  i <- pmatch(highlight, supported, nomatch = 0L)
+  if (i > 0L) return(supported[i])
 
   # Otherwise it could be a custom (built-in) .theme file
   if (!pandoc2.0()) {

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -628,7 +628,17 @@ resolve_highlight <- function(highlight, supported = highlighters()) {
     rstudio = pkg_file_highlight("rstudio.theme")
   )
   # if not an alias use the provided custom path
-  custom[[highlight]] %||% highlight
+  highlight <- custom[[highlight]] %||% highlight
+  # Check for extension or give informative error otherwise
+  if (!identical(xfun::file_ext(highlight), "theme")) {
+    msg <- c(
+      sprintf("`highlight` argument must be one of %s",
+              knitr::combine_words(c(supported, names(custom)), and = " or ", before = "`")),
+      " or a file with extension `.theme`."
+    )
+    stop(msg, call. = FALSE)
+  }
+  highlight
 }
 
 #' Find the \command{pandoc} executable

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -564,25 +564,6 @@ pandoc_html_highlight_args <- function(template,
   # no highlighting engine
   if (is.null(highlight)) return(pandoc_highlight_args(NULL))
 
-  # TODO: move out so that it works also for other formats
-  resolve_highlight <- function(highlight) {
-    # if Pandoc built-in highlighter, do no nothing
-    if (highlight %in% highlighters()) return(highlight)
-    if (!pandoc2.0()) {
-      stop("Using a custom highlighting style requires Pandoc 2.0 and above",
-           call. = FALSE)
-    }
-    custom <- list(
-      # from distill
-      # https://raw.githubusercontent.com/apreshill/distill/arrow/inst/rmarkdown/templates/distill_article/resources/arrow.theme
-      arrow = pkg_file_highlight("arrow.theme"),
-      # from distill
-      # https://github.com/rstudio/distill/blob/c98d332192ff75f268ddf69bddace34e4db6d89b/inst/rmarkdown/templates/distill_article/resources/rstudio.theme
-      rstudio = pkg_file_highlight("rstudio.theme")
-    )
-    # if not an alias use the provided custom path
-    custom[[highlight]] %||% highlight
-  }
   highlight <- resolve_highlight(highlight)
 
   check_highlightjs <- function(highlight, engine) {
@@ -622,6 +603,25 @@ pandoc_html_highlight_args <- function(template,
 
 is_highlightjs <- function(highlight) {
   !is.null(highlight) && (highlight %in% c("default", "textmate"))
+}
+
+resolve_highlight <- function(highlight) {
+  # if Pandoc built-in highlighter, do no nothing
+  if (highlight %in% highlighters()) return(highlight)
+  if (!pandoc2.0()) {
+    stop("Using a custom highlighting style requires Pandoc 2.0 and above",
+         call. = FALSE)
+  }
+  custom <- list(
+    # from distill
+    # https://raw.githubusercontent.com/apreshill/distill/arrow/inst/rmarkdown/templates/distill_article/resources/arrow.theme
+    arrow = pkg_file_highlight("arrow.theme"),
+    # from distill
+    # https://github.com/rstudio/distill/blob/c98d332192ff75f268ddf69bddace34e4db6d89b/inst/rmarkdown/templates/distill_article/resources/rstudio.theme
+    rstudio = pkg_file_highlight("rstudio.theme")
+  )
+  # if not an alias use the provided custom path
+  custom[[highlight]] %||% highlight
 }
 
 #' Find the \command{pandoc} executable

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -564,7 +564,7 @@ pandoc_html_highlight_args <- function(template,
   # no highlighting engine
   if (is.null(highlight)) return(pandoc_highlight_args(NULL))
 
-  highlight <- resolve_highlight(highlight)
+  highlight <- resolve_highlight(highlight, html_highlighters())
 
   check_highlightjs <- function(highlight, engine) {
     if (highlight != "default" && is_highlightjs(highlight)) {
@@ -605,9 +605,16 @@ is_highlightjs <- function(highlight) {
   !is.null(highlight) && (highlight %in% c("default", "textmate"))
 }
 
-resolve_highlight <- function(highlight) {
-  # if Pandoc built-in highlighter, do no nothing
-  if (highlight %in% highlighters()) return(highlight)
+resolve_highlight <- function(highlight, supported = highlighters()) {
+  is_supported <- TRUE
+  # for backward compatibility, partial match still need to work
+  highlight <- tryCatch(
+    error = function(e) { is_supported <<- FALSE; highlight },
+    match.arg(highlight, supported)
+  )
+  if (is_supported) return(highlight)
+
+  # Otherwise it could be a custom (built-in) .theme file
   if (!pandoc2.0()) {
     stop("Using a custom highlighting style requires Pandoc 2.0 and above",
          call. = FALSE)

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -127,7 +127,7 @@ pdf_document <- function(toc = FALSE,
     args <- c(args, "--number-sections")
 
   # highlighting
-  if (!is.null(highlight)) highlight <- resolve_highlight(highlight)
+  if (!is.null(highlight)) highlight <- resolve_highlight(highlight, highlighters())
   args <- c(args, pandoc_highlight_args(highlight))
 
   # latex engine

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -127,8 +127,7 @@ pdf_document <- function(toc = FALSE,
     args <- c(args, "--number-sections")
 
   # highlighting
-  if (!is.null(highlight))
-    highlight <- match.arg(highlight, highlighters())
+  if (!is.null(highlight)) highlight <- resolve_highlight(highlight)
   args <- c(args, pandoc_highlight_args(highlight))
 
   # latex engine

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -46,9 +46,18 @@
 #'   \command{ghostscript} to be installed. By default, \code{fig_crop = TRUE}
 #'   if these two tools are available.
 #' @param dev Graphics device to use for figure output (defaults to pdf)
-#' @param highlight Syntax highlighting style. Supported styles include
-#'   "default", "tango", "pygments", "kate", "monochrome", "espresso",
-#'   "zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.
+#' @param highlight Syntax highlighting style passed to Pandoc.
+#'
+#'  Supported built-in styles include "default", "tango", "pygments", "kate",
+#'  "monochrome", "espresso", "zenburn", "haddock", and "breezedark".
+#'
+#'   Two custom styles are also included, "arrow", an accessible color scheme,
+#'   and "rstudio", which mimics the default IDE theme. Alternatively, supply a
+#'   path to a \samp{.theme} file to use
+#'   \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+#'   style}. Note that custom theme requires Pandoc 2.0+.
+#'
+#'   Pass \code{NULL} to prevent syntax highlighting.
 #' @param keep_tex Keep the intermediate tex file used in the conversion to PDF
 #' @param latex_engine LaTeX engine for producing PDF output. Options are
 #'   "pdflatex", "lualatex", "xelatex" and "tectonic".

--- a/R/slidy_presentation.R
+++ b/R/slidy_presentation.R
@@ -119,6 +119,7 @@ slidy_presentation <- function(number_sections = FALSE,
     args <- c()
 
     # highlight
+    if (!is.null(highlight)) highlight <- resolve_highlight(highlight, highlighters())
     args <- c(args, pandoc_highlight_args(highlight, default = "pygments"))
 
     # return additional args

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -71,8 +71,7 @@ word_document <- function(toc = FALSE,
   }
 
   # highlighting
-  if (!is.null(highlight))
-    highlight <- match.arg(highlight, highlighters())
+  if (!is.null(highlight)) highlight <- resolve_highlight(highlight, highlighters())
   args <- c(args, pandoc_highlight_args(highlight))
 
   # reference docx

--- a/man/beamer_presentation.Rd
+++ b/man/beamer_presentation.Rd
@@ -80,9 +80,18 @@ frame printing section} in bookdown book for examples.}
 
 \item{fonttheme}{Beamer font theme (e.g. "structurebold").}
 
-\item{highlight}{Syntax highlighting style. Supported styles include
-"default", "tango", "pygments", "kate", "monochrome", "espresso",
-"zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
+\item{highlight}{Syntax highlighting style passed to Pandoc.
+
+ Supported built-in styles include "default", "tango", "pygments", "kate",
+ "monochrome", "espresso", "zenburn", "haddock", and "breezedark".
+
+  Two custom styles are also included, "arrow", an accessible color scheme,
+  and "rstudio", which mimics the default IDE theme. Alternatively, supply a
+  path to a \samp{.theme} file to use
+  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+  style}. Note that custom theme requires Pandoc 2.0+.
+
+  Pass \code{NULL} to prevent syntax highlighting.}
 
 \item{template}{Pandoc template to use for rendering. Pass "default" to use
 the rmarkdown package default template; pass \code{NULL} to use pandoc's

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -119,15 +119,15 @@ theme name (for backwards-compatibility).
 "default" (and "textmate") will use highlightjs as syntax highlighting
 engine instead of Pandoc.
 
-Any other value will be passed to Pandoc's
-\href{https://pandoc.org/MANUAL.html#syntax-highlighting}{highlighting
-style}. Pandoc's built-in styles include "tango", "pygments", "kate",
-"monochrome", "espresso", "zenburn", "haddock" and "breezedark".
+Any other value will be passed as Pandoc's highlighting style. Pandoc's
+built-in styles include "tango", "pygments", "kate", "monochrome",
+"espresso", "zenburn", "haddock" and "breezedark".
 
 Two custom styles are also included, "arrow", an accessible color scheme,
 and "rstudio", which mimics the default IDE theme. Alternatively, supply a
-path to a \samp{.theme} to use a custom Pandoc style. Note that custom theme
-requires Pandoc 2.0+.
+path to a \samp{.theme} to use
+\href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+style}. Note that custom theme requires Pandoc 2.0+.
 
 Pass \code{NULL} to prevent syntax highlighting.}
 

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -79,15 +79,15 @@ theme name (for backwards-compatibility).
 "default" (and "textmate") will use highlightjs as syntax highlighting
 engine instead of Pandoc.
 
-Any other value will be passed to Pandoc's
-\href{https://pandoc.org/MANUAL.html#syntax-highlighting}{highlighting
-style}. Pandoc's built-in styles include "tango", "pygments", "kate",
-"monochrome", "espresso", "zenburn", "haddock" and "breezedark".
+Any other value will be passed as Pandoc's highlighting style. Pandoc's
+built-in styles include "tango", "pygments", "kate", "monochrome",
+"espresso", "zenburn", "haddock" and "breezedark".
 
 Two custom styles are also included, "arrow", an accessible color scheme,
 and "rstudio", which mimics the default IDE theme. Alternatively, supply a
-path to a \samp{.theme} to use a custom Pandoc style. Note that custom theme
-requires Pandoc 2.0+.
+path to a \samp{.theme} to use
+\href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+style}. Note that custom theme requires Pandoc 2.0+.
 
 Pass \code{NULL} to prevent syntax highlighting.}
 

--- a/man/pdf_document.Rd
+++ b/man/pdf_document.Rd
@@ -67,9 +67,18 @@ can disable the \code{df_print} behavior entirely by setting the option
 \href{https://bookdown.org/yihui/rmarkdown/html-document.html#data-frame-printing}{Data
 frame printing section} in bookdown book for examples.}
 
-\item{highlight}{Syntax highlighting style. Supported styles include
-"default", "tango", "pygments", "kate", "monochrome", "espresso",
-"zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
+\item{highlight}{Syntax highlighting style passed to Pandoc.
+
+ Supported built-in styles include "default", "tango", "pygments", "kate",
+ "monochrome", "espresso", "zenburn", "haddock", and "breezedark".
+
+  Two custom styles are also included, "arrow", an accessible color scheme,
+  and "rstudio", which mimics the default IDE theme. Alternatively, supply a
+  path to a \samp{.theme} file to use
+  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+  style}. Note that custom theme requires Pandoc 2.0+.
+
+  Pass \code{NULL} to prevent syntax highlighting.}
 
 \item{template}{Pandoc template to use for rendering. Pass "default" to use
 the rmarkdown package default template; pass \code{NULL} to use pandoc's

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -88,9 +88,18 @@ scripts, stylesheets, images, and videos. Note that even for self contained
 documents MathJax is still loaded externally (this is necessary because of
 its size).}
 
-\item{highlight}{Syntax highlighting style. Supported styles include
-"default", "tango", "pygments", "kate", "monochrome", "espresso",
-"zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
+\item{highlight}{Syntax highlighting style passed to Pandoc.
+
+ Supported built-in styles include "default", "tango", "pygments", "kate",
+ "monochrome", "espresso", "zenburn", "haddock", and "breezedark".
+
+  Two custom styles are also included, "arrow", an accessible color scheme,
+  and "rstudio", which mimics the default IDE theme. Alternatively, supply a
+  path to a \samp{.theme} file to use
+  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+  style}. Note that custom theme requires Pandoc 2.0+.
+
+  Pass \code{NULL} to prevent syntax highlighting.}
 
 \item{mathjax}{Include mathjax. The "default" option uses an https URL from a
 MathJax CDN. The "local" option uses a local version of MathJax (which is

--- a/man/tufte_handout.Rd
+++ b/man/tufte_handout.Rd
@@ -29,9 +29,18 @@ if these two tools are available.}
 
 \item{dev}{Graphics device to use for figure output (defaults to pdf)}
 
-\item{highlight}{Syntax highlighting style. Supported styles include
-"default", "tango", "pygments", "kate", "monochrome", "espresso",
-"zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
+\item{highlight}{Syntax highlighting style passed to Pandoc.
+
+ Supported built-in styles include "default", "tango", "pygments", "kate",
+ "monochrome", "espresso", "zenburn", "haddock", and "breezedark".
+
+  Two custom styles are also included, "arrow", an accessible color scheme,
+  and "rstudio", which mimics the default IDE theme. Alternatively, supply a
+  path to a \samp{.theme} file to use
+  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+  style}. Note that custom theme requires Pandoc 2.0+.
+
+  Pass \code{NULL} to prevent syntax highlighting.}
 
 \item{keep_tex}{Keep the intermediate tex file used in the conversion to PDF}
 

--- a/man/word_document.Rd
+++ b/man/word_document.Rd
@@ -46,9 +46,18 @@ can disable the \code{df_print} behavior entirely by setting the option
 \href{https://bookdown.org/yihui/rmarkdown/html-document.html#data-frame-printing}{Data
 frame printing section} in bookdown book for examples.}
 
-\item{highlight}{Syntax highlighting style. Supported styles include
-"default", "tango", "pygments", "kate", "monochrome", "espresso",
-"zenburn", and "haddock". Pass \code{NULL} to prevent syntax highlighting.}
+\item{highlight}{Syntax highlighting style passed to Pandoc.
+
+ Supported built-in styles include "default", "tango", "pygments", "kate",
+ "monochrome", "espresso", "zenburn", "haddock", and "breezedark".
+
+  Two custom styles are also included, "arrow", an accessible color scheme,
+  and "rstudio", which mimics the default IDE theme. Alternatively, supply a
+  path to a \samp{.theme} file to use
+  \href{https://pandoc.org/MANUAL.html#syntax-highlighting}{a custom Pandoc
+  style}. Note that custom theme requires Pandoc 2.0+.
+
+  Pass \code{NULL} to prevent syntax highlighting.}
 
 \item{reference_docx}{Use the specified file as a style reference in
 producing a docx file. For best results, the reference docx should be a

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -12,6 +12,10 @@ test_that("build highlight args for pandoc correctly", {
 test_that("Detect if a theme file is providing in highlight", {
   expect_equal(resolve_highlight("default"), "default")
   expect_equal(resolve_highlight("breezedark"), "breezedark")
+  expect_equal(resolve_highlight("breez"), "breezedark")
+  expect_equal(
+    resolve_highlight("textmate", html_highlighters()), "textmate"
+  )
   if (pandoc_available("2.0")) {
     expect_equal(resolve_highlight("arrow"), pkg_file_highlight("arrow.theme"))
     expect_equal(resolve_highlight("custom.theme"), "custom.theme")

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -9,6 +9,16 @@ test_that("build highlight args for pandoc correctly", {
   expect_equal(pandoc_highlight_args("zenburn"), hl_style("zenburn"))
 })
 
+test_that("Detect if a theme file is providing in highlight", {
+  expect_equal(resolve_highlight("default"), "default")
+  expect_equal(resolve_highlight("breezedark"), "breezedark")
+  if (pandoc_available("2.0")) {
+    expect_equal(resolve_highlight("arrow"), pkg_file_highlight("arrow.theme"))
+    expect_equal(resolve_highlight("custom.theme"), "custom.theme")
+  } else {
+    expect_error(resolve_highlight("arrow"), "requires Pandoc 2.0")
+  }
+})
 
 test_that("Correct HTML highlighting argument as requested", {
   # helpers

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -13,12 +13,14 @@ test_that("Detect if a theme file is providing in highlight", {
   expect_equal(resolve_highlight("default"), "default")
   expect_equal(resolve_highlight("breezedark"), "breezedark")
   expect_equal(resolve_highlight("breez"), "breezedark")
+  expect_error(resolve_highlight("textmate"), "must be one of")
   expect_equal(
     resolve_highlight("textmate", html_highlighters()), "textmate"
   )
   if (pandoc_available("2.0")) {
     expect_equal(resolve_highlight("arrow"), pkg_file_highlight("arrow.theme"))
     expect_equal(resolve_highlight("custom.theme"), "custom.theme")
+    expect_error(resolve_highlight("custom.json"), "a file with extension")
   } else {
     expect_error(resolve_highlight("arrow"), "requires Pandoc 2.0")
   }


### PR DESCRIPTION
This PR follows #1941 by adding support for custom highlight `.theme` file in other format like PDF 

this will close #2035 

It uses the same internal function as previous PR to support HTML but added a logic for non HTML format too. 

I also brought back backward compatibility for partial matching of Pandoc's style name are `match.arg` was used before and also took the opportunity to add informative error message if unknown value is provided in order to error from R and not from Pandoc