### PR TITLE
Add a new empty line before adding shiny prerendered context dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.13.1
+Version: 2.13.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.14
 ================================================================================
 
-
+- Fix an issue with Shiny prerendered documents and Pandoc not correctly rendering last markdown paragraph in HTML (thanks, @gadenbuie, #2336).
 
 rmarkdown 2.13
 ================================================================================

--- a/R/shiny_prerendered.R
+++ b/R/shiny_prerendered.R
@@ -359,9 +359,13 @@ shiny_prerendered_append_dependencies <- function(input, # always UTF-8
   # remove NULLs (excluded dependencies)
   dependencies <- dependencies[!sapply(dependencies, is.null)]
 
-  # append them to the file (guarnateed to be UTF-8)
+  # append them to the file (guaranteed to be UTF-8)
   con <- file(input, open = "at", encoding = "UTF-8")
   on.exit(close(con), add = TRUE)
+
+  # Add newline before adding any raw html dependency script
+  # https://github.com/rstudio/rmarkdown/issues/2336
+  writeLines("", con = con)
 
   # write deps to connection
   dependencies_json <- jsonlite::serializeJSON(dependencies, pretty = FALSE)


### PR DESCRIPTION
This fixes #2336 by making sure an empty line is added before any script dependencies. 