### PR TITLE
Ensure that rmarkdown::reneder() always returns invisibly

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -1036,11 +1036,11 @@ render <- function(input,
     intermediates <- setdiff(intermediates, c(input, intermediates_fig))
     # did not run pandoc; returns the markdown output with attributes of the
     # knitr meta data and intermediate files
-    structure(input,
+    invisible(structure(input,
               knit_meta = knit_meta,
               files_dir = files_dir,
               intermediates_dir = intermediates_fig,
-              intermediates = intermediates)
+              intermediates = intermediates))
   }
 }
 


### PR DESCRIPTION
Even when `run_pandoc` is `FALSE`