### PR TITLE
Do not wrap text in ioslides_presentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ rmarkdown 2.13
 
 - Fix an issue with older R version and `preserve_yaml = TRUE` in `md_document()` (#2325).
 
+- Long title in `ioslides_presentation` failed to work with Pandoc 2.17.x (thanks, @Am386DX-40, #2327).
+
+
 rmarkdown 2.12
 ================================================================================
 

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -328,6 +328,10 @@ ioslides_presentation <- function(number_sections = FALSE,
   if (!is.null(analytics))
     args <- c(args, pandoc_variable_arg("analytics", analytics))
 
+  # do not wrap lines: https://github.com/rstudio/rmarkdown/issues/2327
+  if (!length(grep('--wrap', pandoc_args)))
+    pandoc_args <- c('--wrap', 'none', pandoc_args)
+
   # pre-processor for arguments that may depend on the name of the
   # the input file (e.g. ones that need to copy supporting files)
   pre_processor <- function(metadata, input_file, runtime, knit_meta, files_dir,


### PR DESCRIPTION
otherwise it can generate an invalid JSON object like

```
    var SLIDE_CONFIG = {
      // Slide settings
      settings: {
                title: 'This is a very long title that breaks
rmarkdown or knitr or something',
    ...
```

which will lead to failure to generate the slides.