### PR TITLE
Support incremental for Powerpoint presentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.8
+Version: 2.11.9
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.12
 ================================================================================
 
+- Following support in Pandoc 2.15, `powerpoint_presentation()` gains a `incremental` argument as other slide formats. As a reminder, setting `incremental = TRUE` will make lists to display incrementally. See more in [Pandoc's MANUAL](https://pandoc.org/MANUAL.html#incremental-lists).
+
 - Improved the highlighting mechanism in formats that supports `highlight` argument: 
   * It is now possible to pass a custom theme file `.theme` in `highlight` argument for customizing the [syntax highlighting style used by Pandoc](https://pandoc.org/MANUAL.html#syntax-highlighting). 
   * In addition to Pandoc's own supported themes, two more themes are bundled in the package:  `highlight: arrow` a theme [optimized for accessibility and color constrast](https://www.a11yproject.com/) (thanks to @apreshill), and `highlight: rstudio` to mimic the RStudio editor theme.

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -2,40 +2,40 @@
 #'
 #' Format for converting from R Markdown to a Beamer presentation.
 #'
-#' See the \href{https://bookdown.org/yihui/rmarkdown/beamer-presentation.html}{online
-#' documentation} for additional details on using the \code{beamer_presentation}
-#' format.
+#' See the [online documentation](https://bookdown.org/yihui/rmarkdown/beamer-presentation.html)
+#' for additional details on using the `beamer_presentation` format.
 #'
 #' Creating Beamer output from R Markdown requires that LaTeX be installed.
 #'
 #' R Markdown documents can have optional metadata that is used to generate a
 #' document header that includes the title, author, and date. For more details
-#' see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
+#' see the documentation on R Markdown [metadata][rmd_metadata].
 #'
 #' R Markdown documents also support citations. You can find more information on
 #' the markdown syntax for citations in the
-#' \href{https://pandoc.org/MANUAL.html#citations}{Bibliographies
-#' and Citations} article in the online documentation.
+#' [Bibliographies and Citations](https://pandoc.org/MANUAL.html#citations)
+#' article in the online documentation.
 #' @inheritParams pdf_document
 #' @inheritParams html_document
-#' @param toc \code{TRUE} to include a table of contents in the output (only
+#' @param toc `TRUE` to include a table of contents in the output (only
 #'   level 1 headers will be included in the table of contents).
 #' @param slide_level The heading level which defines individual slides. By
 #'   default this is the highest header level in the hierarchy that is followed
 #'   immediately by content, and not another header, somewhere in the document.
 #'   This default can be overridden by specifying an explicit
-#'   \code{slide_level}.
-#' @param incremental \code{TRUE} to render slide bullets incrementally. Note
+#'   `slide_level`.
+#' @param incremental `TRUE` to render slide bullets incrementally. Note
 #'   that if you want to reverse the default incremental behavior for an
-#'   individual bullet you can precede it with \code{>}. For example:
-#'   \emph{\code{> - Bullet Text}}
+#'   individual bullet you can precede it with `>`. For example:
+#'   *`> - Bullet Text`*. See more in
+#'   [Pandoc's Manual](https://pandoc.org/MANUAL.html#incremental-lists)
 #' @param theme Beamer theme (e.g. "AnnArbor").
 #' @param colortheme Beamer color theme (e.g. "dolphin").
 #' @param fonttheme Beamer font theme (e.g. "structurebold").
-#' @param self_contained Whether to generate a full LaTeX document (\code{TRUE})
-#'   or just the body of a LaTeX document (\code{FALSE}). Note the LaTeX
-#'   document is an intermediate file unless \code{keep_tex = TRUE}.
-#' @return R Markdown output format to pass to \code{\link{render}}
+#' @param self_contained Whether to generate a full LaTeX document (`TRUE`)
+#'   or just the body of a LaTeX document (`FALSE`). Note the LaTeX
+#'   document is an intermediate file unless `keep_tex = TRUE`.
+#' @return R Markdown output format to pass to [render()]
 #' @examples
 #' \dontrun{
 #'
@@ -47,6 +47,7 @@
 #' # specify an option for incremental rendering
 #' render("pres.Rmd", beamer_presentation(incremental = TRUE))
 #' }
+#' @md
 #' @export
 beamer_presentation <- function(toc = FALSE,
                                 slide_level = NULL,

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -11,6 +11,7 @@
 powerpoint_presentation <- function(toc = FALSE,
                                     toc_depth = 2,
                                     number_sections = FALSE,
+                                    incremental = FALSE,
                                     fig_width = 5,
                                     fig_height = 4,
                                     fig_caption = TRUE,
@@ -37,6 +38,18 @@ powerpoint_presentation <- function(toc = FALSE,
 
   # ppt template
   args <- c(args, reference_doc_args("doc", reference_doc))
+
+  # incremental
+  if (incremental) {
+    if (!pandoc_available('2.15')) {
+      warning(
+        "`incremental = TRUE` for powerpoint presentation is supported since Pandoc 2.15.\n",
+        " It will have no effect with current Pandoc used: ", pandoc_version(), "."
+      )
+    } else {
+      args <- c(args, "--incremental")
+    }
+  }
 
   # slide level
   if (!is.null(slide_level))

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -45,7 +45,8 @@ powerpoint_presentation <- function(toc = FALSE,
     if (!pandoc_available('2.15')) {
       warning(
         "`incremental = TRUE` for powerpoint presentation is supported since Pandoc 2.15.\n",
-        " It will have no effect with current Pandoc used: ", pandoc_version(), "."
+        " It will have no effect with current Pandoc version used: ", pandoc_version(), ".",
+        call. = FALSE
       )
     } else {
       args <- c(args, "--incremental")

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -8,12 +8,18 @@
 #' @param reference_doc Path to a PowerPoint template.
 #' @export
 #' @return R Markdown output format to pass to \code{\link{render}}
-powerpoint_presentation <- function(
-  toc = FALSE, toc_depth = 2, number_sections = FALSE,
-  fig_width = 5, fig_height = 4, fig_caption = TRUE,
-  df_print = 'default', keep_md = FALSE, md_extensions = NULL,
-  slide_level = NULL, reference_doc = 'default', pandoc_args = NULL
-) {
+powerpoint_presentation <- function(toc = FALSE,
+                                    toc_depth = 2,
+                                    number_sections = FALSE,
+                                    fig_width = 5,
+                                    fig_height = 4,
+                                    fig_caption = TRUE,
+                                    df_print = "default",
+                                    keep_md = FALSE,
+                                    md_extensions = NULL,
+                                    slide_level = NULL,
+                                    reference_doc = "default",
+                                    pandoc_args = NULL) {
 
   # PowerPoint has been supported since Pandoc 2.0.5
   pandoc_available('2.0.5', error = TRUE)

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -6,8 +6,9 @@
 #' @inheritParams html_document
 #' @inheritParams beamer_presentation
 #' @param reference_doc Path to a PowerPoint template.
+#' @return R Markdown output format to pass to [render()]
+#' @md
 #' @export
-#' @return R Markdown output format to pass to \code{\link{render}}
 powerpoint_presentation <- function(toc = FALSE,
                                     toc_depth = 2,
                                     number_sections = FALSE,

--- a/man/beamer_presentation.Rd
+++ b/man/beamer_presentation.Rd
@@ -45,7 +45,8 @@ This default can be overridden by specifying an explicit
 \item{incremental}{\code{TRUE} to render slide bullets incrementally. Note
 that if you want to reverse the default incremental behavior for an
 individual bullet you can precede it with \code{>}. For example:
-\emph{\code{> - Bullet Text}}}
+\emph{\verb{> - Bullet Text}}. See more in
+\href{https://pandoc.org/MANUAL.html#incremental-lists}{Pandoc's Manual}}
 
 \item{fig_width}{Default width (in inches) for figures}
 
@@ -126,15 +127,14 @@ additional details.}
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 }
 \value{
-R Markdown output format to pass to \code{\link{render}}
+R Markdown output format to pass to \code{\link[=render]{render()}}
 }
 \description{
 Format for converting from R Markdown to a Beamer presentation.
 }
 \details{
-See the \href{https://bookdown.org/yihui/rmarkdown/beamer-presentation.html}{online
-documentation} for additional details on using the \code{beamer_presentation}
-format.
+See the \href{https://bookdown.org/yihui/rmarkdown/beamer-presentation.html}{online documentation}
+for additional details on using the \code{beamer_presentation} format.
 
 Creating Beamer output from R Markdown requires that LaTeX be installed.
 
@@ -144,8 +144,8 @@ see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
 
 R Markdown documents also support citations. You can find more information on
 the markdown syntax for citations in the
-\href{https://pandoc.org/MANUAL.html#citations}{Bibliographies
-and Citations} article in the online documentation.
+\href{https://pandoc.org/MANUAL.html#citations}{Bibliographies and Citations}
+article in the online documentation.
 }
 \examples{
 \dontrun{

--- a/man/powerpoint_presentation.Rd
+++ b/man/powerpoint_presentation.Rd
@@ -8,6 +8,7 @@ powerpoint_presentation(
   toc = FALSE,
   toc_depth = 2,
   number_sections = FALSE,
+  incremental = FALSE,
   fig_width = 5,
   fig_height = 4,
   fig_caption = TRUE,
@@ -25,6 +26,12 @@ powerpoint_presentation(
 \item{toc_depth}{Depth of headers to include in table of contents}
 
 \item{number_sections}{\code{TRUE} to number section headings}
+
+\item{incremental}{\code{TRUE} to render slide bullets incrementally. Note
+that if you want to reverse the default incremental behavior for an
+individual bullet you can precede it with \code{>}. For example:
+\emph{\verb{> - Bullet Text}}. See more in
+\href{https://pandoc.org/MANUAL.html#incremental-lists}{Pandoc's Manual}}
 
 \item{fig_width}{Default width (in inches) for figures}
 
@@ -63,7 +70,7 @@ This default can be overridden by specifying an explicit
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 }
 \value{
-R Markdown output format to pass to \code{\link{render}}
+R Markdown output format to pass to \code{\link[=render]{render()}}
 }
 \description{
 Format for converting from R Markdown to a PowerPoint presentation. Pandoc

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -37,7 +37,8 @@ slidy_presentation(
 \item{incremental}{\code{TRUE} to render slide bullets incrementally. Note
 that if you want to reverse the default incremental behavior for an
 individual bullet you can precede it with \code{>}. For example:
-\emph{\code{> - Bullet Text}}}
+\emph{\verb{> - Bullet Text}}. See more in
+\href{https://pandoc.org/MANUAL.html#incremental-lists}{Pandoc's Manual}}
 
 \item{slide_level}{The heading level which defines individual slides. By
 default this is the highest header level in the hierarchy that is followed

--- a/tests/testthat/test-powerpoint_presentation.R
+++ b/tests/testthat/test-powerpoint_presentation.R
@@ -9,3 +9,9 @@ test_that("Incremental feature", {
     expect_false("--incremental" %in% ppt_out$pandoc$args)
   }
 })
+
+test_that("Powerpoint require Pandoc 2.0.5 and above", {
+  skip_if_not_pandoc()
+  skip_if_pandoc("2.0.5")
+  expect_error(powerpoint_presentation(), "is required and was not found")
+})

--- a/tests/testthat/test-powerpoint_presentation.R
+++ b/tests/testthat/test-powerpoint_presentation.R
@@ -4,6 +4,7 @@ test_that("Incremental feature", {
     ppt_out <- powerpoint_presentation(incremental = TRUE)
     expect_true("--incremental" %in% ppt_out$pandoc$args)
   } else {
+    skip_if_not_pandoc("2.0.5")
     expect_warning(ppt_out <- powerpoint_presentation(incremental = TRUE),
                    "is supported since Pandoc 2.15", fixed = TRUE)
     expect_false("--incremental" %in% ppt_out$pandoc$args)

--- a/tests/testthat/test-powerpoint_presentation.R
+++ b/tests/testthat/test-powerpoint_presentation.R
@@ -1,18 +1,21 @@
+test_that("Powerpoint require Pandoc 2.0.5 and above", {
+  skip_if_not_pandoc()
+  skip_if_pandoc("2.0.5")
+  expect_error(powerpoint_presentation(), "is required and was not found")
+})
+
+skip_if_not_pandoc("2.0.5")
+
 test_that("Incremental feature", {
   skip_if_not_pandoc()
   if (pandoc_available("2.15")) {
     ppt_out <- powerpoint_presentation(incremental = TRUE)
     expect_true("--incremental" %in% ppt_out$pandoc$args)
   } else {
-    skip_if_not_pandoc("2.0.5")
     expect_warning(ppt_out <- powerpoint_presentation(incremental = TRUE),
                    "is supported since Pandoc 2.15", fixed = TRUE)
     expect_false("--incremental" %in% ppt_out$pandoc$args)
   }
 })
 
-test_that("Powerpoint require Pandoc 2.0.5 and above", {
-  skip_if_not_pandoc()
-  skip_if_pandoc("2.0.5")
-  expect_error(powerpoint_presentation(), "is required and was not found")
-})
+

--- a/tests/testthat/test-powerpoint_presentation.R
+++ b/tests/testthat/test-powerpoint_presentation.R
@@ -1,0 +1,11 @@
+test_that("Incremental feature", {
+  skip_if_not_pandoc()
+  if (pandoc_available("2.15")) {
+    ppt_out <- powerpoint_presentation(incremental = TRUE)
+    expect_true("--incremental" %in% ppt_out$pandoc$args)
+  } else {
+    expect_warning(ppt_out <- powerpoint_presentation(incremental = TRUE),
+                   "is supported since Pandoc 2.15", fixed = TRUE)
+    expect_false("--incremental" %in% ppt_out$pandoc$args)
+  }
+})


### PR DESCRIPTION
Closes #2212 

This PR adds support for `incremental = TRUE` in `powerpoint_presentation()` based on support in Pandoc 2.15

A warning will be issued when using Pandoc before 2.15

I added some quick test to check error and the argument. I think we should add more simple test like that just to be sure we don't break anything in the future. Seems like dummy tests but I guess that simple test are often the best.

I also took the opportunity to convert some other doc to Markdown syntax. 

I'll prepare a PR for the R Markdown book that we could merge following the next release