### PR TITLE
Remove `stringr` dependency

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # CITATION file created with {cffr} R package, v0.4.1
 # See also: https://docs.ropensci.org/cffr/
 # -----------------------------------------------------------
- 
+
 cff-version: 1.2.0
 message: 'To cite package "rmarkdown" in publications use:'
 type: software
@@ -271,18 +271,6 @@ references:
   year: '2023'
   institution:
     name: R Foundation for Statistical Computing
-- type: software
-  title: stringr
-  abstract: 'stringr: Simple, Consistent Wrappers for Common String Operations'
-  notes: Imports
-  url: https://stringr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=stringr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-  year: '2023'
-  version: '>= 1.2.0'
 - type: software
   title: tinytex
   abstract: 'tinytex: Helper Functions to Install and Maintain TeX Live, and Compile

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,6 @@ Imports:
     jsonlite,
     knitr (>= 1.22),
     methods,
-    stringr (>= 1.2.0),
     tinytex (>= 0.31),
     tools,
     utils,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.26
 
 - Get rid of the superfluous warning in `find_pandoc()` (thanks, @jszhao, #2527).
 
+- Removed the **stringr** dependency since it is used only once in the package and the equivalent base R code is simple enough (thanks, @etiennebacher, #2530).
+
 
 rmarkdown 2.25
 ================================================================================

--- a/R/base64.R
+++ b/R/base64.R
@@ -10,15 +10,9 @@ process_html_res <- function(html, reg, processor) {
       character(1)
     )
   }
+  m <- gregexpr(reg, html, perl = TRUE)
+  regmatches(html, m) <- lapply(regmatches(html, m), process_img_src)
 
-  # base R alternative to stringr::str_replace_all() with a function in
-  # replacement
-  mtchs <- regmatches(html, gregexpr(reg, html, perl = TRUE))[[1]]
-  if (length(mtchs) > 0) {
-    for (i in rev(mtchs)) {
-      html <- gsub(i, process_img_src(i), html, fixed = TRUE)
-    }
-  }
   strsplit(html, "\n", fixed = TRUE)[[1]]
 }
 

--- a/R/base64.R
+++ b/R/base64.R
@@ -10,7 +10,15 @@ process_html_res <- function(html, reg, processor) {
       character(1)
     )
   }
-  html <- stringr::str_replace_all(html, reg, process_img_src)
+
+  # base R alternative to stringr::str_replace_all() with a function in
+  # replacement
+  mtchs <- regmatches(html, gregexpr(reg, html, perl = TRUE))[[1]]
+  if (length(mtchs) > 0) {
+    for (i in rev(mtchs)) {
+      html <- gsub(i, process_img_src(i), html, fixed = TRUE)
+    }
+  }
   strsplit(html, "\n", fixed = TRUE)[[1]]
 }
 

--- a/tests/testthat/site/PageA.Rmd
+++ b/tests/testthat/site/PageA.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(echo = TRUE)
 Let's load a package (from existing dependencies) and make sure it's not on the search path when rendering a subsequent file.
 
 ```{r}
-library(stringr)
+library(bslib)
 plot(cars)
 ```
 

--- a/tests/testthat/site/PageA.Rmd
+++ b/tests/testthat/site/PageA.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(echo = TRUE)
 Let's load a package (from existing dependencies) and make sure it's not on the search path when rendering a subsequent file.
 
 ```{r}
-library(bslib)
+library(tinytex)
 plot(cars)
 ```
 

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -66,9 +66,9 @@ test_that("render_site respects 'new_session' in the config", {
   a <- readLines(file.path(site_dir, "_site", "PageA.html"))
   b <- readLines(file.path(site_dir, "_site", "PageB.html"))
 
-  # pkg loaded in PageA (stringr) should show up in search path of PageB
-  expect_match(a, "library(stringr)", fixed = TRUE, all = FALSE)
-  expect_true(any(grepl("stringr", b, fixed = TRUE)))
+  # pkg loaded in PageA (bslib) should show up in search path of PageB
+  expect_match(a, "library(bslib)", fixed = TRUE, all = FALSE)
+  expect_true(any(grepl("bslib", b, fixed = TRUE)))
 
   # edit config --> new_session: true
   cat("new_session: true", file = file.path(site_dir, "_site.yml"), append = TRUE)
@@ -77,9 +77,9 @@ test_that("render_site respects 'new_session' in the config", {
   a <- readLines(file.path(site_dir, "_site", "PageA.html"))
   b <- readLines(file.path(site_dir, "_site", "PageB.html"))
 
-  # pkg loaded in PageA (stringr) should NOT show up in search path of PageB
-  expect_match(a, "library(stringr)", fixed = TRUE, all = FALSE)
-  expect_false(any(grepl("stringr", b, fixed = TRUE)))
+  # pkg loaded in PageA (bslib) should NOT show up in search path of PageB
+  expect_match(a, "library(bslib)", fixed = TRUE, all = FALSE)
+  expect_false(any(grepl("bslib", b, fixed = TRUE)))
 })
 
 test_that("clean_site gives notices before removing", {

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -66,9 +66,9 @@ test_that("render_site respects 'new_session' in the config", {
   a <- readLines(file.path(site_dir, "_site", "PageA.html"))
   b <- readLines(file.path(site_dir, "_site", "PageB.html"))
 
-  # pkg loaded in PageA (bslib) should show up in search path of PageB
-  expect_match(a, "library(bslib)", fixed = TRUE, all = FALSE)
-  expect_true(any(grepl("bslib", b, fixed = TRUE)))
+  # pkg loaded in PageA (tinytex) should show up in search path of PageB
+  expect_match(a, "library(tinytex)", fixed = TRUE, all = FALSE)
+  expect_true(any(grepl("tinytex", b, fixed = TRUE)))
 
   # edit config --> new_session: true
   cat("new_session: true", file = file.path(site_dir, "_site.yml"), append = TRUE)
@@ -77,9 +77,9 @@ test_that("render_site respects 'new_session' in the config", {
   a <- readLines(file.path(site_dir, "_site", "PageA.html"))
   b <- readLines(file.path(site_dir, "_site", "PageB.html"))
 
-  # pkg loaded in PageA (bslib) should NOT show up in search path of PageB
-  expect_match(a, "library(bslib)", fixed = TRUE, all = FALSE)
-  expect_false(any(grepl("bslib", b, fixed = TRUE)))
+  # pkg loaded in PageA (tinytex) should NOT show up in search path of PageB
+  expect_match(a, "library(tinytex)", fixed = TRUE, all = FALSE)
+  expect_false(any(grepl("tinytex", b, fixed = TRUE)))
 })
 
 test_that("clean_site gives notices before removing", {


### PR DESCRIPTION
The aim of this PR is to remove the `stringr` dependency. `stringr` is only used once in the package but adds 4 (sometimes heavy) dependencies: `stringi`, `vctrs`, `magrittr`, and `stringr` itself.

```r
pak::pkg_deps("rmarkdown", dependencies = "hard") |> 
    dplyr::pull(ref) |> 
    unique() |> 
    length()
#> 31
```
After this PR:
```r
pak::local_deps(".", dependencies = "hard") |> 
    dplyr::pull(ref) |> 
    unique() |> 
    length()
#> 27
```
I didn't test on external packages, I only relied on the test suite here.