### PR TITLE
[ioslide] Only do the chcp setting with Pandoc before 2.0

### DIFF
--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -428,7 +428,7 @@ ioslides_presentation <- function(number_sections = FALSE,
     # duration of the Pandoc command. Without this, Pandoc fails when attempting
     # to hand UTF-8 encoded non-ASCII characters over to the custom Lua writer.
     # See https://github.com/rstudio/rmarkdown/issues/134
-    if (is_windows()) {
+    if (is_windows() && !pandoc2.0()) {
       # 'chcp' returns e.g., "Active code page: 437"; strip characters and parse
       # the number
       codepage <- as.numeric(gsub("\\D", "", system2("chcp", stdout = TRUE)))


### PR DESCRIPTION
To fix #2480 

This usage of chcp was introduced in 955ebae74a6797f13953bee5d586b83b84a0dada to fix #134 - quite old code.

It was pre pandoc 2.0 and accompanied with an issue upstream https://github.com/jgm/pandoc/issues/2101

I believe pandoc now handles directly this better and this is not needed anymore. I suggest to not do that anymore when Pandoc 2 or above. 

@yihui any argument against this ? 

I could also try to fix the proper issue, but I believe this is something related to encoding between what system call returns and the OS or R encoding. 

EDIT: I investigated at https://github.com/rstudio/rmarkdown/issues/2480#issuecomment-1527533282 and it seems this is R 4.3 big change on Windows