### PR TITLE
Add render() output_file argument repetition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.18
 ================================================================================
 
+- `rmarkdown::render()` argument `output_file` is now used for all output formats, if there is only one name for multiple output formats (thanks, @MaelAstruc, issue #2421).
 
 rmarkdown 2.17
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.18
 ================================================================================
 
-- `rmarkdown::render()` argument `output_file` is now used for all output formats, if there is only one name for multiple output formats (thanks, @MaelAstruc, issue #2421).
+- `rmarkdown::render()` argument `output_file` is now used for all output formats, if there is only one name for multiple output formats (thanks, @MaelAstruc, #2421).
 
 rmarkdown 2.17
 ================================================================================

--- a/R/render.R
+++ b/R/render.R
@@ -291,6 +291,7 @@ render <- function(input,
   # then recursively call this function with each format by name
   if (is.character(output_format) && length(output_format) > 1) {
     outputs <- character()
+    if (length(output_file) == 1) output_file <- rep(output_file, length(output_format))
     for (i in seq_along(output_format)) {
       # the output_file argument is intentionally ignored (we can't give
       # the same name to each rendered output); copy the rest by name


### PR DESCRIPTION
Closes #2421

If multiple output formats are provided and only one file name is provided, this file name will be used for all formats, instead of only the first one.

Here is a short example :
```
---
title: "Title"
author: "Author"
output:
  html_document: default
  pdf_document: default
  word_document: default
knit: (function(inputFile, encoding) {
  rmarkdown::render(inputFile,
                    encoding = encoding,
                    output_file = paste0("test_", Sys.Date()),
                    output_format = "all")
                    })
---
```

Before :
![Before_2022-10-14_182015](https://user-images.githubusercontent.com/51231202/195900244-93431807-df51-4eed-95da-34c15ff88948.png)

After :
![After_2022-10-14_183457](https://user-images.githubusercontent.com/51231202/195900294-e06825de-8e24-4aef-b755-cf165bf2c343.png)