### PR TITLE
Support R KaTeX package as a new `math-method`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,6 +76,7 @@ Suggests:
     fs,
     rsconnect,
     downlit (>= 0.4.0),
+    katex (>= 1.3.0),
     sass (>= 0.4.0),
     shiny (>= 1.6.0),
     testthat (>= 3.0.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.15
+Version: 2.11.16
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,7 @@ Suggests:
     fs,
     rsconnect,
     downlit (>= 0.4.0),
-    katex (>= 1.3.0),
+    katex (>= 1.4.0),
     sass (>= 0.4.0),
     shiny (>= 1.6.0),
     testthat (>= 3.0.3),

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ rmarkdown 2.12
   Most HTML output format using `html_document()` or `html_document_base()` as based format should benefit from this new feature.
   See `?rmarkdown::html_document()` for details (thanks, @atusy, #1940).
   
+- Added support for [**katex**](https://docs.ropensci.org/katex/) R package as a math engine with `math_method = "r-katex"` in HTML documents. This method offers server-side rendering of all the equations, which means no JS processing is needed in the browser as with usual KaTeX or MathJaX methods. (thanks, @jeroen, #2304).
+  
 - Fixed broken links to section headers when `number_sections = TRUE` is specified in `md_document` and `github_document` (thanks, @atusy, #2093).
 
 - Added `available_templates()` to list all the templates from a specific package that can be used with `rmarkdown::draft()`.

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -92,7 +92,7 @@
 #'@param math_method Math rendering engine to use. This will define the math method to use with Pandoc.
 #'
 #'  * It can be a string for the engine, one of
-#'  `r knitr::combine_words(pandoc_math_engines(), and = "or ", before = "'")`,
+#'  `r knitr::combine_words(c(pandoc_math_engines(), "r-katex"), and = "or ", before = "'")`,
 #'  or `default` for `mathjax`.
 #'  * It can be a list of
 #'    * `engine`:  one of
@@ -110,9 +110,14 @@
 #'        url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
 #'  ```
 #'
-#'  See [Pandoc's Manual about Math in HTML](https://pandoc.org/MANUAL.html#math-rendering-in-html) for the details.
-#'  Note that `c(mathjax = "local")` is equivalent to specifying "local" to
-#'  `mathjax`.
+#'  See [Pandoc's Manual about Math in
+#'  HTML](https://pandoc.org/MANUAL.html#math-rendering-in-html) for the details
+#'  about Pandoc supported methods.
+#'
+#'  Using `math_method = "r-katex"` will opt-in server side rendering using
+#'  KaTeX thanks to [katex](https://docs.ropensci.org/katex/) R package. This is
+#'  useful compared to `math_method = "katex"` to have no JS dependency, only a
+#'  CSS dependency for styling equation.
 #'@param section_divs Wrap sections in \code{<div>} tags, and attach identifiers to the
 #'  enclosing \code{<div>} rather than the header itself.
 #'@param template Pandoc template to use for rendering. Pass "default" to use

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -91,12 +91,11 @@
 #'  \code{NULL} to exclude MathJax entirely.
 #'@param math_method Math rendering engine to use. This will define the math method to use with Pandoc.
 #'
-#'  * It can be a string for the engine, one of
-#'  `r knitr::combine_words(c(pandoc_math_engines(), "r-katex"), and = "or ", before = "'")`,
-#'  or `default` for `mathjax`.
+#'  * It can be a string for the engine, one of `r knitr::combine_words(c(pandoc_math_engines(), "r-katex"), and = "or ", before = '"')`
+#'  or "default" for `mathjax`.
 #'  * It can be a list of
 #'    * `engine`:  one of
-#'      `r knitr::combine_words(pandoc_math_engines(), and = "or ", before = "'")`.
+#'      `r knitr::combine_words(pandoc_math_engines(), and = "or ", before = '"')`.
 #'    * `url`: A specific url to use with `mathjax`, `katex` or `webtex`.
 #'      Note that for `engine = "mathjax"`, `url = "local"` will use a local version of MathJax (which is
 #'  copied into the output directory).

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -291,8 +291,8 @@ add_math_support <- function(math, template, files_dir, output_dir) {
       # TODO: patch template to remove the math variable when needed.
       return(list(args = pandoc_math_args("katex")))
     }
-    warning2("katex R package (>= 1.4.0) is required for server side rendering. Defaulting to online KaTeX.")
-    math$engine <- "katex"
+    stop2("katex R package (>= 1.4.0) is required for server-side rendering.\n",
+          "Install the package or change `math_method`.")
   }
 
   # Default

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -284,14 +284,14 @@ add_math_support <- function(math, template, files_dir, output_dir) {
 
   # Special handling: KaTeX R package
   if (identical(math$engine, "r-katex")) {
-    if (xfun::pkg_available("katex")) {
-      # katex R package will recognize `$..$` and `\(...\)` (inline)
-      # or '$$...$$' and '\\[...\\]' (display). so it is done by Pandoc with
-      # `--mathjax` and not `--katex`
-      # setting no flag will make Pandoc throw a warning
-      return(list(args = pandoc_math_args("mathjax")))
+    if (xfun::pkg_available("katex", "1.4.0")) {
+      # We need to tell pandoc to process the equation,
+      # setting no math argument will make Pandoc throw a warning
+      # If used with a template contained `$math$`, JS and CSS will be inserted
+      # TODO: patch template to remove the math variable when needed.
+      return(list(args = pandoc_math_args("katex")))
     }
-    warning2("katex R package is required for server side rendering. Defaulting to online KaTeX.")
+    warning2("katex R package (>= 1.4.0) is required for server side rendering. Defaulting to online KaTeX.")
     math$engine <- "katex"
   }
 

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -165,7 +165,7 @@ html_document_base <- function(theme = NULL,
   post_processor <- function(metadata, input_file, output_file, clean, verbose) {
 
     # Special KaTeX math support
-    if (identical(math_method, "r-katex") && xfun::pkg_available("katex")) {
+    if (identical(math_method, "r-katex") && xfun::pkg_available("katex", "1.4.0")) {
       katex::render_math_in_html(output_file, output = output_file)
     }
 

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -144,12 +144,12 @@ Only Pandoc color schemes are supported with this engine. With
 
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
-\item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
+\item It can be a string for the engine, one of "mathjax", "mathml", "webtex", "katex", "gladtex", or "r-katex"
+or "default" for \code{mathjax}.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
-'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
+"mathjax", "mathml", "webtex", "katex", or "gladtex".
 \item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
 Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
 copied into the output directory).

--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -145,7 +145,7 @@ Only Pandoc color schemes are supported with this engine. With
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
 \item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
+\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
@@ -163,9 +163,13 @@ For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
       url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
 }\if{html}{\out{</div>}}
 
-See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
-Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
-\code{mathjax}.}
+See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details
+about Pandoc supported methods.
+
+Using \code{math_method = "r-katex"} will opt-in server side rendering using
+KaTeX thanks to \href{https://docs.ropensci.org/katex/}{katex} R package. This is
+useful compared to \code{math_method = "katex"} to have no JS dependency, only a
+CSS dependency for styling equation.}
 
 \item{mathjax}{Include mathjax. The "default" option uses an https URL from a
 MathJax CDN. The "local" option uses a local version of MathJax (which is

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -47,12 +47,12 @@ bootstrap, etc.) into. By default this will be the name of the document with
 
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
-\item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
+\item It can be a string for the engine, one of "mathjax", "mathml", "webtex", "katex", "gladtex", or "r-katex"
+or "default" for \code{mathjax}.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
-'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
+"mathjax", "mathml", "webtex", "katex", or "gladtex".
 \item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
 Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
 copied into the output directory).

--- a/man/html_document_base.Rd
+++ b/man/html_document_base.Rd
@@ -48,7 +48,7 @@ bootstrap, etc.) into. By default this will be the name of the document with
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
 \item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
+\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
@@ -66,9 +66,13 @@ For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
       url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
 }\if{html}{\out{</div>}}
 
-See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
-Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
-\code{mathjax}.}
+See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details
+about Pandoc supported methods.
+
+Using \code{math_method = "r-katex"} will opt-in server side rendering using
+KaTeX thanks to \href{https://docs.ropensci.org/katex/}{katex} R package. This is
+useful compared to \code{math_method = "katex"} to have no JS dependency, only a
+CSS dependency for styling equation.}
 
 \item{mathjax}{Include mathjax. The "default" option uses an https URL from a
 MathJax CDN. The "local" option uses a local version of MathJax (which is

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -104,12 +104,12 @@ Only Pandoc color schemes are supported with this engine. With
 
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
-\item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
+\item It can be a string for the engine, one of "mathjax", "mathml", "webtex", "katex", "gladtex", or "r-katex"
+or "default" for \code{mathjax}.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
-'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
+"mathjax", "mathml", "webtex", "katex", or "gladtex".
 \item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
 Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
 copied into the output directory).

--- a/man/html_notebook.Rd
+++ b/man/html_notebook.Rd
@@ -105,7 +105,7 @@ Only Pandoc color schemes are supported with this engine. With
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
 \item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
+\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
@@ -123,9 +123,13 @@ For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
       url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
 }\if{html}{\out{</div>}}
 
-See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
-Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
-\code{mathjax}.}
+See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details
+about Pandoc supported methods.
+
+Using \code{math_method = "r-katex"} will opt-in server side rendering using
+KaTeX thanks to \href{https://docs.ropensci.org/katex/}{katex} R package. This is
+useful compared to \code{math_method = "katex"} to have no JS dependency, only a
+CSS dependency for styling equation.}
 
 \item{mathjax}{Include mathjax. The "default" option uses an https URL from a
 MathJax CDN. The "local" option uses a local version of MathJax (which is

--- a/man/ioslides_presentation.Rd
+++ b/man/ioslides_presentation.Rd
@@ -97,12 +97,12 @@ header (see \emph{Presentation Size} below for details).}
 
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
-\item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
+\item It can be a string for the engine, one of "mathjax", "mathml", "webtex", "katex", "gladtex", or "r-katex"
+or "default" for \code{mathjax}.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
-'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
+"mathjax", "mathml", "webtex", "katex", or "gladtex".
 \item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
 Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
 copied into the output directory).

--- a/man/ioslides_presentation.Rd
+++ b/man/ioslides_presentation.Rd
@@ -98,7 +98,7 @@ header (see \emph{Presentation Size} below for details).}
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
 \item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
+\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
@@ -116,9 +116,13 @@ For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
       url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
 }\if{html}{\out{</div>}}
 
-See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
-Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
-\code{mathjax}.}
+See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details
+about Pandoc supported methods.
+
+Using \code{math_method = "r-katex"} will opt-in server side rendering using
+KaTeX thanks to \href{https://docs.ropensci.org/katex/}{katex} R package. This is
+useful compared to \code{math_method = "katex"} to have no JS dependency, only a
+CSS dependency for styling equation.}
 
 \item{mathjax}{Include mathjax. The "default" option uses an https URL from a
 MathJax CDN. The "local" option uses a local version of MathJax (which is

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -106,7 +106,7 @@ its size).}
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
 \item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'or }default\code{for}mathjax`.
+\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
@@ -124,9 +124,13 @@ For example,\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
       url: https://cdn.jsdelivr.net/npm/katex@0.11.1/dist
 }\if{html}{\out{</div>}}
 
-See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details.
-Note that \code{c(mathjax = "local")} is equivalent to specifying "local" to
-\code{mathjax}.}
+See \href{https://pandoc.org/MANUAL.html#math-rendering-in-html}{Pandoc's Manual about Math in HTML} for the details
+about Pandoc supported methods.
+
+Using \code{math_method = "r-katex"} will opt-in server side rendering using
+KaTeX thanks to \href{https://docs.ropensci.org/katex/}{katex} R package. This is
+useful compared to \code{math_method = "katex"} to have no JS dependency, only a
+CSS dependency for styling equation.}
 
 \item{mathjax}{Include mathjax. The "default" option uses an https URL from a
 MathJax CDN. The "local" option uses a local version of MathJax (which is

--- a/man/slidy_presentation.Rd
+++ b/man/slidy_presentation.Rd
@@ -105,12 +105,12 @@ its size).}
 
 \item{math_method}{Math rendering engine to use. This will define the math method to use with Pandoc.
 \itemize{
-\item It can be a string for the engine, one of
-\verb{r 'mathjax', 'mathml', 'webtex', 'katex', 'gladtex', or 'r-katex'or }default\code{for}mathjax`.
+\item It can be a string for the engine, one of "mathjax", "mathml", "webtex", "katex", "gladtex", or "r-katex"
+or "default" for \code{mathjax}.
 \item It can be a list of
 \itemize{
 \item \code{engine}:  one of
-'mathjax', 'mathml', 'webtex', 'katex', or 'gladtex'.
+"mathjax", "mathml", "webtex", "katex", or "gladtex".
 \item \code{url}: A specific url to use with \code{mathjax}, \code{katex} or \code{webtex}.
 Note that for \code{engine = "mathjax"}, \code{url = "local"} will use a local version of MathJax (which is
 copied into the output directory).


### PR DESCRIPTION
This is based of #2215 and replaces it. It is based on new math support in **rmarkdown** to offer support for R package **katex** (https://docs.ropensci.org/katex/) 

````yaml
output:
  html_document:
    math_method: r-katex
````

If R package is not available, then it fallbacks to use `math_method: katex`. 

Regarding the implementation,  Pandoc requires us to set some math method otherwise some warnings will be thrown (`[WARNING] Could not convert TeX math `) by Pandoc. And **katex** R packages only handles the syntax resulting by `--mathjax` flag for Pandoc (and not `--katex`). 

This leads to a limitation: On a template where `$math$` variable is included into Pandoc's template, the Mathjax JS library will be inserted in `<head>`. For our default template, we don't have it, but it could happen with non default template (`template` arg in `html_document_base()`. 

