### PR TITLE
`find_external_resources` works with custom format using `theme`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.22.1
+Version: 2.22.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.23
 ================================================================================
 
+- `find_external_resources()` works with formats defining there own `theme` argument, like `cleanrmd::html_document_clean()`, not related to **bslib** supports (thanks, @gadenbuie, #2493, r-lib/pkgdown#2319).
 
 rmarkdown 2.22
 ================================================================================

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -84,6 +84,7 @@ bootstrap_dependencies <- function(theme) {
   if (inherits(deps, "html_dependency")) list(deps) else deps
 }
 
+# resolves boostrap theme for bslib compatibility
 resolve_theme <- function(theme) {
   # theme = NULL means no Bootstrap
   if (is.null(theme)) return(theme)

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -216,8 +216,9 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
         output_render_files <- unlist(output_format[c(
           'includes', 'pandoc_args', 'logo', 'reference_doc', 'reference_docx', 'template'
         )])
+        resolved_theme <- tryCatch(resolve_theme(output_format[["theme"]]), error = function(e) NULL)
         # css needs to be copied for sass or bslib processing in formate rendering
-        needed <- if (is_bs_theme(resolve_theme(output_format[["theme"]]))) TRUE else {
+        needed <- if (is_bs_theme(resolved_theme)) TRUE else {
           needs_sass(output_format[['css']])
         }
         output_render_files <- c(output_render_files, output_format[['css']][needed])

--- a/tests/rmd/clean-format.Rmd
+++ b/tests/rmd/clean-format.Rmd
@@ -1,0 +1,8 @@
+---
+output: 
+  cleanrmd::html_document_clean:
+    highlight: prism
+    theme: almond
+---
+
+# test

--- a/tests/testrmd.R
+++ b/tests/testrmd.R
@@ -39,4 +39,8 @@ if (.Platform$OS.type == 'unix' && !isTRUE(as.logical(Sys.getenv("CI"))) && rmar
   # https://github.com/rstudio/rmarkdown/pull/1964
   rmarkdown::render("rmd/anchor-sections.Rmd")
 
+  # Finding resource in custom formats
+  # https://github.com/rstudio/rmarkdown/issues/2493
+  rmarkdown::render("rmd/clean-format.Rmd")
+
 }


### PR DESCRIPTION
This is fixing #2493 in a quite scoped manner. 

This PR account for error when `resolve_theme()` is used in finding resources step. 
Some custom theme could use the `theme` configuration in other context that bslib theming detection. However, `resolve_theme()` is an internal function to detect if this is a bslib theme, and `css` should be copied as resource for rendering in another folder.

We consider that an error  means `theme` is not what rmarkdown's format expect it to be (either a vector of string, or a non built-in boostrap 3 theme), this is indeed not a bslib and we should not copy CSS. 

@yihui just adding you as reviewer, if you happen to pass around here. I'll merge it otherwise as I know you are travelling