### PR TITLE
Correctly avoid writing to the input file when there are no preserved chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ rmarkdown 2.26
 
 - For the output format option `fig_crop: auto`, it will now use the same logic as in **knitr** to decide if cropping is possible (yihui/knitr#2246).
 
+- Avoid corrupting input files by accident (thanks, @J-Moravec, #2534).
+
 
 rmarkdown 2.25
 ================================================================================

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -251,7 +251,7 @@ html_document_base <- function(theme = NULL,
 }
 
 extract_preserve_chunks <- function(input_file, extract = extractPreserveChunks) {
-  input_str <- read_utf8(input_file)
+  input_str <- one_string(read_utf8(input_file))
   preserve <- extract(input_str)
   if (!identical(preserve$value, input_str)) write_utf8(preserve$value, input_file)
   preserve$chunks


### PR DESCRIPTION
Fix #2534: `htmltools::extractPreserveChunks()` will collapse the input character vector: https://github.com/rstudio/htmltools/blob/a8a3559edbfd9dda78418251e69273fa9dfeb9bc/R/tags.R#L1581-L1583 so we need to compare the collapsed version vs the extracted value later in `identical()`.