### PR TITLE
shinyrmd: Safer dependency extraction from pre-rendered HTML

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.23.3
+Version: 2.23.4
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ rmarkdown 2.24
 
 - Added `output_format_dependency()` which allows extending output format from within chunks (thanks, @atusy, #2462)
 
+- Fix an issue with shiny prerendered document where dependencies context were written twice leasing to parsing error (thanks, @gadenbuie, rstudio/learn#597, #2500).
+
 rmarkdown 2.23
 ================================================================================
 


### PR DESCRIPTION
This PR provides a fix for #2499 that doesn't address the root cause but will avoid the downstream errors caused by that issue.

In short, under unknown circumstances, the shinyrmd context script tags for dependencies and execution dependencies are written _twice_ into the pre-rendered HTML files. rmarkdown then passes a length-2 character vector to `jsonlite::unserializeJSON()`, which causes a parsing error.

This PR does two primary things:

1. I extracted the HTML and JSON parsing of dependencies into a single function `shiny_prerendered_extract_context_serialized()`. This function ensures a single character string is passed to `jsonlite::unserializedJSON()`, using the last context in the document if more than one non-unique context is found.

2. rmarkdown reads both dependency types in `shiny_prerendered_prerender()` (the function that decides if a pre-render run is required). At this point, we don't need to error if parsing fails and can instead trigger a pre-rendered pass to happen again. Ideally, this new pre-render pass will fix any issues in the pre-rendered HTML file, but if it somehow writes invalid dependency JSON again, `shiny_prerendered_html()` will still fail (rather than infinitely looping).

   Note that avoiding an infinite loop is hypothetical; the current bug wouldn't trigger a new pre-render pass.