### PR TITLE
Add function in `shared.lua` for sharing fixes in Lua filters across packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.11
+Version: 2.11.12
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,10 @@ rmarkdown 2.12
   
 - Added support for Pandoc's `dir` variable in HTML templates. This is the second [Language Variables](https://pandoc.org/MANUAL.html#language-variables) after `lang`. 
 
+- Lua Filters: Added two more functions in `shared.lua` for other package to use: 
+  * Added `type()` function backward compatible following Pandoc 2.17 changes.
+  * Added `print_debug()` for easier logging during debug.
+
 rmarkdown 2.11
 ================================================================================
 

--- a/inst/rmarkdown/lua/shared.lua
+++ b/inst/rmarkdown/lua/shared.lua
@@ -47,3 +47,44 @@ function pandocAvailable(target)
   end
   return true
 end
+
+
+--- Returns the type of a metadata value.
+--  Author: Albert Krewinkel
+--  Source: https://github.com/pandoc/lua-filters/commit/3057acc52d1d6cfb7134c934a5039ce170bf78fa
+--
+--  Backward compatible function as retrieving type on Metadata has changed.
+--  `pandoc.utils.type()` not available before Pandoc 2.17
+--
+-- @param v a metadata value
+-- @treturn string one of `Blocks`, `Inlines`, `List`, `Map`, `string`, `boolean`
+function metatype (v)
+  if pandoc.utils.type == nil then
+    local metatag = type(v) == 'table' and v.t and v.t:gsub('^Meta', '')
+    return metatag and metatag ~= 'Map' and metatag or type(v)
+  end
+  return pandoc.utils.type(v)
+end
+
+type = pandoc.utils.type or metatype
+
+-- for debuging purpose
+function print_debug(label,obj,iter)
+  local debug_mode = os.getenv("DEBUG_PANDOC_LUA") == "TRUE"
+  obj = obj or nil
+  iter = iter or pairs
+  label = label or ""
+  label = "DEBUG (from custom-environment.lua): "..label
+  if (debug_mode) then
+      if not obj then
+          print(label.." nil")
+      elseif (type(obj) == "string") then
+          print(label.." "..obj)
+      elseif type(obj) == "table" then
+          for k,v in iter(obj) do
+              print(label.."id:"..k.. " val:"..v)
+          end
+      end
+  end
+  return nil
+end

--- a/inst/rmarkdown/lua/shared.lua
+++ b/inst/rmarkdown/lua/shared.lua
@@ -48,26 +48,6 @@ function pandocAvailable(target)
   return true
 end
 
-
---- Returns the type of a metadata value.
---  Author: Albert Krewinkel
---  Source: https://github.com/pandoc/lua-filters/commit/3057acc52d1d6cfb7134c934a5039ce170bf78fa
---
---  Backward compatible function as retrieving type on Metadata has changed.
---  `pandoc.utils.type()` not available before Pandoc 2.17
---
--- @param v a metadata value
--- @treturn string one of `Blocks`, `Inlines`, `List`, `Map`, `string`, `boolean`
-function metatype (v)
-  if pandoc.utils.type == nil then
-    local metatag = type(v) == 'table' and v.t and v.t:gsub('^Meta', '')
-    return metatag and metatag ~= 'Map' and metatag or type(v)
-  end
-  return pandoc.utils.type(v)
-end
-
-type = pandoc.utils.type or metatype
-
 -- for debuging purpose
 function print_debug(label,obj,iter)
   local debug_mode = os.getenv("DEBUG_PANDOC_LUA") == "TRUE"
@@ -88,3 +68,24 @@ function print_debug(label,obj,iter)
   end
   return nil
 end
+
+
+--- Returns the type of a metadata value.
+--  Author: Albert Krewinkel
+--  Source: https://github.com/pandoc/lua-filters/commit/3057acc52d1d6cfb7134c934a5039ce170bf78fa
+--
+--  Backward compatible function as retrieving type on Metadata has changed.
+--  `pandoc.utils.type()` not available before Pandoc 2.17
+--
+-- @param v a metadata value
+-- @treturn string one of `Blocks`, `Inlines`, `List`, `Map`, `string`, `boolean`
+local origtype = type -- base Lua function
+function metatype (v)
+  if PANDOC_VERSION <= '2.16.2' then
+    local metatag = origtype(v) == 'table' and v.t and v.t:gsub('^Meta', '')
+    return metatag and metatag ~= 'Map' and metatag or origtype(v)
+  end
+  return pandoc.utils.type(v)
+end
+
+type = pandoc.utils.type or metatype

--- a/inst/rmarkdown/lua/shared.lua
+++ b/inst/rmarkdown/lua/shared.lua
@@ -79,13 +79,11 @@ end
 --
 -- @param v a metadata value
 -- @treturn string one of `Blocks`, `Inlines`, `List`, `Map`, `string`, `boolean`
-local origtype = type -- base Lua function
-function metatype (v)
-  if PANDOC_VERSION <= '2.16.2' then
-    local metatag = origtype(v) == 'table' and v.t and v.t:gsub('^Meta', '')
-    return metatag and metatag ~= 'Map' and metatag or origtype(v)
+function pandoc_type (v)
+  if pandoc.utils.type == nil then
+    local metatag = type(v) == 'table' and v.t and v.t:gsub('^Meta', '')
+    return metatag and metatag ~= 'Map' and metatag or type(v)
   end
   return pandoc.utils.type(v)
 end
 
-type = pandoc.utils.type or metatype


### PR DESCRIPTION
This will add 2 more functions 

* `print_debug()` that we had previously in **bookdown**: useful for debugging
* `pandoc_type()` in the context of fixing Pandoc 2.17 changes (rstudio/bookdown#1302 and rstudio/pagedown#268)