### PR TITLE
[GHA] New setup pandoc action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # testing R release with last shipped pandoc version in RStudio IDE and new pandoc
+          # testing R release with latest  pandoc version and their dev version
           - {os: windows-latest, pandoc: 'latest',  r: 'release'}
           - {os: windows-latest, pandoc: 'latest',  r: 'release'}
           - {os: macOS-latest,   pandoc: 'latest',  r: 'release'}
@@ -45,10 +45,10 @@ jobs:
           - {os: ubuntu-latest,  pandoc: '2.7.3',    r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.5',      r: 'release'}
           # testing other R versions
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-1'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-2'}
-          - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'oldrel-3'}
+          - {os: ubuntu-latest,  pandoc: 'latest',   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  pandoc: 'latest',   r: 'oldrel-1'}
+          - {os: ubuntu-latest,  pandoc: 'latest',   r: 'oldrel-2'}
+          - {os: ubuntu-latest,  pandoc: 'latest',   r: 'oldrel-3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update to latest r-lib/actions/setup-pandoc which support nighlty and latest. This makes my fork unneeded now. 