### PR TITLE
Fix header-includes and in_header in `beamer_presentation`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.14
+Version: 2.11.15
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.12
 ================================================================================
 
+- Fix an issue in `beamer_presentation()` where `header-includes` would be overwritten by `includes = list(in_header =)` (thanks, @samcarter, #2294). Same fix as for `pdf_document()` (#1359).
+
 - `html_document()` and `html_document_base()` gains the `math_method` argument to support [all the math rendering engines from Pandoc](https://pandoc.org/MANUAL.html#math-rendering-in-html): "mathjax", "katex", "mathml", "webtex", and "gladtex". For backward compatibility, `mathjax` argument is still working when `math_method = "default"` which is the default, and will take precedence is `mathjax` is different that `"default"`.  
   From now on, use `math_method` to customize the engine
   ```yaml

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -137,8 +137,15 @@ beamer_presentation <- function(toc = FALSE,
     # save files dir (for generating intermediates)
     saved_files_dir <<- files_dir
 
+    # make sure --include-in-header from command line will not completely
+    # override header-includes in metadata but give the latter lower precedence:
+    # https://github.com/rstudio/rmarkdown/issues/1359
+    # Same in PDF for beamer
+    # https://github.com/rstudio/rmarkdown/issues/2294
+    args <- append_in_header(process_header_includes(metadata))
+
     # no-op other than caching dir location
-    invisible(NULL)
+    args
   }
 
   # generate intermediates (required to make resources available for publish)

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -122,10 +122,6 @@ pdf_document <- function(toc = FALSE,
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))
 
-  append_in_header <- function(text, file = as_tmpfile(text)) {
-    includes_to_pandoc_args(includes(in_header = file))
-  }
-
   # template path and assets
   if (!is.null(template) && !identical(template, "default")) {
     args <- c(args, "--template", pandoc_path_arg(template))
@@ -231,6 +227,19 @@ pdf_document <- function(toc = FALSE,
   )
 }
 
+#' @param ... Arguments passed to \code{pdf_document()}.
+#' @rdname pdf_document
+#' @export
+latex_document <- function(...) {
+  merge_lists(pdf_document(..., keep_tex = TRUE), list(pandoc = list(ext = ".tex")))
+}
+
+#' @rdname pdf_document
+#' @export
+latex_fragment <- function(...) {
+  latex_document(..., template = pkg_file("rmd/fragment/default.tex"))
+}
+
 general_intermediates_generator <- function(
   saved_files_dir, original_input, intermediates_dir
 ) {
@@ -279,11 +288,6 @@ fix_horiz_rule <- function(file) {
   }
 }
 
-process_header_includes <- function(x) {
-  x <- unlist(x[["header-includes"]])
-  gsub('(^|\n)\\s*```\\{=latex\\}\n(.+?\n)```\\s*(\n|$)', '\\1\\2\\3', x)
-}
-
 citation_package_arg <- function(value) {
   value <- value[1]
   if (value == "none") {
@@ -294,20 +298,18 @@ citation_package_arg <- function(value) {
   if (value != "default") paste0("--", value)
 }
 
+# utils
 default_geometry <- function(meta_names, pandoc_args = NULL) {
   !any(c('geometry', 'documentclass') %in% meta_names) &&
     length(grep('^(--(variable|metadata)=)?documentclass:', pandoc_args)) == 0
 }
 
-#' @param ... Arguments passed to \code{pdf_document()}.
-#' @rdname pdf_document
-#' @export
-latex_document <- function(...) {
-  merge_lists(pdf_document(..., keep_tex = TRUE), list(pandoc = list(ext = ".tex")))
+process_header_includes <- function(x) {
+  x <- unlist(x[["header-includes"]])
+  gsub('(^|\n)\\s*```\\{=latex\\}\n(.+?\n)```\\s*(\n|$)', '\\1\\2\\3', x)
 }
 
-#' @rdname pdf_document
-#' @export
-latex_fragment <- function(...) {
-  latex_document(..., template = pkg_file("rmd/fragment/default.tex"))
+append_in_header <- function(text, file = as_tmpfile(text)) {
+  includes_to_pandoc_args(includes(in_header = file))
 }
+


### PR DESCRIPTION
This closes #2294 by doing the same fix as as in 5499ec6 for #1359. 

This solves also the issue of using raw code because the `header-includes` will be put into a preamble file include at command line. 

This is a trick but seems to be useful and needed.