### PR TITLE
Change the code-folding button text from "Code" to "Show"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@ rmarkdown 2.22
 
 - Fix an issue with YAML header ending with a commented line containing incomplete yaml (thanks, @keithnewman, #2483).
 
+- When code folding is enabled in `html_document()`, the text on the button to show the content has been changed from "Code" to "Show", because the content to show is not necessarily code, e.g., yihui/knitr#2227.
+
+
 rmarkdown 2.21
 ================================================================================
 

--- a/inst/rmd/h/navigation-1.1/codefolding.js
+++ b/inst/rmd/h/navigation-1.1/codefolding.js
@@ -31,7 +31,7 @@ window.initializeCodeFolding = function(show) {
     $(this).detach().appendTo(div);
 
     // add a show code button right above
-    var showCodeText = $('<span>' + (showThis ? 'Hide' : 'Code') + '</span>');
+    var showCodeText = $('<span>' + (showThis ? 'Hide' : 'Show') + '</span>');
     var showCodeButton = $('<button type="button" class="btn btn-default btn-xs btn-secondary btn-sm code-folding-btn pull-right float-right"></button>');
     showCodeButton.append(showCodeText);
     showCodeButton
@@ -57,7 +57,7 @@ window.initializeCodeFolding = function(show) {
     //   * Change text
     //   * add a class for intermediate states styling
     div.on('hide.bs.collapse', function () {
-      showCodeText.text('Code');
+      showCodeText.text('Show');
       showCodeButton.addClass('btn-collapsing');
     });
     div.on('hidden.bs.collapse', function () {


### PR DESCRIPTION
The content to show is not necessarily code, e.g., https://github.com/yihui/knitr/issues/2227