### PR TITLE
Fix dropdowns and navbar collapsing with Bootstrap 5

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -769,6 +769,7 @@ navbar_links_tags <- function(links, depth = 0L) {
                 tags$a(
                   href = "#", class = "dropdown-toggle",
                   `data-toggle` = "dropdown", role = "button",
+                  `data-bs-toggle` = "dropdown", # BS5
                   `aria-expanded` = "false", link_text),
                 tags$ul(class = "dropdown-menu", role = "menu", submenuLinks)
         )

--- a/inst/rmd/h/_navbar.html
+++ b/inst/rmd/h/_navbar.html
@@ -2,7 +2,7 @@
 <div class="navbar navbar-%s  navbar-fixed-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-bs-toggle="collapse" data-target="#navbar" data-bs-target="#navbar">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>

--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -488,7 +488,7 @@ $if(theme)$
 
 $if(code_menu)$
 <div class="btn-group pull-right float-right">
-<button type="button" class="btn btn-default btn-xs btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span>Code</span> <span class="caret"></span></button>
+<button type="button" class="btn btn-default btn-xs btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span>Code</span> <span class="caret"></span></button>
 <ul class="dropdown-menu dropdown-menu-right" style="min-width: 50px;">
 $if(code_folding)$
 <li><a id="rmd-show-all-code" href="#">Show All Code</a></li>

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -34,7 +34,9 @@ window.initializeCodeFolding = function(show) {
     showCodeButton.append(showCodeText);
     showCodeButton
         .attr('data-toggle', 'collapse')
+        .attr('data-bs-toggle', 'collapse') // BS5
         .attr('data-target', '#' + id)
+        .attr('data-bs-target', '#' + id)   // BS5
         .attr('aria-expanded', showThis)
         .attr('aria-controls', id);
 


### PR DESCRIPTION
For some context, see https://github.com/rstudio/bslib/issues/414

Also, it turns out navbar's are pretty broken in Bootstrap 5 with the latest bslib, but I'll be fixing that inside bslib