### PR TITLE
Use new version of `has_crop_tools()` from knitr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,7 @@ Imports:
     htmltools (>= 0.5.1),
     jquerylib,
     jsonlite,
-    knitr (>= 1.22),
+    knitr (>= 1.43),
     methods,
     tinytex (>= 0.31),
     tools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ rmarkdown 2.26
 
 - Removed the **stringr** dependency since it is used only once in the package and the equivalent base R code is simple enough (thanks, @etiennebacher, #2530).
 
+- When `fig_crop: auto`, it will now uses the same logic as in knitr to decide if cropping is possible (yihui/knitr#2246). This fix an issue with detecting Ghostscript on Windows. It requires **knitr** 1.43 for this fix to apply.
+
 
 rmarkdown 2.25
 ================================================================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,13 @@
 rmarkdown 2.26
 ================================================================================
 
+- **rmarkdown** has now a dependency on **knitr** >= 1.43.
+
 - Get rid of the superfluous warning in `find_pandoc()` (thanks, @jszhao, #2527).
 
 - Removed the **stringr** dependency since it is used only once in the package and the equivalent base R code is simple enough (thanks, @etiennebacher, #2530).
 
-- When `fig_crop: auto`, it will now uses the same logic as in knitr to decide if cropping is possible (yihui/knitr#2246). This fix an issue with detecting Ghostscript on Windows. It requires **knitr** 1.43 for this fix to apply.
+- When `fig_crop: auto`, it will now uses the same logic as in knitr to decide if cropping is possible (yihui/knitr#2246).
 
 
 rmarkdown 2.25

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,13 @@
 rmarkdown 2.26
 ================================================================================
 
-- **rmarkdown** has now a dependency on **knitr** >= 1.43.
+- **rmarkdown** now requires **knitr** >= 1.43.
 
 - Get rid of the superfluous warning in `find_pandoc()` (thanks, @jszhao, #2527).
 
 - Removed the **stringr** dependency since it is used only once in the package and the equivalent base R code is simple enough (thanks, @etiennebacher, #2530).
 
-- When `fig_crop: auto`, it will now uses the same logic as in knitr to decide if cropping is possible (yihui/knitr#2246).
+- For the output format option `fig_crop: auto`, it will now use the same logic as in **knitr** to decide if cropping is possible (yihui/knitr#2246).
 
 
 rmarkdown 2.25

--- a/R/util.R
+++ b/R/util.R
@@ -315,9 +315,7 @@ find_program <- function(program) {
   }
 }
 
-has_crop_tools <- function(warn = TRUE) {
- knitr:::has_crop_tools(warn)
-}
+has_crop_tools <- function(...) knitr:::has_crop_tools(...)
 
 # given a string, escape the regex metacharacters it contains:
 # regex metas are these,

--- a/R/util.R
+++ b/R/util.R
@@ -316,7 +316,7 @@ find_program <- function(program) {
 }
 
 has_crop_tools <- function(warn = TRUE) {
-  if (packageVersion("knitr")>= "1.43")) return(knitr:::has_crop_tools(warn))
+  if (packageVersion("knitr")>= "1.43") return(knitr:::has_crop_tools(warn))
 
   # TODO: Remove when we update knitr requirement
   tools <- c(

--- a/R/util.R
+++ b/R/util.R
@@ -316,21 +316,7 @@ find_program <- function(program) {
 }
 
 has_crop_tools <- function(warn = TRUE) {
-  if (packageVersion("knitr")>= "1.43") return(knitr:::has_crop_tools(warn))
-
-  # TODO: Remove when we update knitr requirement
-  tools <- c(
-    pdfcrop = unname(find_program("pdfcrop")),
-    ghostscript = unname(tools::find_gs_cmd())
-  )
-  missing <- tools[tools == ""]
-  if (length(missing) == 0) return(TRUE)
-  x <- paste0(names(missing), collapse = ", ")
-  if (warn) warning(
-    sprintf("\nTool(s) not installed or not in PATH: %s", x),
-    "\n-> As a result, figure cropping will be disabled."
-  )
-  FALSE
+  return(knitr:::has_crop_tools(warn))
 }
 
 # given a string, escape the regex metacharacters it contains:

--- a/R/util.R
+++ b/R/util.R
@@ -316,7 +316,7 @@ find_program <- function(program) {
 }
 
 has_crop_tools <- function(warn = TRUE) {
-  return(knitr:::has_crop_tools(warn))
+ knitr:::has_crop_tools(warn)
 }
 
 # given a string, escape the regex metacharacters it contains:

--- a/R/util.R
+++ b/R/util.R
@@ -316,6 +316,9 @@ find_program <- function(program) {
 }
 
 has_crop_tools <- function(warn = TRUE) {
+  if (packageVersion("knitr")>= "1.43")) return(knitr:::has_crop_tools(warn))
+
+  # TODO: Remove when we update knitr requirement
   tools <- c(
     pdfcrop = unname(find_program("pdfcrop")),
     ghostscript = unname(tools::find_gs_cmd())


### PR DESCRIPTION
Context: 

* https://github.com/yihui/knitr/issues/2246
* https://github.com/yihui/knitr/commit/4953bec489479bcef6eeb2f52cb9be40daabe47b

We improved the logic in **knitr** but never ported to **rmarkdown**. 

I use conditional to use internal **knitr** function. 

* Should it be exported from **knitr** instead ? 
* Should we inline instead to replace the one in **rmarkdown** completely ? 
* Or is it old enough so that we bump **knitr** min requirement ? 
