### PR TITLE
Fix GHA action regarding older pandoc

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,23 +30,23 @@ jobs:
       matrix:
         config:
           # testing R release with last shipped pandoc version in RStudio IDE and new pandoc
-          - {os: windows-latest, pandoc: '3.1.1',    r: 'release'}
-          - {os: macOS-latest,   pandoc: '3.1.1',    r: 'release'}
-          - {os: ubuntu-latest,  pandoc: 'devel',    r: 'release'}
-          # testing older pandoc versions
-          - {os: ubuntu-latest,  pandoc: '2.19.2',   r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.18',     r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.17.1.1', r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.16.2',   r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.14.2',   r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'release'}
+          # - {os: windows-latest, pandoc: '3.1.1',    r: 'release'}
+          # - {os: macOS-latest,   pandoc: '3.1.1',    r: 'release'}
+          # - {os: ubuntu-latest,  pandoc: 'devel',    r: 'release'}
+          # # testing older pandoc versions
+          # - {os: ubuntu-latest,  pandoc: '2.19.2',   r: 'release'}
+          # - {os: ubuntu-latest,  pandoc: '2.18',     r: 'release'}
+          # - {os: ubuntu-latest,  pandoc: '2.17.1.1', r: 'release'}
+          # - {os: ubuntu-latest,  pandoc: '2.16.2',   r: 'release'}
+          # - {os: ubuntu-latest,  pandoc: '2.14.2',   r: 'release'}
+          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.7.3',    r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.5',      r: 'release'}
-          # testing other R versions
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-1'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-2'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-3'}
+          # - {os: ubuntu-latest,  pandoc: '2.5',      r: 'release'}
+          # # testing other R versions
+          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'devel', http-user-agent: 'release'}
+          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-1'}
+          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-2'}
+          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -90,6 +90,9 @@ jobs:
           tinytex::tlmgr("--version")
           tinytex::tl_pkgs()
         shell: Rscript {0}
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,23 +30,23 @@ jobs:
       matrix:
         config:
           # testing R release with last shipped pandoc version in RStudio IDE and new pandoc
-          # - {os: windows-latest, pandoc: '3.1.1',    r: 'release'}
-          # - {os: macOS-latest,   pandoc: '3.1.1',    r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: 'devel',    r: 'release'}
-          # # testing older pandoc versions
-          # - {os: ubuntu-latest,  pandoc: '2.19.2',   r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.18',     r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.17.1.1', r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.16.2',   r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.14.2',   r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'release'}
+          - {os: windows-latest, pandoc: '3.1.1',    r: 'release'}
+          - {os: macOS-latest,   pandoc: '3.1.1',    r: 'release'}
+          - {os: ubuntu-latest,  pandoc: 'devel',    r: 'release'}
+          # testing older pandoc versions
+          - {os: ubuntu-latest,  pandoc: '2.19.2',   r: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.18',     r: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.17.1.1', r: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.16.2',   r: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.14.2',   r: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.7.3',    r: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.5',      r: 'release'}
-          # # testing other R versions
-          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'devel', http-user-agent: 'release'}
-          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-1'}
-          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-2'}
-          # - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-3'}
+          - {os: ubuntu-latest,  pandoc: '2.5',      r: 'release'}
+          # testing other R versions
+          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-1'}
+          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-2'}
+          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Remove default Pandoc (installed manually after)
+      - name: Remove default installed Pandoc
         if: runner.os == 'Linux'
         run: sudo dpkg -r pandoc
 
@@ -94,9 +94,6 @@ jobs:
           tinytex::tlmgr("--version")
           tinytex::tl_pkgs()
         shell: Rscript {0}
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,14 +55,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v2
-        if: matrix.config.pandoc != 'devel'
-        with:
-          pandoc-version: ${{ matrix.config.pandoc }}
-
-      - uses: cderv/actions/setup-pandoc-nightly@nightly-pandoc
-        if: matrix.config.pandoc == 'devel'
-
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
@@ -83,6 +75,18 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+
+      - name: Remove default Pandoc (installed manually after)
+        if: runner.os == 'Linux'
+        run: sudo dpkg -r pandoc
+
+      - uses: r-lib/actions/setup-pandoc@v2
+        if: matrix.config.pandoc != 'devel'
+        with:
+          pandoc-version: ${{ matrix.config.pandoc }}
+
+      - uses: cderv/actions/setup-pandoc-nightly@nightly-pandoc
+        if: matrix.config.pandoc == 'devel'
 
       - name: Pandoc and Tinytex info
         run: |


### PR DESCRIPTION
* debug with tmate

* Related to https://github.com/r-lib/actions/issues/710 - Pandoc need to be uninstall and install manually so that new Ubuntu version does not replace the manually installed one