### PR TITLE
Search also in `index.rmd` for `site:` key in YAML header in addition to `index.Rmd`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.17
 ================================================================================
 
-
+- `rmarkdown::render_site()` will now also look for `index.rmd` in addition to `index.Rmd` for custom site generator in YAML with `site:` (thanks, @kamalsacranie, #2409).
 
 rmarkdown 2.16
 ================================================================================

--- a/R/render_site.R
+++ b/R/render_site.R
@@ -256,7 +256,7 @@ site_generator <- function(input = ".", output_format = NULL) {
   }
   # look for the closest index file with 'site' metadata
   root <- tryCatch(
-    proj_root(input, "^index.R?md$", "^\\s*site:.*::.*$", has_rproj),
+    proj_root(input, "^index.[rR]?md$", "^\\s*site:.*::.*$", has_rproj),
     error = function(e) NULL
   )
 
@@ -273,9 +273,11 @@ site_generator <- function(input = ".", output_format = NULL) {
   }
 
   # determine the index file (will be index.Rmd or index.md)
-  index <- file.path(root, "index.Rmd")
-  if (!file.exists(index))
-    index <- file.path(root, "index.md")
+  index <- xfun::existing_files(
+    file.path(root, xfun::with_ext("index", c("Rmd", "rmd"))),
+    first = TRUE, error = FALSE
+  )
+  if (length(index) == 0) index <- file.path(root, "index.md")
 
   # is this in a subdir of the site root? (only some generators support this)
   in_subdir <- !same_path(input, root)

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -1,4 +1,4 @@
-context("site")
+local_edition(3)
 
 # copy part of our demo site to a tempdir
 local_create_site <- function(files, env = parent.frame()) {
@@ -13,7 +13,7 @@ local_create_site <- function(files, env = parent.frame()) {
   site_dir
 }
 
-test_that("render_site", {
+test_that("render_site works", {
 
   # copy our demo site to a tempdir
   site_dir <- local_create_site()
@@ -39,6 +39,18 @@ test_that("render_site", {
   # respected excluded
   excluded <- "docs.txt"
   expect_true(all(!file.exists(file.path(site_dir, "_site", excluded))))
+})
+
+test_that("site_generator() correctly try to use custom site generator", {
+  # copy our demo site to a tempdir
+  site_dir <- local_create_site()
+  withr::local_dir(site_dir)
+  expect_equal(site_generator(), default_site("."))
+  xfun::gsub_file("index.Rmd", "(output: html_document)", "\\1\nsite: rmarkdown::dummy_site")
+  # It errors if not found
+  expect_error(site_generator(), regexp = "'dummy_site' is not an exported object from 'namespace:rmarkdown'", fixed = TRUE)
+  file.rename("index.Rmd", "index.rmd")
+  expect_error(site_generator(), regexp = "'dummy_site' is not an exported object from 'namespace:rmarkdown'", fixed = TRUE)
 })
 
 test_that("render_site respects 'new_session' in the config", {


### PR DESCRIPTION
Fixes #2409 - it is also related to https://github.com/rstudio/bookdown/issues/1349 as possible pre requisite. 

@yihui does it looks fine to you ? 