### PR TITLE
Add support for native math by default in Github document

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.14.1
+Version: 2.14.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ rmarkdown 2.15
 
 - The `tufte_handout()` function inside **rmarkdown** is defunct now. Its codebase was moved to the **tufte** package in 2016, and this function was marked as deprecated in 2021. Please use `tufte::tufte_handout()` instead of `rmarkdown::tufte_handout()`. The latter will be removed eventually from this package.
 
+- `github_document()` gains `math_method = "default"` and defaults to it. No special processing will be done to inline maths in `$` and block maths 
+in `$$` as now [Github supports it](https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/) and will render using Mathjax (thanks, @kylebutts, #2361).
+
 
 rmarkdown 2.14
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,7 @@ rmarkdown 2.15
 
 - The `tufte_handout()` function inside **rmarkdown** is defunct now. Its codebase was moved to the **tufte** package in 2016, and this function was marked as deprecated in 2021. Please use `tufte::tufte_handout()` instead of `rmarkdown::tufte_handout()`. The latter will be removed eventually from this package.
 
-- `github_document()` gains `math_method = "default"` and defaults to it. No special processing will be done to inline maths in `$` and block maths 
-in `$$` as now [Github supports it](https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/) and will render using Mathjax (thanks, @kylebutts, #2361).
+- `github_document()` gains `math_method = "default"` and defaults to it. No special processing will be done to inline maths in `$` and block maths in `$$` as now [Github supports it](https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/) and will render using Mathjax (thanks, @kylebutts, #2361).
 
 
 rmarkdown 2.14

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -39,7 +39,7 @@
 github_document <- function(toc = FALSE,
                             toc_depth = 3,
                             number_sections = FALSE,
-                            math_method = "webtex",
+                            math_method = "default",
                             preserve_yaml = FALSE,
                             fig_width = 7,
                             fig_height = 5,
@@ -81,12 +81,18 @@ github_document <- function(toc = FALSE,
   # math support
   if (!is.null(math_method)) {
     math <- check_math_argument(math_method)
-    if (math$engine != "webtex") {
-      stop("Markdown output format only support 'webtex' for math engine")
+    if (!math$engine %in% c("default", "webtex")) {
+      stop("Markdown output format only support 'default' for native Github Math support or 'webtex' for using a Webtex online service to render math.")
     }
-    if (is.null(math$url)) {
-      # default to png and white background
+    if (math$engine == "webtex" && is.null(math$url)) {
+      # default to png and white background for webtex
       math$url <- "https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;"
+    } else if (math$engine == "default") {
+      # don't activate math in Pandoc and pass it as is
+      # https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/
+      math <- NULL
+      # TODO: Check for version - should be the default in Pandoc 2.19+
+      variant <- paste0(variant, "+tex_math_dollars")
     }
     math <- add_math_support(math, NULL, NULL, NULL)
     pandoc_args <- c(pandoc_args, math$args)
@@ -106,7 +112,11 @@ github_document <- function(toc = FALSE,
   format$post_processor <- function(metadata, input_file, output_file, clean, verbose) {
 
     if (is.function(post)) output_file <- post(metadata, input_file, output_file, clean, verbose)
-
+    # handle specifically math method for preview
+    preview_math_arg <- switch(math_method %||% "",
+                               default = "--mathjax",
+                               webtex  = math$args,
+                               NULL)
     if (html_preview) {
       css <- pkg_file_arg(
         "rmarkdown/templates/github_document/resources/github.css")
@@ -117,7 +127,7 @@ github_document <- function(toc = FALSE,
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
         if (pandoc2) c("--metadata", "pagetitle=PREVIEW"),  # HTML5 requirement
-        if (!is.null(math_method)) math$args
+        preview_math_arg
       )
 
       # run pandoc

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -79,7 +79,7 @@ github_document <- function(toc = FALSE,
   }
 
   # math support
-  if (!is.null(math_method)) {
+  if (!is.null(math_method) && pandoc_available("2.0.4")) {
     math <- check_math_argument(math_method)
     preview_math <- NULL
     if (!math$engine %in% c("default", "webtex")) {

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -106,6 +106,7 @@ github_document <- function(toc = FALSE,
       preview_math <- check_math_argument("webtex")
     }
     math <- add_math_support(math, NULL, NULL, NULL)
+    preview_math <- add_math_support(preview_math, NULL, NULL, NULL)
     pandoc_args <- c(pandoc_args, math$args)
   }
 
@@ -134,7 +135,7 @@ github_document <- function(toc = FALSE,
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
         if (pandoc2) c("--metadata", "pagetitle=PREVIEW"),  # HTML5 requirement
-        if (!is.null(preview_math)) add_math_support(preview_math)$args
+        if (!is.null(preview_math)) preview_math$args
       )
 
       # run pandoc

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -8,9 +8,12 @@
 #' @inheritParams output_format
 #' @inheritParams html_document
 #' @inheritParams md_document
-#' @param math_method `"webtex"` (the default) is used to render equations. This
-#'   will insert math an image in the resulting Markdown. See [html_document()]
-#'   for option to change webtex URL. Set to `NULL` to opt-out.
+#' @param math_method `"default"` means that [native Github
+#'   support](https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/)
+#'    for math notations using Mathjax syntax will be used. Other possible value
+#'   is `"webtex"` where equation will be rendered to an image in the resulting
+#'   Markdown. See [html_document()] for option to change webtex URL. Set `math_method`to
+#'   `NULL` to opt-out any math treatment.
 #' @param hard_line_breaks `TRUE` to generate markdown that uses a simple
 #'   newline to represent a line break (as opposed to two-spaces and a newline).
 #' @param html_preview `TRUE` to also generate an HTML file for the purpose of
@@ -20,7 +23,11 @@
 #'
 #' @details # About Math support
 #'
-#' For Github Markdown output, PNG images with a white background are used so
+#' Default behavior is to keep any inline equation using `$` and any block
+#' equation using `$$` in the resulting markdown as Github will process those
+#' using Mathjax.
+#'
+#' When using `webtex`, PNG images with a white background are used by default so
 #' that it shows correctly on Github on both light and dark theme. You can
 #' choose to only output SVG for better quality by changing the URL used:
 #'
@@ -33,6 +40,7 @@
 #' ```
 #'
 #' Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
+#'
 #' @return R Markdown output format to pass to [render()]
 #' @export
 #' @md

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -25,11 +25,9 @@
 #'
 #' Default behavior is to keep any inline equation using `$` and any block
 #' equation using `$$` in the resulting markdown as Github will process those
-#' using Mathjax.
+#' using Mathjax. **This feature is only available with Pandoc 2.10.1 and above**
 #'
-#' **This feature is only available with Pandoc 2.10.1 and above**
-#'
-#' When using `webtex`, PNG images with a white background are used by default so
+#' When using `"webtex"`, PNG images with a white background are used by default so
 #' that it shows correctly on Github on both light and dark theme. You can
 #' choose to only output SVG for better quality by changing the URL used:
 #'
@@ -43,7 +41,7 @@
 #'
 #' Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
 #'
-#' **Using `webtex` will be the default with Pandoc 2.0.4 until Pandoc 2.10. Before 2.0.4, Github document output does not support math.**
+#' Using `"webtex"` will be the default with Pandoc 2.0.4 until Pandoc 2.10. Before 2.0.4, Github document output does not support math.
 #'
 #' @return R Markdown output format to pass to [render()]
 #' @export

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -27,6 +27,8 @@
 #' equation using `$$` in the resulting markdown as Github will process those
 #' using Mathjax.
 #'
+#' **This feature is only available with Pandoc 2.10.1 and above**
+#'
 #' When using `webtex`, PNG images with a white background are used by default so
 #' that it shows correctly on Github on both light and dark theme. You can
 #' choose to only output SVG for better quality by changing the URL used:
@@ -40,6 +42,8 @@
 #' ```
 #'
 #' Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
+#'
+#' **Using `webtex` will be the default with Pandoc 2.0.4 until Pandoc 2.10. Before 2.0.4, Github document output does not support math.**
 #'
 #' @return R Markdown output format to pass to [render()]
 #' @export

--- a/inst/rmarkdown/templates/github_document/resources/preview.html
+++ b/inst/rmarkdown/templates/github_document/resources/preview.html
@@ -21,6 +21,10 @@ body {
 }
 </style>
 
+$if(math)$
+  $math$
+$endif$
+
 </head>
 
 <body>

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -8,7 +8,7 @@ github_document(
   toc = FALSE,
   toc_depth = 3,
   number_sections = FALSE,
-  math_method = "webtex",
+  math_method = "default",
   preserve_yaml = FALSE,
   fig_width = 7,
   fig_height = 5,

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -88,11 +88,9 @@ format.
 \section{About Math support}{
 Default behavior is to keep any inline equation using \code{$} and any block
 equation using \verb{$$} in the resulting markdown as Github will process those
-using Mathjax.
+using Mathjax. \strong{This feature is only available with Pandoc 2.10.1 and above}
 
-\strong{This feature is only available with Pandoc 2.10.1 and above}
-
-When using \code{webtex}, PNG images with a white background are used by default so
+When using \code{"webtex"}, PNG images with a white background are used by default so
 that it shows correctly on Github on both light and dark theme. You can
 choose to only output SVG for better quality by changing the URL used:\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
   github_document:
@@ -103,6 +101,6 @@ choose to only output SVG for better quality by changing the URL used:\if{html}{
 
 Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
 
-\strong{Using \code{webtex} will be the default with Pandoc 2.0.4 until Pandoc 2.10. Before 2.0.4, Github document output does not support math.}
+Using \code{"webtex"} will be the default with Pandoc 2.0.4 until Pandoc 2.10. Before 2.0.4, Github document output does not support math.
 }
 

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -90,6 +90,8 @@ Default behavior is to keep any inline equation using \code{$} and any block
 equation using \verb{$$} in the resulting markdown as Github will process those
 using Mathjax.
 
+\strong{This feature is only available with Pandoc 2.10.1 and above}
+
 When using \code{webtex}, PNG images with a white background are used by default so
 that it shows correctly on Github on both light and dark theme. You can
 choose to only output SVG for better quality by changing the URL used:\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
@@ -100,5 +102,7 @@ choose to only output SVG for better quality by changing the URL used:\if{html}{
 }\if{html}{\out{</div>}}
 
 Background or fonts color cannot be changed for now and your equation may not be visible on dark theme.
+
+\strong{Using \code{webtex} will be the default with Pandoc 2.0.4 until Pandoc 2.10. Before 2.0.4, Github document output does not support math.}
 }
 

--- a/man/github_document.Rd
+++ b/man/github_document.Rd
@@ -29,9 +29,11 @@ github_document(
 
 \item{number_sections}{\code{TRUE} to number section headings}
 
-\item{math_method}{\code{"webtex"} (the default) is used to render equations. This
-will insert math an image in the resulting Markdown. See \code{\link[=html_document]{html_document()}}
-for option to change webtex URL. Set to \code{NULL} to opt-out.}
+\item{math_method}{\code{"default"} means that \href{https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/}{native Github support}
+for math notations using Mathjax syntax will be used. Other possible value
+is \code{"webtex"} where equation will be rendered to an image in the resulting
+Markdown. See \code{\link[=html_document]{html_document()}} for option to change webtex URL. Set \code{math_method}to
+\code{NULL} to opt-out any math treatment.}
 
 \item{preserve_yaml}{Preserve YAML front matter in final document.}
 
@@ -84,7 +86,11 @@ See the \href{https://rmarkdown.rstudio.com/github_document_format.html}{online 
 format.
 }
 \section{About Math support}{
-For Github Markdown output, PNG images with a white background are used so
+Default behavior is to keep any inline equation using \code{$} and any block
+equation using \verb{$$} in the resulting markdown as Github will process those
+using Mathjax.
+
+When using \code{webtex}, PNG images with a white background are used by default so
 that it shows correctly on Github on both light and dark theme. You can
 choose to only output SVG for better quality by changing the URL used:\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
   github_document:

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -60,7 +60,7 @@ test_that("github_document supports native math", {
 
 test_that("github_document supports math with webtex", {
   skip_on_cran()
-  skip_if_not_pandoc()
+  skip_if_not_pandoc("2.0.4")
   skip_if_offline("latex.codecogs.com")
   tmp_file <- local_rmd_file(c(
     "**The Cauchy-Schwarz Inequality**",
@@ -75,6 +75,7 @@ test_that("github_document supports math with webtex", {
 test_that("github_document uses webtex as default for pandoc before 2.10.1", {
   skip_on_cran()
   skip_if_pandoc("2.10.1")
+  skip_if_not_pandoc("2.0.4")
   skip_if_offline("latex.codecogs.com")
   tmp_file <- local_rmd_file(c(
     "**The Cauchy-Schwarz Inequality**",

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -44,4 +44,30 @@ test_that("github_document produces atx-header", {
   expect_snapshot_file(res, "github-atx.md", compare = compare_file_text)
 })
 
+test_that("github_document math support with native math", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  tmp_file <- local_rmd_file(c(
+    "**The Cauchy-Schwarz Inequality**",
+    "$$\\sum_{k=1}^n$$",
+    "",
+    "This sentence uses `$` delimiters to show math inline:  $\\sqrt{3x-1}+(1+x)^2$"
+  ))
+  res <- .render_and_read(tmp_file, output_format = github_document(html_preview = FALSE))
+  expect_match(res, "$$\\sum_{k=1}^n$$", fixed = TRUE, all = FALSE)
+  expect_match(res, "$\\sqrt{3x-1}+(1+x)^2$", fixed = TRUE, all = FALSE)
+})
 
+test_that("github_document math support with webtex math math", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  skip_if_offline("latex.codecogs.com")
+  tmp_file <- local_rmd_file(c(
+    "**The Cauchy-Schwarz Inequality**",
+    "$$\\sum_{k=1}^n$$",
+    "",
+    "This sentence uses `$` delimiters to show math inline:  $\\sqrt{3x-1}+(1+x)^2$"
+  ))
+  res <- .render_and_read(tmp_file, output_format = github_document(html_preview = FALSE, math_method = "webtex"))
+  expect_match(res, "^!\\[.*][(]https://latex[.]codecogs[.]com", all = FALSE)
+})

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -44,9 +44,9 @@ test_that("github_document produces atx-header", {
   expect_snapshot_file(res, "github-atx.md", compare = compare_file_text)
 })
 
-test_that("github_document math support with native math", {
+test_that("github_document supports native math", {
   skip_on_cran()
-  skip_if_not_pandoc()
+  skip_if_not_pandoc("2.10.1")
   tmp_file <- local_rmd_file(c(
     "**The Cauchy-Schwarz Inequality**",
     "$$\\sum_{k=1}^n$$",
@@ -58,7 +58,7 @@ test_that("github_document math support with native math", {
   expect_match(res, "$\\sqrt{3x-1}+(1+x)^2$", fixed = TRUE, all = FALSE)
 })
 
-test_that("github_document math support with webtex math math", {
+test_that("github_document supports math with webtex", {
   skip_on_cran()
   skip_if_not_pandoc()
   skip_if_offline("latex.codecogs.com")
@@ -69,5 +69,19 @@ test_that("github_document math support with webtex math math", {
     "This sentence uses `$` delimiters to show math inline:  $\\sqrt{3x-1}+(1+x)^2$"
   ))
   res <- .render_and_read(tmp_file, output_format = github_document(html_preview = FALSE, math_method = "webtex"))
+  expect_match(res, "^!\\[.*][(]https://latex[.]codecogs[.]com", all = FALSE)
+})
+
+test_that("github_document uses webtex as default for pandoc before 2.10.1", {
+  skip_on_cran()
+  skip_if_pandoc("2.10.1")
+  skip_if_offline("latex.codecogs.com")
+  tmp_file <- local_rmd_file(c(
+    "**The Cauchy-Schwarz Inequality**",
+    "$$\\sum_{k=1}^n$$",
+    "",
+    "This sentence uses `$` delimiters to show math inline:  $\\sqrt{3x-1}+(1+x)^2$"
+  ))
+  res <- .render_and_read(tmp_file, output_format = github_document(html_preview = FALSE, math_method = "default"))
   expect_match(res, "^!\\[.*][(]https://latex[.]codecogs[.]com", all = FALSE)
 })


### PR DESCRIPTION
This closes #2361

This PR introduce `math_method = "default"`, at use it by default; This will make sure that maths are passed as-is to Markdown document as Github will now handle it using Mathjax for the rendering. 

For github document HTML preview, we use `mathjax` or `webtex` to make the math rendered.

Only uncertainty right now is which is the minimal version that supports its. I'll test.