### PR TITLE
detecting external resources needs to consider css argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.21.4
+Version: 2.21.5
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.22
 ================================================================================
 
+- Using `css` with `.scss` and `.sass` file, or with a bslib theme, now works as expected with a shiny runtime (thanks, @cpsievert, #2443, #2447).
+
 - Add a `pandoc_metadata_file_arg()` function to match Pandoc's CLI flag `--metadata-file`.
 
 - Mentions that **webshot** or **webshot2** is required to take screenshot of HTML widget. When not installed, an error message mentionning `always_allow_html: true` solution will be shown, but setting this is not the solution (quarto-dev/quarto-cli#4225).

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -153,6 +153,10 @@ theme_version <- function(theme) {
   substr(html_dependency_bootstrap("default")$version, 1, 1)
 }
 
+needs_sass <- function(css) {
+  grepl("\\.s[ac]ss$", css)
+}
+
 
 # Create an HTML dependency for tocify
 #' @rdname html-dependencies

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -96,7 +96,7 @@ html_document_base <- function(theme = NULL,
 
     # Process css files as Pandoc argument if not already been processed by bslib
     for (f in css) {
-      if (grepl("\\.s[ac]ss$", f)) {
+      if (needs_sass(f)) {
         if (!xfun::loadable("sass")) {
           stop2("Using `.sass` or `.scss` file in `css` argument requires the sass package.")
         }

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -214,7 +214,6 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
     for (output_format in output_formats) {
       if (is.list(output_format)) {
         output_render_files <- unlist(output_format[c(
-          # css is needed as it could be used by bslib and needs to be available
           'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template'
         )])
         # css needs to be copied for sass or bslib processing in formate rendering

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -55,7 +55,7 @@ find_external_resources <- function(input_file, encoding = 'UTF-8') {
   # ensure we're working with valid input
   ext <- tolower(xfun::file_ext(input_file))
   if (!(ext %in% c("md", "rmd", "qmd", "html", "htm", "r", "css"))) {
-    stop("Resource discovery is only supported for R Markdown files or HTML files.")
+    stop("Resource discovery is only supported for R Markdown, Quarto files or HTML (and CSS) files.")
   }
 
   if (!file.exists(input_file)) {
@@ -138,7 +138,7 @@ find_external_resources <- function(input_file, encoding = 'UTF-8') {
   # clean row names (they're not meaningful)
   rownames(discovered_resources) <- NULL
 
-  # convert paths from factors if necssary, and clean any redundant ./ leaders
+  # convert paths from factors if necessary, and clean any redundant ./ leaders
   discovered_resources$path <- as.character(discovered_resources$path)
   has_prefix <- grepl("^\\./", discovered_resources$path)
   discovered_resources$path[has_prefix] <- substring(discovered_resources$path[has_prefix], 3)
@@ -214,7 +214,8 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
     for (output_format in output_formats) {
       if (is.list(output_format)) {
         output_render_files <- unlist(output_format[c(
-          'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template'
+          # css is needed as it could be used by bslib and needs to be available
+          'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template', 'css'
         )])
         lapply(output_render_files, discover_render_resource)
       }

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -218,12 +218,12 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
           'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template'
         )])
         # css needs to be copied for sass or bslib processing in formate rendering
-        if (
-          is_bs_theme(output_format["theme"]) ||
-          any(needed <- needs_sass(output_format['css']))
-        ) {
-          output_render_files <- c(output_render_files, unlist(output_format['css'][needed]))
+        if (is_bs_theme(resolve_theme(output_format[["theme"]]))) {
+          output_render_files <- c(output_render_files, unlist(output_format['css']))
+        } else if (any(needed <- needs_sass(output_format[['css']]))) {
+          output_render_files <- c(output_render_files, unlist(output_format[['css']][needed]))
         }
+
         lapply(output_render_files, discover_render_resource)
       }
     }

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -217,11 +217,10 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
           'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template'
         )])
         # css needs to be copied for sass or bslib processing in formate rendering
-        if (is_bs_theme(resolve_theme(output_format[["theme"]]))) {
-          output_render_files <- c(output_render_files, unlist(output_format['css']))
-        } else if (any(needed <- needs_sass(output_format[['css']]))) {
-          output_render_files <- c(output_render_files, unlist(output_format[['css']][needed]))
+        needed <- if (is_bs_theme(resolve_theme(output_format[["theme"]]))) TRUE else {
+          needs_sass(output_format[['css']])
         }
+        output_render_files <- c(output_render_files, output_format[['css']][needed])
 
         lapply(output_render_files, discover_render_resource)
       }

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -215,8 +215,15 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
       if (is.list(output_format)) {
         output_render_files <- unlist(output_format[c(
           # css is needed as it could be used by bslib and needs to be available
-          'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template', 'css'
+          'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template'
         )])
+        # css needs to be copied for sass or bslib processing in formate rendering
+        if (
+          is_bs_theme(output_format["theme"]) ||
+          any(needed <- needs_sass(output_format['css']))
+        ) {
+          output_render_files <- c(output_render_files, unlist(output_format['css'][needed]))
+        }
         lapply(output_render_files, discover_render_resource)
       }
     }

--- a/tests/manual/shiny/shiny-css-bslib.Rmd
+++ b/tests/manual/shiny/shiny-css-bslib.Rmd
@@ -1,0 +1,11 @@
+---
+title: "Title"
+runtime: shiny
+output:
+  html_document:
+    css: styles.css
+    theme:
+      version: 5
+---
+
+### Another title

--- a/tests/manual/shiny/shiny-scss.Rmd
+++ b/tests/manual/shiny/shiny-scss.Rmd
@@ -1,0 +1,10 @@
+---
+title: "Title"
+runtime: shiny
+output:
+  html_document:
+    css: styles.scss
+    theme: darkly
+---
+
+### Another title

--- a/tests/manual/shiny/styles.css
+++ b/tests/manual/shiny/styles.css
@@ -1,0 +1,1 @@
+body {background-color: purple;}

--- a/tests/manual/shiny/styles.scss
+++ b/tests/manual/shiny/styles.scss
@@ -1,0 +1,1 @@
+body {background-color: purple;}

--- a/tests/testthat/test-html_dependencies.R
+++ b/tests/testthat/test-html_dependencies.R
@@ -210,3 +210,13 @@ test_that("header-attr can be opt-out", {
   withr::local_options(list(rmarkdown.html_dependency.header_attr = FALSE))
   expect_null(html_dependency_header_attrs())
 })
+
+test_that('needs_saas', {
+  expect_true(needs_sass('dummy.scss'))
+  expect_true(needs_sass('dummy.sass'))
+  expect_false(needs_sass('dummy.css'))
+  expect_identical(
+    needs_sass(c('dummy.scss', 'dummy.sass', 'dummy.css')),
+    c(TRUE, TRUE, FALSE)
+  )
+})

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -2,8 +2,8 @@ context("resource discovery")
 
 test_that("R Markdown resource discovery finds expected resources", {
   # Test with the current version of the template
-  file.copy(pkg_file("rmd/h/default.html"), 'resources/template.html')
-  resources <- find_external_resources("resources/rmarkdown.Rmd")
+  file.copy(pkg_file("rmd/h/default.html"), test_path('resources/template.html'), overwrite = TRUE)
+  resources <- find_external_resources(test_path("resources/rmarkdown.Rmd"))
   expected <- data.frame(
     path = c("empty.md", "empty.png", "empty.tsv", "empty.Rmd", "empty.css",
              "empty.jpg", "empty.html", "template.html", "empty.csv"),

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -1,5 +1,12 @@
 context("resource discovery")
 
+sort_resources <- function(resources) {
+  # sort by filename and remove rownames to avoid errors arising from file ordering
+  # -- we don't really care what order these come back in
+  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
+  rownames(resources) <- NULL
+}
+
 test_that("R Markdown resource discovery finds expected resources", {
   # Test with the current version of the template
   file.copy(pkg_file("rmd/h/default.html"), test_path('resources/template.html'), overwrite = TRUE)
@@ -11,13 +18,64 @@ test_that("R Markdown resource discovery finds expected resources", {
     web      = c(FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE,  FALSE),
     stringsAsFactors = FALSE)
 
-  # sort by filename and remove rownames to avoid errors arising from file ordering
-  # -- we don't really care what order these come back in
-  resources <- as.data.frame(resources[order(resources[[1]]), , drop = FALSE])
-  expected <- as.data.frame(expected[order(expected[[1]]), , drop = FALSE])
-  rownames(resources) <- rownames(expected) <- NULL
+  resources <- sort_resources(resources)
+  expected <- sort_resources(expected)
 
   expect_equal(resources, expected)
+})
+
+test_that("R Markdown resource discovery finds expected scss when sass is used", {
+  skip_if_not_installed("sass")
+  css_files <- c("empty.scss", "empty.css", "empty2.scss", "empty2.css")
+  yaml <- yaml::as.yaml(list(
+    title = "test",
+    output = list(
+      html_document = list(
+        css = c("empty.scss", "empty.css", "empty2.scss", "empty2.css"),
+        theme = "cerulean"
+      )
+    )
+  ))
+  rmd <- local_rmd_file(knitr::knit_expand(text = c("---", "{{yaml}}", "---", "", "# test")))
+  withr::local_dir(dirname(rmd))
+  file.create(css_files)
+  resources <- find_external_resources(basename(rmd))
+  resource <- resources[resources$path %in% css_files, ]
+  expected <- data.frame(
+    path = css_files,
+    explicit = rep_len(FALSE, length(css_files)),
+    web      = !needs_sass(css_files),
+    stringsAsFactors = FALSE)
+  resource <- sort_resources(resource)
+  expected <- sort_resources(expected)
+  expect_equal(resource, expected)
+})
+
+test_that("R Markdown resource discovery finds expected scss and css when bslib is used", {
+  skip_if_not_installed("bslib")
+  css_files <- c("empty.scss", "empty.css", "empty2.scss", "empty2.css")
+  yaml <- yaml::as.yaml(list(
+    title = "test",
+    output = list(
+      html_document = list(
+        css = c("empty.scss", "empty.css", "empty2.scss", "empty2.css"),
+        theme = list(version = "5")
+      )
+    )
+  ))
+  rmd <- local_rmd_file(knitr::knit_expand(text = c("---", "{{yaml}}", "---", "", "# test")))
+  withr::local_dir(dirname(rmd))
+  file.create(css_files)
+  resources <- find_external_resources(basename(rmd))
+  resource <- resources[resources$path %in% css_files, ]
+  expected <- data.frame(
+    path = css_files,
+    explicit = rep_len(FALSE, length(css_files)),
+    web      = rep_len(FALSE, length(css_files)),
+    stringsAsFactors = FALSE)
+  resource <- sort_resources(resource)
+  expected <- sort_resources(expected)
+  expect_equal(resource, expected)
 })
 
 


### PR DESCRIPTION
This is because `css` can be processed by bslib in pre_knit and/or pre_processor, including when rendering md file in temp directory

Closes https://github.com/rstudio/rmarkdown/issues/2443
Closes https://github.com/rstudio/rmarkdown/issues/2447

The real issue is not with shiny, but rather how renders and resource discovery works when `intermediates_dir` is passed, and when it is another directory. This happens with shiny rendering but could happen in other situations too, not even just when intermediates is a temp directory.

<details>
<summary>Error without shiny example</summary>

* Markdown file
````markdown
---
title: "Title"
output:
  html_document:
    css: styles.scss
    theme: darkly
---

### Another title

```{r}
xfun::file_string("README.md")
```
````
* scss file

````scss
body {background-color: purple;}
````
** rendering
````r
> tmp <- tempfile(); rmarkdown::render("test.Rmd", intermediates_dir = tmp, output_dir = tmp)
Error in `sass::sass_file()`:
! Could not find file: 'styles.scss' in dir: C:/Users/chris/AppData/Local/Temp/RtmpcPUFmU
Run `rlang::last_trace()` to see where the error occurred.
> rlang::last_trace()
<error/rlang_error>
Error in `sass::sass_file()`:
! Could not find file: 'styles.scss' in dir: C:/Users/chris/AppData/Local/Temp/RtmpcPUFmU
---
Backtrace:
     ▆
  1. └─rmarkdown::render("test.Rmd", intermediates_dir = tmp, output_dir = tmp)
  2.   └─output_format$intermediates_generator(original_input, intermediates_dir) at rmarkdown/R/render.R:516:4
  3.     └─rmarkdown:::copy_render_intermediates(...) at rmarkdown/R/html_document_base.R:159:4
  4.       └─rmarkdown::find_external_resources(original_input) at rmarkdown/R/html_resources.R:404:2
  5.         └─rmarkdown:::discover_rmd_resources(input_file, discover_single_resource) at rmarkdown/R/html_resources.R:108:4
  6.           └─rmarkdown::render(...) at rmarkdown/R/html_resources.R:339:2
  7.             └─output_format$pre_processor(...) at rmarkdown/R/render.R:845:6
  8.               └─rmarkdown (local) base(...) at rmarkdown/R/output_format.R:126:6
  9.                 ├─sass::sass(...) at rmarkdown/R/html_document_base.R:103:8
 10.                 │ └─sass::as_sass(input)
 11.                 │   ├─htmltools::attachDependencies(...)
 12.                 │   │ └─htmltools:::asDependencies(value)
 13.                 │   └─sass:::find_dependencies(input)
 14.                 │     └─sass:::is_sass_bundle_like(x)
 15.                 │       └─sass::is_sass_bundle(x)
 16.                 └─sass::sass_file(f)
````

It would happen with `tmp <- "dummy"` too. 

</details>

This happens in our finding resources processing, because we render to an `.md` file in a temp directory, and we need to move the resource in this temp folder at this time. `css` or `scss` could be processed by **bslib** or **sass** in pre_knit and/or pre_processor, including when rendering md file in temp directory. We need to account for this. 

@cpsievert  this PR closes #2448 without merging as this is a broader fix, even when `shiny` is not used. 