### PR TITLE
Pandoc requires a `=` between math flag and its url value

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -490,7 +490,7 @@ pandoc_math_args <- function(engine = pandoc_math_engines(), url = NULL) {
     stop2(sprintf("%s does not support setting a URL.", engine))
   }
 
-  c(paste0("--", engine), if (!is.null(url)) url)
+  paste0(c("--", engine, if (!is.null(url)) c("=", url)), collapse = "")
 }
 
 

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -87,6 +87,6 @@ test_that("Converting bib file is working", {
 
 test_that("pandoc_math_args() build correct CLI flag", {
   expect_identical(pandoc_math_args("katex"), c("--katex"))
-  expect_identical(pandoc_math_args("katex", "CDN"), c("--katex", "CDN"))
+  expect_identical(pandoc_math_args("webtex", "url"), c("--webtex=url"))
   expect_error(pandoc_math_args("gladtex", "CDN"), "gladtex does not support")
 })


### PR DESCRIPTION
Discovered while looking into the rendering issue
https://github.com/jgm/pandoc/issues/7888