### PR TITLE
`site_generator()` stops search at RStudio project root

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.13.3
+Version: 2.13.4
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.14
 ================================================================================
 
+- Fix an issue with `site_generator()` detection of a site project (thanks, @bhattmaulik, #2344).
+
 - Fix an issue with Shiny prerendered documents and Pandoc not correctly rendering last markdown paragraph in HTML (thanks, @gadenbuie, #2336).
 
 - Fixed a bug that `site_generator()` fails to detect the root dir of the site and causes infinite recursion (thanks, @fisher-j, #2339).

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -251,10 +251,12 @@ clean_site <- function(input = ".", preview = TRUE, quiet = FALSE,
 #' @rdname render_site
 #' @export
 site_generator <- function(input = ".", output_format = NULL) {
-
+  has_rproj <- function(dir) {
+    length(list.files(dir, "[.]Rproj$")) != 0
+  }
   # look for the closest index file with 'site' metadata
   root <- tryCatch(
-    proj_root(input, "^index.R?md$", "^\\s*site:.*::.*$"),
+    proj_root(input, "^index.R?md$", "^\\s*site:.*::.*$", has_rproj),
     error = function(e) NULL
   )
 

--- a/R/util.R
+++ b/R/util.R
@@ -532,14 +532,15 @@ xfun_session_info <- function() {
 
 # given a path of a file (or dir) in a potential project (e.g., an R package),
 # figure out the project root
-proj_root <- function(path, file = '^DESCRIPTION$', pattern = '^Package: ') {
+proj_root <- function(path, file = '^DESCRIPTION$', pattern = '^Package: ', stop_when = NULL) {
   dir <- if (dir_exists(path)) path else dirname(path)
   if (same_path(dir, file.path(dir, '..'))) return()
   for (f in list.files(dir, file, full.names = TRUE)) {
     if (length(grep(pattern, read_utf8(f)))) return(dir)
   }
+  if (is.function(stop_when) && stop_when(dir)) return()
   dir <- normalize_path(dir)
-  proj_root(dirname(dir), file, pattern)
+  proj_root(dirname(dir), file, pattern, stop_when)
 }
 
 


### PR DESCRIPTION
This fixes #2344 by making sure that we don't look too far up the folder trees when looking for a project root. 

I added a `stop_when` condition which should be a function that will take the current `dir` analysed and return `TRUE` is stop condition is met. This allows to keep the `proj_root` function quite generic. However, we could maybe internalize the stop condition ? 

`proj_root()` is also used in here 
https://github.com/rstudio/rmarkdown/blob/04a8bebb0a0d1a1489acecd0f3994608feca3fee/R/shiny_prerendered.R#L330
do you think it should also be stopped at `.Rproj` level ? 

I am not sure as the main issue here is to prevent the RStudio IDE to wrongly decide it is a project website to build. 

