### PR TITLE
Test pandoc-devel on ubuntu latest

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,8 +30,8 @@ jobs:
           # testing R release with last shipped pandoc version in RStudio IDE and new pandoc
           - {os: windows-latest, pandoc: '2.18',  r: 'release'}
           - {os: macOS-latest,   pandoc: '2.18',  r: 'release'}
+          - {os: ubuntu-latest,  pandoc: 'devel',   r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.18',  r: 'release'}
-          - {os: ubuntu-18.04,   pandoc: 'devel',   r: 'release'}
           # testing older pandoc versions
           - {os: ubuntu-18.04,   pandoc: '2.17.1.1',  r: 'release'}
           - {os: ubuntu-18.04,   pandoc: '2.14.2',  r: 'release'}


### PR DESCRIPTION
as Pandoc daily is now built on ubuntu-latest
https://github.com/jgm/pandoc/commit/1f3f9d6dda46f5125d9710bf095fbb449a98b823

fix #2396