### PR TITLE
add missing functionality to merge file_scope on creating output_format

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -1200,7 +1200,11 @@ resolve_df_print <- function(df_print) {
 output_metadata = knitr:::new_defaults()
 
 file_scope_split <- function(input, fun) {
-  inputs <- fun(input)
+  inputs <- if (length(formals(fun)) == 1L) {
+    fun(input) # for the backward compatibility
+  } else {
+    fun(input, NULL) # the second argument implies current file scope
+  }
 
   # file_scope_fun should split the input file in several
   # do nothing if not and return input file unsplited

--- a/tests/testthat/test-output_format.R
+++ b/tests/testthat/test-output_format.R
@@ -7,6 +7,7 @@ test_that("all elements can be NULL", {
 
 test_that("inherits base format", {
   base_fmt <- html_document()
+  base_fmt$file_scope <- identity
   out_fmt <- output_format(
     knitr = NULL, pandoc = NULL, keep_md = NULL, clean_supporting = NULL,
     base_format = base_fmt
@@ -15,6 +16,23 @@ test_that("inherits base format", {
   expect_identical(lapply(out_fmt, class), classes)
   not_fun <- vapply(classes, function(x) !"function" %in% x, NA)
   expect_identical(out_fmt[not_fun], base_fmt[not_fun])
+})
+
+test_that("file_scope replaces base format", {
+  base_fmt <- html_document()
+  base_fmt$file_scope <- function(input_file, file_scope, ...) {
+    return(list("foo" = "foo"))
+  }
+  out_fmt <- output_format(
+    knitr = NULL, pandoc = NULL, keep_md = NULL, clean_supporting = NULL,
+    file_scope = function(input_file, file_scope, ...) {
+      file_scope$bar <- "bar"
+      return(file_scope)
+    },
+    base_format = base_fmt
+  )
+  expect_identical(out_fmt$file_scope("input", NULL),
+                   list("foo" = "foo", "bar" = "bar"))
 })
 
 test_that("clean_supporting is coerced to FALSE only if keep_md is TRUE", {


### PR DESCRIPTION
Currently, new output format ignores the file scope of the base format.
It is totally lost.

In this PR I fix the above behavior and add `merge_file_scope()`.

To achieve merging, `file_scope` function needs two arguments, and the latter is new

- `input_files` which already exists
- `current_file_scope` which is determined by the base `file_scope` function

In this way, overlay can take into account of file scope determined by the base.

This is an API change, so I added some warnings and fallback mechanisms.
