### PR TITLE
unit-test for #2534

### DIFF
--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -37,6 +37,6 @@ test_that("Input file is not corrupted", {
   input <- tempfile()
   on.exit(unlink(input), add = TRUE, after = FALSE)
   saveRDS("test", input)
-  try(rmarkdown::render(file, quiet = TRUE), silent = TRUE)
+ rmarkdown::render(input, quiet = TRUE)
   expect_equal(readRDS(input), "test")
 })

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -32,3 +32,11 @@ test_that("file_scope split correctly input file", {
   expect_snapshot_file(splitted[1])
   expect_snapshot_file(splitted[2])
 })
+
+test_that("Input file is not corrupted", {
+  input <- tempfile()
+  on.exit(unlink(input), add = TRUE, after = FALSE)
+  saveRDS("test", input)
+  try(rmarkdown::render(file, quiet = TRUE), silent = TRUE)
+  expect_equal(readRDS(input), "test")
+})

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -37,6 +37,6 @@ test_that("Input file is not corrupted", {
   input <- tempfile()
   on.exit(unlink(input), add = TRUE, after = FALSE)
   saveRDS("test", input)
- rmarkdown::render(input, quiet = TRUE)
+  rmarkdown::render(input, quiet = TRUE)
   expect_equal(readRDS(input), "test")
 })


### PR DESCRIPTION
Unit-test for this particular user-case.

Running `pandoc` is unfortunately necessary.

Tested on CRAN version of `rmarkdown` and a dev version using this fork.

In case of CRAN version, `pandoc` also likes to throw some additional warnings and errors that cannot be suppressed (or at least I don't know how).

If a `withr::with_tempfile()` is required instead of `on.exit()`, I can rework this. Since `on.exit` is already used in this file, I thought that it won't be confusing.