### PR TITLE
Correctly handle preserve_yaml in markdown formats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.15
+Version: 2.11.19
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -66,9 +66,13 @@ github_document <- function(toc = FALSE,
   )
 
   # add a post processor for generating a preview if requested
-  if (html_preview) {
-    format$post_processor <- function(metadata, input_file, output_file, clean, verbose) {
+  post <- format$post_processor
 
+  format$post_processor <- function(metadata, input_file, output_file, clean, verbose) {
+
+    if (is.function(post)) post(metadata, input_file, output_file, clean, verbose)
+
+    if (html_preview) {
       css <- pkg_file_arg(
         "rmarkdown/templates/github_document/resources/github.css")
       # provide a preview that looks like github

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -19,6 +19,7 @@
 github_document <- function(toc = FALSE,
                             toc_depth = 3,
                             number_sections = FALSE,
+                            preserve_yaml = FALSE,
                             fig_width = 7,
                             fig_height = 5,
                             dev = 'png',
@@ -58,10 +59,10 @@ github_document <- function(toc = FALSE,
 
   format <- md_document(
     variant = variant, toc = toc, toc_depth = toc_depth,
-    number_sections = number_sections, fig_width = fig_width,
-    fig_height = fig_height, dev = dev, df_print = df_print,
-    includes = includes, md_extensions = md_extensions,
-    pandoc_args = pandoc_args
+    number_sections = number_sections, preserve_yaml = preserve_yaml,
+    fig_width = fig_width, fig_height = fig_height,
+    dev = dev, df_print = df_print, includes = includes,
+    md_extensions = md_extensions, pandoc_args = pandoc_args
   )
 
   # add a post processor for generating a preview if requested

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -70,7 +70,7 @@ github_document <- function(toc = FALSE,
 
   format$post_processor <- function(metadata, input_file, output_file, clean, verbose) {
 
-    if (is.function(post)) post(metadata, input_file, output_file, clean, verbose)
+    if (is.function(post)) output_file <- post(metadata, input_file, output_file, clean, verbose)
 
     if (html_preview) {
       css <- pkg_file_arg(
@@ -104,8 +104,9 @@ github_document <- function(toc = FALSE,
 
       if (verbose) message("\nPreview created: ", preview_file)
 
-      output_file
     }
+
+    output_file
   }
 
   format  # return format

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -17,6 +17,8 @@
 #'   \href{https://pandoc.org/MANUAL.html}{pandoc online documentation} for
 #'   details.
 #' @param preserve_yaml Preserve YAML front matter in final document.
+#' @param standalone Set to `TRUE` to include title, date and other metadata
+#'   field in addition to Rmd content as a body.
 #' @param fig_retina Scaling to perform for retina displays. Defaults to
 #'   \code{NULL} which performs no scaling. A setting of 2 will work for all
 #'   widely used retina displays, but will also result in the output of

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -38,6 +38,7 @@ md_document <- function(variant = "markdown_strict",
                         toc = FALSE,
                         toc_depth = 3,
                         number_sections = FALSE,
+                        standalone = FALSE,
                         fig_width = 7,
                         fig_height = 5,
                         fig_retina = NULL,
@@ -50,7 +51,10 @@ md_document <- function(variant = "markdown_strict",
 
 
   # base pandoc options for all markdown output
-  args <- c(if (preserve_yaml) "--standalone")
+
+  if (toc) standalone <- TRUE
+
+  args <- c(if (standalone) "--standalone")
 
   # table of contents
   args <- c(args, pandoc_toc_args(toc, toc_depth))

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -87,15 +87,17 @@ md_document <- function(variant = "markdown_strict",
   }
 
   # variants
-  variant <- adapt_md_variant(variant, preserve_yaml)
+  variant <- adapt_md_variant(variant)
 
-  # add post_processor for yaml preservation if not supported by pandoc
-  post_processor <- if (preserve_yaml && !grepl('yaml_metadata_block', variant, fixed = TRUE)) {
+  # add post_processor for yaml preservation as Pandoc +yaml_metadata_block has
+  # undesired sorting (https://github.com/rstudio/rmarkdown/pull/2190/files)
+  post_processor <- if (preserve_yaml) {
     function(metadata, input_file, output_file, clean, verbose) {
       write_utf8(
         .preserve_yaml(read_utf8(input_file), read_utf8(output_file)),
         output_file
       )
+      output_file
     }
   }
 
@@ -124,40 +126,42 @@ md_document <- function(variant = "markdown_strict",
   output_lines
 }
 
-adapt_md_variant <- function(variant, preserve_yaml) {
+adapt_md_variant <- function(variant) {
   variant_base <- gsub("^([^+-]*).*", "\\1", variant)
   variant_extensions <- gsub(sprintf("^%s", variant_base), "", variant)
 
   set_extension <- function(format, ext, add = TRUE) {
     ext <- paste0(ifelse(add, "+", "-"), ext)
-    if (grepl(ext, format, fixed = TRUE)) return(format)
-    paste0(format, ext, collapse = "")
+    for (e in ext) {
+      if (grepl(e, format, fixed = TRUE)) next
+      format <- paste0(format, e, collapse = "")
+    }
+    format
   }
 
-  add_yaml_block_ext <- function(extensions, preserve_yaml) {
-    set_extension(variant_extensions, "yaml_metadata_block", preserve_yaml)
+  # Remove yaml_metadata_block extension unless user asked otherwise in variant
+  if (!grepl("yaml_metadata_block", variant_extensions, fixed = TRUE)) {
+    variant_extensions <- switch(
+      variant_base,
+      gfm = ,
+      commonmark = ,
+      commonmark_x = {
+        if (pandoc_available(2.13)) {
+          set_extension(variant_extensions, "yaml_metadata_block", FALSE)
+        } else {
+          # Unsupported extension before YAML 2.13
+          variant_extensions
+        }
+      },
+      markdown = set_extension(variant_extensions, c("yaml_metadata_block", "pandoc_title_block"), FALSE),
+      markdown_mmd = set_extension(variant_extensions, c("yaml_metadata_block", "mmd_title_block"), FALSE),
+      markdown_github = ,
+      markdown_phpextra = ,
+      markdown_strict = set_extension(variant_extensions, "yaml_metadata_block", FALSE),
+      # do not modified for unknown (yet) md variant
+      variant_extensions
+    )
   }
-
-  # yaml_metadata_block extension
-  variant_extensions <- switch(
-    variant_base,
-    gfm =,
-    commonmark =,
-    commonmark_x = {
-      if (pandoc_available(2.13)) {
-        add_yaml_block_ext(variant_extensions, preserve_yaml)
-      } else {
-        variant_extensions
-      }
-    },
-    markdown =,
-    markdown_phpextra =,
-    markdown_github =,
-    markdown_mmd =,
-    markdown_strict = add_yaml_block_ext(variant_extensions, preserve_yaml),
-    # do not modified for unknown (yet) md variant
-    variant_extensions
-  )
 
   paste0(variant_base, variant_extensions, collapse = "")
 }

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -8,6 +8,7 @@ github_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
+  preserve_yaml = FALSE,
   fig_width = 7,
   fig_height = 5,
   dev = "png",
@@ -26,6 +27,8 @@ github_document(
 \item{toc_depth}{Depth of headers to include in table of contents}
 
 \item{number_sections}{\code{TRUE} to number section headings}
+
+\item{preserve_yaml}{Preserve YAML front matter in final document.}
 
 \item{fig_width}{Default width (in inches) for figures}
 

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -38,6 +38,9 @@ details.}
 
 \item{number_sections}{\code{TRUE} to number section headings}
 
+\item{standalone}{Set to `TRUE` to include title, date and other metadata
+field in addition to Rmd content as a body.}
+
 \item{fig_width}{Default width (in inches) for figures}
 
 \item{fig_height}{Default height (in inches) for figures}

--- a/man/md_document.Rd
+++ b/man/md_document.Rd
@@ -10,6 +10,7 @@ md_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
+  standalone = FALSE,
   fig_width = 7,
   fig_height = 5,
   fig_retina = NULL,

--- a/tests/testthat/test-md_document.R
+++ b/tests/testthat/test-md_document.R
@@ -1,57 +1,33 @@
 local_edition(3)
 
 test_that("adapt_md_variant() adds extensions to markdown variants", {
-  expect_identical(adapt_md_variant("markdown", TRUE), "markdown+yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_phpextra", TRUE), "markdown_phpextra+yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_mmd", TRUE), "markdown_mmd+yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_strict", TRUE), "markdown_strict+yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_github", TRUE), "markdown_github+yaml_metadata_block")
-
-  expect_identical(adapt_md_variant("markdown", FALSE), "markdown-yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_phpextra", FALSE), "markdown_phpextra-yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_mmd", FALSE), "markdown_mmd-yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_strict", FALSE), "markdown_strict-yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown_github", FALSE), "markdown_github-yaml_metadata_block")
-
-  expect_identical(adapt_md_variant("markdown+yaml_metadata_block", TRUE), "markdown+yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown-yaml_metadata_block", TRUE), "markdown-yaml_metadata_block+yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown+yaml_metadata_block", FALSE), "markdown+yaml_metadata_block-yaml_metadata_block")
-  expect_identical(adapt_md_variant("markdown-yaml_metadata_block", FALSE), "markdown-yaml_metadata_block")
-
-  # ignore correctly unsupported variants
-  expect_identical(adapt_md_variant("markdown_new", TRUE), "markdown_new")
-  expect_identical(adapt_md_variant("markdown_new", FALSE), "markdown_new")
+  expect_identical(adapt_md_variant("markdown"), "markdown-yaml_metadata_block-pandoc_title_block")
+  expect_identical(adapt_md_variant("markdown_phpextra"), "markdown_phpextra-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_mmd"), "markdown_mmd-yaml_metadata_block-mmd_title_block")
+  expect_identical(adapt_md_variant("markdown_strict"), "markdown_strict-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown_github"), "markdown_github-yaml_metadata_block")
+  expect_identical(adapt_md_variant("markdown-yaml_metadata_block"), "markdown-yaml_metadata_block")
 })
 
 test_that("adapt_md_variant() ignored unknown variants", {
-  expect_identical(adapt_md_variant("markdown_new", TRUE), "markdown_new")
-  expect_identical(adapt_md_variant("markdown_new", FALSE), "markdown_new")
+  expect_identical(adapt_md_variant("markdown_new"), "markdown_new")
+  expect_identical(adapt_md_variant("markdown_new"), "markdown_new")
 })
 
 test_that("adapt_md_variant() with special variants (pandoc >= 2.13)", {
   skip_if_not_pandoc('2.13')
-  expect_identical(adapt_md_variant("commonmark", TRUE), "commonmark+yaml_metadata_block")
-  expect_identical(adapt_md_variant("gfm", TRUE), "gfm+yaml_metadata_block")
-  expect_identical(adapt_md_variant("commonmark_x", TRUE), "commonmark_x+yaml_metadata_block")
-  expect_identical(adapt_md_variant("commonmark", FALSE), "commonmark-yaml_metadata_block")
-  expect_identical(adapt_md_variant("gfm", FALSE), "gfm-yaml_metadata_block")
-  expect_identical(adapt_md_variant("commonmark_x", FALSE), "commonmark_x-yaml_metadata_block")
-
-  expect_identical(adapt_md_variant("gfm+yaml_metadata_block", TRUE), "gfm+yaml_metadata_block")
-  expect_identical(adapt_md_variant("gfm-yaml_metadata_block", TRUE), "gfm-yaml_metadata_block+yaml_metadata_block")
-  expect_identical(adapt_md_variant("gfm+yaml_metadata_block", FALSE), "gfm+yaml_metadata_block-yaml_metadata_block")
-  expect_identical(adapt_md_variant("gfm-yaml_metadata_block", FALSE), "gfm-yaml_metadata_block")
-
+  expect_identical(adapt_md_variant("commonmark"), "commonmark-yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm"), "gfm-yaml_metadata_block")
+  expect_identical(adapt_md_variant("commonmark"), "commonmark-yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm+yaml_metadata_block"), "gfm+yaml_metadata_block")
+  expect_identical(adapt_md_variant("gfm-yaml_metadata_block"), "gfm-yaml_metadata_block")
 })
 
 test_that("adapt_md_variant() with special variants (pandoc < 2.13)", {
   skip_if_pandoc('2.13')
-  expect_identical(adapt_md_variant("commonmark", TRUE), "commonmark")
-  expect_identical(adapt_md_variant("gfm", TRUE), "gfm")
-  expect_identical(adapt_md_variant("commonmark_x", TRUE), "commonmark_x")
-  expect_identical(adapt_md_variant("commonmark", FALSE), "commonmark")
-  expect_identical(adapt_md_variant("gfm", FALSE), "gfm")
-  expect_identical(adapt_md_variant("commonmark_x", FALSE), "commonmark_x")
+  expect_identical(adapt_md_variant("commonmark"), "commonmark")
+  expect_identical(adapt_md_variant("gfm"), "gfm")
+  expect_identical(adapt_md_variant("commonmark_x"), "commonmark_x")
 })
 
 test_that("md_document() can preserve yaml", {


### PR DESCRIPTION
This PR closes #2297 and revert the change done previously to #2190 to solve #2118

I appears that Pandoc `yaml_metadata_block` and other `*_block` extension are reordering the YAML header, which we don't really want. 

So we deactivate those extensions that have some impact when `--standalone` is set, and we handle the preservation of YAML directly in the format. 

`--standalone` is needed to `toc` but maybe in other case. Instead of trying to guess when , we set a new `standalone` argument to let the user decide. 

New situation:

* `github_document` is gaining a `preserve_yaml` argument, false by default like `md_document`
* `md_document` is gaining a `standalone` argument if one want to have title and other things from the template. `toc = TRUE` implies `standalone: TRUE`
* YAML preservation is now done by **rmarkdown** only and we deactivate all the extensions related to block metadata that would conflict with preserve yaml when `standalone: TRUE`. 

Does this seems ok ? Anything I may have forget to check ? 
