### PR TITLE
Use `while` instead of `for` loop when adjusting pandoc styles

### DIFF
--- a/inst/rmd/h/default.html
+++ b/inst/rmd/h/default.html
@@ -97,13 +97,20 @@ $endif$
   for (var i = 0; i < sheets.length; i++) {
     if (sheets[i].ownerNode.dataset["origin"] !== "pandoc") continue;
     try { var rules = sheets[i].cssRules; } catch (e) { continue; }
-    for (var j = 0; j < rules.length; j++) {
+    var j = 0;
+    while (j < rules.length) {
       var rule = rules[j];
       // check if there is a div.sourceCode rule
-      if (rule.type !== rule.STYLE_RULE || rule.selectorText !== "div.sourceCode") continue;
+      if (rule.type !== rule.STYLE_RULE || rule.selectorText !== "div.sourceCode") {
+        j++;
+        continue;
+      }
       var style = rule.style.cssText;
       // check if color or background-color is set
-      if (rule.style.color === '' && rule.style.backgroundColor === '') continue;
+      if (rule.style.color === '' && rule.style.backgroundColor === '') {
+        j++;
+        continue;
+      }
       // replace div.sourceCode by a pre.sourceCode rule
       sheets[i].deleteRule(j);
       sheets[i].insertRule('pre.sourceCode{' + style + '}', j);


### PR DESCRIPTION
While working on updating [cleanrmd](https://github.com/gadenbuie/cleanrmd)'s custom pandoc template, I realized there's a small bug in the JavaScript code in the `rmd/h/default.html` template.

In the script below, a for loop is used to walk over the elements in `rules`, which contain the CSS rules being modified. Inside the for loop, if a CSS rule matches certain tests, then it is rewritten and re-added to the stylesheet and the original rule is removed.

https://github.com/rstudio/rmarkdown/blob/f2bfeec501441abfa17b64fce12de7157bd75940/inst/rmd/h/default.html#L99-L110

The bug is that `rules` uses reference semantics, so when the rule is deleted at the end of the loop we _should not_ increment `j` (the index of the current rule to be inspected) because the next item to consider in `rules` is in the position of the now-deleted rule. By switching to a `while` loop we have better control over how the counter is incremented.

I wanted to point out the issue and provide a fix, but I haven't tested it extensively since I'm not entirely familiar with exactly what the script needs to accomplish.