### PR TITLE
fix(ioslides): Shiny-specific initialization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.24.2
+Version: 2.24.3
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,9 @@ rmarkdown 2.25
 
 - Fixed a bug that filenames beginning with `-` cause incorrect invocation of Pandoc (thanks, @mbaynton, #2503).
 
-- Documented how to merge `output_format_dependency()` to the output format (thanks, @atusy, #2508)
+- Documented how to merge `output_format_dependency()` to the output format (thanks, @atusy, #2508).
+
+- `ioslides_presentation()` now correctly works with new **shiny** 1.7.5 (thanks, @nicolasgaraycoa, #2514, @gadenbuie, #2516).
 
 rmarkdown 2.24
 ================================================================================

--- a/inst/rmd/ioslides/default.html
+++ b/inst/rmd/ioslides/default.html
@@ -201,6 +201,11 @@ $endif$
          window.jQuery(e.target).trigger('shown');
       });
     }
+    if (window.Shiny) {
+      // Initialize slides when this script appears on the page, since it
+      // indicates that the <slides> markup has been fully loaded.
+      window.loadDeck();
+    }
   })();
 </script>
 

--- a/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
+++ b/inst/rmd/ioslides/ioslides-13.5.1/js/slide-deck.js
@@ -793,17 +793,20 @@ var loadDeck = function(event) {
   });
 };
 
-if (document.readyState !== "loading" &&
-    document.querySelector('slides') === null) { 
-  // if the document is done loading but our element hasn't yet appeared, defer
-  // loading of the deck
-  window.setTimeout(function() {
-    loadDeck(null);
-  }, 0);
-} else {
-  // still loading the DOM, so wait until it's finished
-  document.addEventListener("DOMContentLoaded", loadDeck);
-}
+if (!window.Shiny) {
+  // If Shiny is loaded, the slide deck is initialized in ioslides template
 
+  if (document.readyState !== "loading" &&
+      document.querySelector('slides') === null) {
+    // if the document is done loading but our element hasn't yet appeared, defer
+    // loading of the deck
+    window.setTimeout(function() {
+      loadDeck(null);
+    }, 0);
+  } else {
+    // still loading the DOM, so wait until it's finished
+    document.addEventListener("DOMContentLoaded", loadDeck);
+  }
+}
 
 


### PR DESCRIPTION
Fixes #2514 
Fixes rstudio/shiny#3894

Currently, ioslides waits for the `DOMContentLoaded` event to initialize the slides, assuming that the `<slides>` markup will be there when that event happens.

Beacuse the slides are loaded via dynamic UI with `uiOutput()` (not just the slides, but the app content for any Shiny app in R Markdown), and due to recent changes in Shiny, the dynamic UI isn't present in the DOM yet. This is due to recent changes in Shiny that make dynamic UI rendered asynchronous.

This PR is a minimal fix that adds special initialization code for Shiny in the ioslides pandoc template and prevents the ioslides `slide-deck.js` from trying to initialize slides automatically in a shiny context.

This works because the slides markup, including the new initialization code, are all added to the page at the same time, so by the time `loadDeck()` is called we have a strong guarantee that `<slides>` is present.

cc @cderv @cpsievert (I can't request reviewers)