### PR TITLE
Allow empty server context in shiny prerendered

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.11.20
+Version: 2.11.21
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.12
 ================================================================================
 
+- A shiny prerendered document with only a empty server context does not error anymore. Document will be rendered with a empty server function and `server.R` file will be ignored. To use `server.R`, no server context should be present in the Rmd document (thanks, @jcheng5, #2305).
+
 - Templates for `html_document()` and `ioslides_presentation()` gain a new CSS rule to display single line `<summary>` content inline (rstudio/rstudio#10589).
 
 - `md_document()` is gaining a new `standalone` argument, FALSE by default unless `toc = TRUE`. This allows to output authors, date and other metadata per the Pandoc's template. Due to limitation in how Pandoc is handling metadata blocks in its extensions `yaml_metadata_block`, `preserve_yaml = TRUE` now deactivate any extension to let **rmarkdown** directly handle the keeping of YAML block - this means it does not set `standalone = TRUE` by default. `github_document()` is gaining the `preserve_yaml` argument now (thanks, @florisvdh, #2297).

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -476,6 +476,13 @@ shiny_prerendered_option_hook <- function(input) {
       on.exit(close(conn), add = TRUE)
       write(data_file, file = conn, append = TRUE)
     }
+
+    if (identical(options$context, "server")) {
+      # if empty server context, set a default server function
+      if (is_blank(options$code)) {
+        options$code <- "# empty server context"
+      }
+    }
     options
   }
 }

--- a/R/util.R
+++ b/R/util.R
@@ -112,6 +112,15 @@ is_null_or_string <- function(text) {
   is.null(text) || (is.character(text) && (length(text) == 1))
 }
 
+# TODO: Export knitr:::is_blank() in xfun, and use here
+is_blank <- function(x) {
+  if (length(x)) {
+    all(grepl("^\\s*$", x))
+  } else {
+    TRUE
+  }
+}
+
 read_utf8 <- function(file) {
   if (inherits(file, 'connection')) con <- file else {
     con <- base::file(file, encoding = 'UTF-8'); on.exit(close(con), add = TRUE)


### PR DESCRIPTION
This closes https://github.com/rstudio/rmarkdown/issues/2272 

After looking into other more complex solution, I think this is the easiest and the more targeted to the issue. We don't change **knitr** behavior but only empty chunk with `context = "server"` by defaulting to a empty server function in that case.

Example provided is 
````markdown
---
title: "Hello Prerendered Shiny"
output: html_document
runtime: shinyrmd
---

```{r, echo=FALSE}
sliderInput("bins", "Number of bins:", min = 1, max = 50, value = 30)
```

```{r, context="server"}
```
````

With current **rmarkdown** version, it will lead to an error because no value is passed to context and no `server.R` file is provided. 
As explained in https://github.com/rstudio/rmarkdown/issues/2272#issuecomment-1034009694, this is because **knitr** won't call evaluate hook on an empty code chunk, and so the shiny prerendered magic does not apply. 

This PR insert a comment in the code chunk if an empty server is provided so that knitr trigger the evaluate hook and the context is registered in the HTML.  `shiny_prerendered_app()` generate this server function, 
````r
  server <- function(input, output, session) {
    eval(xfun::parse_only(.server_context))
  }
````
which will result in an empty server function for the app if `.server_context` is only a comment. 

Only possible breaking change I am seing is that previously, if you had a empty server context but a `server.R` file, the app would render. With this change, the `server.R` file won't be used. I don't think this situation would happen so I think it is fine to change. 

Do you think that solves your issue in the first place ? Do you see any side effect I may have not think of ? 