### PR TITLE
make sure `ioslides_presentation` is properly self-contained when requested

### DIFF
--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -360,7 +360,7 @@ ioslides_presentation <- function(number_sections = FALSE,
         file.copy(from = logo, to = logo_path)
         logo_path <- normalized_relative_to(output_dir, logo_path)
       } else {
-        logo_path <- xfun::base64_uri(logo_path)
+        logo_path <- if (!grepl("^data:", logo_path)) xfun::base64_uri(logo_path) else logo_path
       }
       args <- c(args, "--variable", paste("logo=", logo_path, sep = ""))
     }

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -360,7 +360,7 @@ ioslides_presentation <- function(number_sections = FALSE,
         file.copy(from = logo, to = logo_path)
         logo_path <- normalized_relative_to(output_dir, logo_path)
       } else {
-        logo_path <- pandoc_path_arg(logo_path)
+        logo_path <- xfun::base64_uri(logo_path)
       }
       args <- c(args, "--variable", paste("logo=", logo_path, sep = ""))
     }

--- a/tests/testthat/test-ioslides.R
+++ b/tests/testthat/test-ioslides.R
@@ -179,3 +179,25 @@ test_ioslides_presentation_css <- function() {
 
 
 test_that("ioslides presentation is styled", test_ioslides_presentation_css())
+
+test_ioslides_presentation_logo <- function() {
+  
+  outputdir <- tempfile()
+  dir.create(outputdir)
+  on.exit(unlink(outputdir), add = TRUE)
+  
+  # Generate mock md file with logo
+  void <- file.copy("resources/empty.png", file.path(outputdir, "logo.png"))
+  mdtext <- c("# Slide One\n")
+  mock <- mock_markdown(mdtext = mdtext, outputdir = outputdir, self_contained = TRUE, logo = "logo.png")
+  html <- mock$html_file
+  
+  slide_lines <- c(
+    !any(grepl("logo\\.png", html))
+    , any(grep("favIcon: 'data:image/png;base64,[^']*'", html))
+    , any(grepl("background: url\\(data:image/png;base64,[^\\)]*)", html))
+  )
+  expect_true(all(slide_lines), info = "slide lines - self contained logo")
+}
+
+test_that("ioslides presentation embeds logo", test_ioslides_presentation_logo())

--- a/tests/testthat/test-ioslides.R
+++ b/tests/testthat/test-ioslides.R
@@ -198,6 +198,12 @@ test_ioslides_presentation_logo <- function() {
     , any(grepl("background: url\\(data:image/png;base64,[^\\)]*)", html))
   )
   expect_true(all(slide_lines), info = "slide lines - self contained logo")
+  
+  # if logo is passed as base64 string, do not re-encode
+  logobase64 <- xfun::base64_uri("resources/empty.png")
+  mock2 <- mock_markdown(mdtext = mdtext, outputdir = outputdir, self_contained = TRUE, logo = logobase64)
+  html2 <- mock2$html_file
+  expect_equal(html, html2)
 }
 
 test_that("ioslides presentation embeds logo", test_ioslides_presentation_logo())


### PR DESCRIPTION
Currently if `ioslides_presentation` is used with a custom `logo` image and `self_contained = TRUE`, the logo is not properly embedded in the resulting HTML - the relative path to the logo image is used making the HTML document non-portable... This PR aims to fix that by automatically base64-encoding logo