### PR TITLE
Support webtex for Github documents format 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.21
+Version: 2.11.22
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ rmarkdown 2.12
   Most HTML output format using `html_document()` or `html_document_base()` as based format should benefit from this new feature.
   See `?rmarkdown::html_document()` for details (thanks, @atusy, #1940).
   
-- `github_document()` also gains the `math_method` argument set to `"webtex"` by default so that equations can be rendered in the Github Markdown document. Previously, equations were not rendered. Set `math_method = NULL` to deactivate.
+- `github_document()` also gains the `math_method` argument set to `"webtex"` by default so that LaTeX equations can be rendered in the Github Markdown document as images. Previously, LaTeX equations were not rendered. Set `math_method = NULL` to deactivate.
 
 - Added support for [**katex**](https://docs.ropensci.org/katex/) R package as a math engine with `math_method = "r-katex"` in HTML documents. This method offers server-side rendering of all the equations, which means no JS processing is needed in the browser as with usual KaTeX or MathJaX methods. (thanks, @jeroen, #2304).
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@ rmarkdown 2.12
   Most HTML output format using `html_document()` or `html_document_base()` as based format should benefit from this new feature.
   See `?rmarkdown::html_document()` for details (thanks, @atusy, #1940).
   
+- `github_document()` also gain the `math_method` argument set  to `"webtex` by default so that equations can be rendered in the Github Markdown document. Previously, equations were not rendered. Set `math_method = NULL` to deactivate.
+  
 - Fixed broken links to section headers when `number_sections = TRUE` is specified in `md_document` and `github_document` (thanks, @atusy, #2093).
 
 - Added `available_templates()` to list all the templates from a specific package that can be used with `rmarkdown::draft()`.

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -2,8 +2,8 @@
 #'
 #' Format for converting from R Markdown to GitHub Flavored Markdown.
 #'
-#' See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online
-#' documentation} for additional details on using the \code{github_document}
+#' See the [online
+#' documentation](https://rmarkdown.rstudio.com/github_document_format.html) for additional details on using the `github_document()`
 #' format.
 #' @inheritParams output_format
 #' @inheritParams html_document
@@ -11,14 +11,15 @@
 #' @param math_method Use `"webtex"` to activate math rendering using the Webtex
 #'   math method. This will insert math an image in the resulting Markdown. See
 #'   [html_document()] for option to change webtex URL.
-#' @param hard_line_breaks \code{TRUE} to generate markdown that uses a simple
+#' @param hard_line_breaks `TRUE` to generate markdown that uses a simple
 #'   newline to represent a line break (as opposed to two-spaces and a newline).
-#' @param html_preview \code{TRUE} to also generate an HTML file for the purpose of
+#' @param html_preview `TRUE` to also generate an HTML file for the purpose of
 #'   locally previewing what the document will look like on GitHub.
-#' @param keep_html \code{TRUE} to keep the preview HTML file in the working
-#'   directory. Default is \code{FALSE}.
-#' @return R Markdown output format to pass to \code{\link{render}}
+#' @param keep_html `TRUE` to keep the preview HTML file in the working
+#'   directory. Default is `FALSE`.
+#' @return R Markdown output format to pass to [render()]
 #' @export
+#' @md
 github_document <- function(toc = FALSE,
                             toc_depth = 3,
                             number_sections = FALSE,

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -96,7 +96,7 @@ github_document <- function(toc = FALSE,
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
         if (pandoc2) c("--metadata", "pagetitle=PREVIEW"),  # HTML5 requirement
-        if (!is.null(math)) math$args
+        if (!is.null(math_method)) math$args
       )
 
       # run pandoc

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -8,9 +8,9 @@
 #' @inheritParams output_format
 #' @inheritParams html_document
 #' @inheritParams md_document
-#' @param math_method Use `"webtex"` to activate math rendering using the Webtex
-#'   math method. This will insert math an image in the resulting Markdown. See
-#'   [html_document()] for option to change webtex URL.
+#' @param math_method `"webtex"` (the default) is used to render equations. This
+#'   will insert math an image in the resulting Markdown. See [html_document()]
+#'   for option to change webtex URL. Set to `NULL` to opt-out.
 #' @param hard_line_breaks `TRUE` to generate markdown that uses a simple
 #'   newline to represent a line break (as opposed to two-spaces and a newline).
 #' @param html_preview `TRUE` to also generate an HTML file for the purpose of
@@ -23,7 +23,7 @@
 github_document <- function(toc = FALSE,
                             toc_depth = 3,
                             number_sections = FALSE,
-                            math_method = NULL,
+                            math_method = "webtex",
                             fig_width = 7,
                             fig_height = 5,
                             dev = 'png',

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -19,6 +19,7 @@
 github_document <- function(toc = FALSE,
                             toc_depth = 3,
                             number_sections = FALSE,
+                            math_method = NULL,
                             fig_width = 7,
                             fig_height = 5,
                             dev = 'png',
@@ -58,8 +59,9 @@ github_document <- function(toc = FALSE,
 
   format <- md_document(
     variant = variant, toc = toc, toc_depth = toc_depth,
-    number_sections = number_sections, fig_width = fig_width,
-    fig_height = fig_height, dev = dev, df_print = df_print,
+    number_sections = number_sections, math_method = math_method,
+    fig_width = fig_width, fig_height = fig_height,
+    dev = dev, df_print = df_print,
     includes = includes, md_extensions = md_extensions,
     pandoc_args = pandoc_args
   )
@@ -78,6 +80,13 @@ github_document <- function(toc = FALSE,
         "--variable", paste0("github-markdown-css:", css),
         if (pandoc2) c("--metadata", "pagetitle=PREVIEW")  # HTML5 requirement
       )
+
+      # add math support
+      if (!is.null(math_method)) {
+        math <- check_math_argument(math_method)
+        math <- add_math_support(math, NULL, NULL, NULL)
+        args <- c(args, math$args)
+      }
 
       # run pandoc
       preview_file <- file_with_ext(output_file, "html")

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -17,6 +17,22 @@
 #'   locally previewing what the document will look like on GitHub.
 #' @param keep_html `TRUE` to keep the preview HTML file in the working
 #'   directory. Default is `FALSE`.
+#'
+#' @details # About Math support
+#'
+#' For Github Markdown output, PNG images with a white background are used so
+#' that it shows correctly on Github on both light and dark theme. You can
+#' choose to only output SVG for better quality by changing the URL used:
+#'
+#' ```yaml
+#' output:
+#'   github_document:
+#'     math_method:
+#'       engine: webtex
+#'       url: https://latex.codecogs.com/svg.image?
+#' ```
+#'
+#' Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
 #' @return R Markdown output format to pass to [render()]
 #' @export
 #' @md

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -78,11 +78,10 @@ github_document <- function(toc = FALSE,
 
   format <- md_document(
     variant = variant, toc = toc, toc_depth = toc_depth,
-    number_sections = number_sections,
+    number_sections = number_sections, preserve_yaml = preserve_yaml,
     fig_width = fig_width, fig_height = fig_height,
-    dev = dev, df_print = df_print,
-    includes = includes, md_extensions = md_extensions,
-    pandoc_args = pandoc_args
+    dev = dev, df_print = df_print, includes = includes,
+    md_extensions = md_extensions, pandoc_args = pandoc_args
   )
 
   # add a post processor for generating a preview if requested

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -18,9 +18,6 @@
 #'   \href{https://pandoc.org/MANUAL.html}{pandoc online documentation} for
 #'   details.
 #' @param preserve_yaml Preserve YAML front matter in final document.
-#' @param math_method Use `"webtex"` to activate math rendering using the Webtex
-#'   math method. This will insert math an image in the resulting Markdown. See
-#'   [html_document()] for option to change webtex URL.
 #' @param fig_retina Scaling to perform for retina displays. Defaults to
 #'   `NULL` which performs no scaling. A setting of 2 will work for all
 #'   widely used retina displays, but will also result in the output of
@@ -43,7 +40,6 @@ md_document <- function(variant = "markdown_strict",
                         toc = FALSE,
                         toc_depth = 3,
                         number_sections = FALSE,
-                        math_method = NULL,
                         fig_width = 7,
                         fig_height = 5,
                         fig_retina = NULL,
@@ -63,16 +59,6 @@ md_document <- function(variant = "markdown_strict",
 
   # content includes
   args <- c(args, includes_to_pandoc_args(includes))
-
-  # math support
-  if (!is.null(math_method)) {
-    math <- check_math_argument(math_method)
-    if (math$engine != "webtex") {
-      stop("Markdown output format only support 'webtex' for math engine")
-    }
-    math <- add_math_support(math, NULL, NULL, NULL)
-    args <- c(args, math$args)
-  }
 
   # pandoc args
   args <- c(args, pandoc_args)

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -17,6 +17,9 @@
 #'   \href{https://pandoc.org/MANUAL.html}{pandoc online documentation} for
 #'   details.
 #' @param preserve_yaml Preserve YAML front matter in final document.
+#' @param math_method Use `"webtex"` to activate math rendering using the Webtex
+#'   math method. This will insert math an image in the resulting Markdown. See
+#'   [html_document()] for option to change webtex URL.
 #' @param fig_retina Scaling to perform for retina displays. Defaults to
 #'   \code{NULL} which performs no scaling. A setting of 2 will work for all
 #'   widely used retina displays, but will also result in the output of
@@ -33,11 +36,13 @@
 #' render("input.Rmd", md_document(variant = "markdown_github"))
 #' }
 #' @export
+#' @md
 md_document <- function(variant = "markdown_strict",
                         preserve_yaml = FALSE,
                         toc = FALSE,
                         toc_depth = 3,
                         number_sections = FALSE,
+                        math_method = NULL,
                         fig_width = 7,
                         fig_height = 5,
                         fig_retina = NULL,
@@ -57,6 +62,16 @@ md_document <- function(variant = "markdown_strict",
 
   # content includes
   args <- c(args, includes_to_pandoc_args(includes))
+
+  # math support
+  if (!is.null(math_method)) {
+    math <- check_math_argument(math_method)
+    if (math$engine != "webtex") {
+      stop("Markdown output format only support 'webtex' for math engine")
+    }
+    math <- add_math_support(math, NULL, NULL, NULL)
+    args <- c(args, math$args)
+  }
 
   # pandoc args
   args <- c(args, pandoc_args)

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -3,12 +3,13 @@
 #' Format for converting from R Markdown to another variant of markdown (e.g.
 #' strict markdown or github flavored markdown)
 #'
-#' See the \href{https://bookdown.org/yihui/rmarkdown/markdown-document.html}{online
-#' documentation} for additional details on using the \code{md_document} format.
+#' See the [online
+#' documentation](https://bookdown.org/yihui/rmarkdown/markdown-document.html)
+#' for additional details on using the `md_document()` format.
 #'
 #' R Markdown documents can have optional metadata that is used to generate a
 #' document header that includes the title, author, and date. For more details
-#' see the documentation on R Markdown \link[=rmd_metadata]{metadata}.
+#' see the documentation on R Markdown [metadata][rmd_metadata].
 #' @inheritParams html_document
 #' @param variant Markdown variant to produce (defaults to "markdown_strict").
 #'   Other valid values are "commonmark", "gfm", "commonmark_x", "markdown_mmd",
@@ -21,12 +22,12 @@
 #'   math method. This will insert math an image in the resulting Markdown. See
 #'   [html_document()] for option to change webtex URL.
 #' @param fig_retina Scaling to perform for retina displays. Defaults to
-#'   \code{NULL} which performs no scaling. A setting of 2 will work for all
+#'   `NULL` which performs no scaling. A setting of 2 will work for all
 #'   widely used retina displays, but will also result in the output of
-#'   \code{<img>} tags rather than markdown images due to the need to set the
+#'   `<img>` tags rather than markdown images due to the need to set the
 #'   width of the image explicitly.
 #' @param ext Extension of the output file (defaults to ".md").
-#' @return R Markdown output format to pass to \code{\link{render}}
+#' @return R Markdown output format to pass to [render()]
 #' @examples
 #' \dontrun{
 #' library(rmarkdown)

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -8,6 +8,7 @@ github_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
+  math_method = NULL,
   fig_width = 7,
   fig_height = 5,
   dev = "png",
@@ -26,6 +27,31 @@ github_document(
 \item{toc_depth}{Depth of headers to include in table of contents}
 
 \item{number_sections}{\code{TRUE} to number section headings}
+
+\item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
+\itemize{
+\item It can be a string for the engine, one of
+\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
+\item It can be a list of
+\itemize{
+\item \code{engine}:  one of
+'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
+\item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
+Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
+copied into the output directory).
+}
+}
+
+For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
+  html_document:
+    math_method:
+      engine: katex
+      url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
+}\if{html}{\out{</div>}}
+
+See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
+Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
+\code{mathjax}.}
 
 \item{fig_width}{Default width (in inches) for figures}
 

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -28,30 +28,9 @@ github_document(
 
 \item{number_sections}{\code{TRUE} to number section headings}
 
-\item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
-\itemize{
-\item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
-\item It can be a list of
-\itemize{
-\item \code{engine}:  one of
-'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
-\item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
-Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
-copied into the output directory).
-}
-}
-
-For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
-  html_document:
-    math_method:
-      engine: katex
-      url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
-}\if{html}{\out{</div>}}
-
-See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
-Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
-\code{mathjax}.}
+\item{math_method}{Use \code{"webtex"} to activate math rendering using the Webtex
+math method. This will insert math an image in the resulting Markdown. See
+\code{\link[=html_document]{html_document()}} for option to change webtex URL.}
 
 \item{fig_width}{Default width (in inches) for figures}
 
@@ -92,13 +71,12 @@ locally previewing what the document will look like on GitHub.}
 directory. Default is \code{FALSE}.}
 }
 \value{
-R Markdown output format to pass to \code{\link{render}}
+R Markdown output format to pass to \code{\link[=render]{render()}}
 }
 \description{
 Format for converting from R Markdown to GitHub Flavored Markdown.
 }
 \details{
-See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online
-documentation} for additional details on using the \code{github_document}
+See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online documentation} for additional details on using the \code{github_document()}
 format.
 }

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -83,3 +83,16 @@ Format for converting from R Markdown to GitHub Flavored Markdown.
 See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online documentation} for additional details on using the \code{github_document()}
 format.
 }
+\section{About Math support}{
+For Github Markdown output, PNG images with a white background are used so
+that it shows correctly on Github on both light and dark theme. You can
+choose to only output SVG for better quality by changing the URL used:\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
+  github_document:
+    math_method:
+      engine: webtex
+      url: https://latex.codecogs.com/svg.image?
+}\if{html}{\out{</div>}}
+
+Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
+}
+

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -8,7 +8,7 @@ github_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
-  math_method = NULL,
+  math_method = "webtex",
   fig_width = 7,
   fig_height = 5,
   dev = "png",
@@ -28,9 +28,9 @@ github_document(
 
 \item{number_sections}{\code{TRUE} to number section headings}
 
-\item{math_method}{Use \code{"webtex"} to activate math rendering using the Webtex
-math method. This will insert math an image in the resulting Markdown. See
-\code{\link[=html_document]{html_document()}} for option to change webtex URL.}
+\item{math_method}{\code{"webtex"} (the default) is used to render equations. This
+will insert math an image in the resulting Markdown. See \code{\link[=html_document]{html_document()}}
+for option to change webtex URL. Set to \code{NULL} to opt-out.}
 
 \item{fig_width}{Default width (in inches) for figures}
 

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -49,7 +49,7 @@ math method. This will insert math an image in the resulting Markdown. See
 \item{fig_retina}{Scaling to perform for retina displays. Defaults to
 \code{NULL} which performs no scaling. A setting of 2 will work for all
 widely used retina displays, but will also result in the output of
-\code{<img>} tags rather than markdown images due to the need to set the
+\verb{<img>} tags rather than markdown images due to the need to set the
 width of the image explicitly.}
 
 \item{dev}{Graphics device to use for figure output (defaults to png)}
@@ -80,15 +80,15 @@ additional details.}
 \item{ext}{Extension of the output file (defaults to ".md").}
 }
 \value{
-R Markdown output format to pass to \code{\link{render}}
+R Markdown output format to pass to \code{\link[=render]{render()}}
 }
 \description{
 Format for converting from R Markdown to another variant of markdown (e.g.
 strict markdown or github flavored markdown)
 }
 \details{
-See the \href{https://bookdown.org/yihui/rmarkdown/markdown-document.html}{online
-documentation} for additional details on using the \code{md_document} format.
+See the \href{https://bookdown.org/yihui/rmarkdown/markdown-document.html}{online documentation}
+for additional details on using the \code{md_document()} format.
 
 R Markdown documents can have optional metadata that is used to generate a
 document header that includes the title, author, and date. For more details

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -10,7 +10,6 @@ md_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
-  math_method = NULL,
   fig_width = 7,
   fig_height = 5,
   fig_retina = NULL,
@@ -37,10 +36,6 @@ details.}
 \item{toc_depth}{Depth of headers to include in table of contents}
 
 \item{number_sections}{\code{TRUE} to number section headings}
-
-\item{math_method}{Use \code{"webtex"} to activate math rendering using the Webtex
-math method. This will insert math an image in the resulting Markdown. See
-\code{\link[=html_document]{html_document()}} for option to change webtex URL.}
 
 \item{fig_width}{Default width (in inches) for figures}
 

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -10,6 +10,7 @@ md_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
+  math_method = NULL,
   fig_width = 7,
   fig_height = 5,
   fig_retina = NULL,
@@ -36,6 +37,10 @@ details.}
 \item{toc_depth}{Depth of headers to include in table of contents}
 
 \item{number_sections}{\code{TRUE} to number section headings}
+
+\item{math_method}{Use \code{"webtex"} to activate math rendering using the Webtex
+math method. This will insert math an image in the resulting Markdown. See
+\code{\link[=html_document]{html_document()}} for option to change webtex URL.}
 
 \item{fig_width}{Default width (in inches) for figures}
 


### PR DESCRIPTION
This should resolve #1886 and #2003

This adds a `math_method` argument to `github_document()` so that equation can be rendered as an image in the resulting md document

````markdown
---
output:
  github_document:
    math_method: "webtex"
---

Some content

$$
\int \frac{1}{x} dx = \ln \left| x \right| + C
$$
````

is rendered as 

----

Some content

![
\\int \\frac{1}{x} dx = \\ln \\left\| x \\right\| + C
](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;%0A%5Cint%20%5Cfrac%7B1%7D%7Bx%7D%20dx%20%3D%20%5Cln%20%5Cleft%7C%20x%20%5Cright%7C%20%2B%20C%0A "
\int \frac{1}{x} dx = \ln \left| x \right| + C
")

----


We ended up activating by default in github document where there is math. Like in Quarto. 

We default to using PNG format with a DPI of 110 and using white background because otherwise (using svg for example) the equation would not be seen on dark mode in Github. We can't change the color font with the API. 
However, Quarto defaults to SVG because this gives way cleaner output. Quarto documents how to change the background using PNG. Quarto doc about this: https://quarto.org/docs/output-formats/gfm.html#webtex-math 

Should we default to the same ? 

One thing is I am not sure about how we should consider CodeCog fair usage policy. https://editor.codecogs.com/docs/3-fair_usage.php, but I guess it is ok. 
