### PR TITLE
Vectorise str_replace_all()

### DIFF
--- a/R/base64.R
+++ b/R/base64.R
@@ -4,7 +4,6 @@ process_html_res <- function(html, reg, processor) {
   html <- one_string(html)
   process_img_src <- function(img_src) {
     src <- sub(reg, '\\1', img_src)
-
     vapply(
       seq_along(img_src),
       function(i) processor(img_src[[i]], src[[i]]),

--- a/R/base64.R
+++ b/R/base64.R
@@ -4,7 +4,12 @@ process_html_res <- function(html, reg, processor) {
   html <- one_string(html)
   process_img_src <- function(img_src) {
     src <- sub(reg, '\\1', img_src)
-    processor(img_src, src)
+
+    vapply(
+      seq_along(img_src),
+      function(i) processor(img_src[[i]], src[[i]]),
+      character(1)
+    )
   }
   html <- stringr::str_replace_all(html, reg, process_img_src)
   strsplit(html, "\n", fixed = TRUE)[[1]]


### PR DESCRIPTION
In the development version of stringr, I'm exploring vectorising the function form of `str_replace_all()` (https://github.com/tidyverse/stringr/pull/462) because it offers considerable performance improvements. This patch quickly hacks rmarkdown to work with this change. It would probably be worthwhile to vectorise the two users of `process_html_res()` as that is likely to give a small, but meaningful, performance boost when there are many matches.

This patch will work with both CRAN and dev stringr.