### PR TITLE
Support custom url for KaTeX as `math_method`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.13
+Version: 2.11.14
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ rmarkdown 2.12
         url: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js
   ```
   
+  For `math_method = "katex"`, KaTeX CDN will be inserted in version 0.15.2 by default (from jsdelivr). A custom URL toward another CDN can be passed as `url`.
+  
   Most HTML output format using `html_document()` or `html_document_base()` as based format should benefit from this new feature.
   See `?rmarkdown::html_document()` for details (thanks, @atusy, #1940).
   

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -472,16 +472,36 @@ html_dependency_header_attrs <- function() {
 }
 
 # Store KaTeX as a html dependency to include in our template
-html_dependency_katex <- function() {
-  cdn <- "https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/"
+html_dependency_katex <- function(href = NULL) {
+  # supporting custom url
+  if (is.null(href)) {
+    href <- "https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/"
+    version <- "0.15.2"
+    integrity <- "sha256-bgI9WhLOPSUlPrdgHUg3rPIB2vq+D+mYkUTM3q0U8fw="
+  } else {
+    # if a custom url is passed we can't set value we don't know
+    integrity <- NULL
+    # guessing version from a CDN
+    r <- "^.*katex@([0-9.]+).*"
+    version <- if (grepl(r, href)) {
+      gsub(r, "\\1", href)
+    } else  {
+      "99.99.99"
+    }
+  }
+
   htmlDependency(
-    name = "katex", version = "0.15.2",
-    src = c(href = cdn),
-    script = list(src = "katex.min.js",
-                  integrity = "sha256-bgI9WhLOPSUlPrdgHUg3rPIB2vq+D+mYkUTM3q0U8fw=",
-                  crossorigin = 'anonymous',
-                  'data-external' = "1",
-                  defer = NA),
+    name = "katex",
+    version = version,
+    src = c(href = href),
+    script = c(
+      list(src = "katex.min.js",
+           'data-external' = "1",
+           defer = NA),
+      if (!is.null(integrity)) {
+        list(integrity = integrity, crossorigin = 'anonymous')
+      }
+    ),
     # TODO: reactivate when we can set data-external = 1 in htmltools
     #
     # stylesheet = c("katex.min.css"),
@@ -502,7 +522,7 @@ html_dependency_katex <- function() {
       '      });',
       '    }}});',
       '</script>',
-      sprintf('<link rel="stylesheet" href="%skatex.min.css" data-external="1">', cdn)
+      sprintf('<link rel="stylesheet" href="%skatex.min.css" data-external="1">', href)
     )
   )
 }

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -297,7 +297,7 @@ add_math_support <- function(math, template, files_dir, output_dir) {
   if (identical(math$engine, "katex")) {
     if (identical(template, "default")) {
       args <- pandoc_math_args(math$engine)
-      extras <- list(html_dependency_katex())
+      extras <- list(html_dependency_katex(math$url))
     } else {
       args <- c(pandoc_math_args(math$engine, math$url))
     }

--- a/tests/testthat/test-math.R
+++ b/tests/testthat/test-math.R
@@ -56,6 +56,13 @@ test_that("add_math_support() builds correct Pandoc arguments", {
   )
 })
 
+test_that("html_dependency_katex() supports custom url", {
+  expect_identical(html_dependency_katex("cdn/katex@2.1.2")$version, "2.1.2")
+  expect_identical(html_dependency_katex("cdn/katex@2.1.2")$src$href, "cdn/katex@2.1.2")
+  expect_identical(html_dependency_katex("cdn/katex")$version, "99.99.99")
+  expect_identical(html_dependency_katex("cdn/katex")$src$href, "cdn/katex")
+})
+
 test_that("Local mathjax does not work with self_contained", {
   expect_error(validate_self_contained(list(engine = "mathjax", url = "local")),
                "isn't compatible")


### PR DESCRIPTION
Just in case someone really need to pass a custom KaTeX URL. 

This is supported by Pandoc so we should probably support it as we do our own thing instead of Pandoc's for KaTeX