### PR TITLE
Fix #1508: do not resolve input files that are symlinks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,7 @@ Imports:
     tinytex (>= 0.31),
     tools,
     utils,
-    xfun (>= 0.35.3),
+    xfun (>= 0.36),
     yaml (>= 2.1.19)
 Suggests:
     digest,
@@ -88,4 +88,3 @@ Config/Needs/website: rstudio/quillt, pkgdown
 Encoding: UTF-8
 RoxygenNote: 7.2.3
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org
-Remotes: yihui/xfun

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,7 @@ Imports:
     tinytex (>= 0.31),
     tools,
     utils,
-    xfun (>= 0.35.2),
+    xfun (>= 0.35.3),
     yaml (>= 2.1.19)
 Suggests:
     digest,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,7 @@ Imports:
     tinytex (>= 0.31),
     tools,
     utils,
-    xfun (>= 0.30),
+    xfun (>= 0.35.2),
     yaml (>= 2.1.19)
 Suggests:
     digest,
@@ -88,3 +88,4 @@ Config/Needs/website: rstudio/quillt, pkgdown
 Encoding: UTF-8
 RoxygenNote: 7.2.3
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org
+Remotes: yihui/xfun

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.20
 
 - The defunct `tufte_handout()` has been removed from **rmarkdown**. Please use `tufte::tufte_handout()` instead.
 
+- If an input path to `rmarkdown::render()` is a symbolic link, it is no longer resolved to its real path (thanks, @SamDM @jmw86069, #1508).
+
 
 rmarkdown 2.19
 ================================================================================

--- a/R/includes.R
+++ b/R/includes.R
@@ -47,6 +47,8 @@ includes_to_pandoc_args <- function(includes,
 
 # simple wrapper over normalizePath that preserves NULLs and applies pandoc-
 # friendly defaults
-normalize_path <- function(path, winslash = "/", must_work = NA) {
-  if (!is.null(path)) normalizePath(path, winslash = winslash, mustWork = must_work)
+normalize_path <- function(path, ..., must_work = NA) {
+  if (!is.null(path)) xfun::normalize_path(
+    path, ..., must_work = must_work, resolve_symlink = FALSE
+  )
 }


### PR DESCRIPTION
Call `xfun::normalize_path(..., resolve_symlink = FALSE)` instead of `normalizePath()`, since the latter would resolve symlinks.

`rmarkdown:::normalize_path()` is used in several places in this package. I'm not sure how risky this change is. I guess not many people use symlinks so the impact should be low. There are two possible ways to prevent the potential breaking change:

1. Narrow the scope of the change, i.e., only change the `normalizePath()` calls inside `render()`. This should be enough to fix #1508. I guess in general, not resolving symlinks is more preferable when dealing with paths, so this PR made a global change instead.
2. Provide an option for users to keep the old behavior, e.g., `options(rmarkdown.render.resolve_symlink = TRUE)`.

To test this PR:

```r
remotes::install_github('rstudio/rmarkdown#2438')
```