### PR TITLE
Optionize rmarkdown temp directory suffix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.27
 ================================================================================
 
+- Provide a global option `rmarkdown.files.suffix` to configure the suffix of the directory for auxiliary files (thanks, @certara-tzweers, #2550). By default, this suffix is `_files`, which can cause HTML output files to be deleted automatically on Microsoft OneDrive or Google Drive. If that is the case for you, you may set a different suffix in your `.Rprofile`, e.g., `options(rmarkdown.files.suffix = "_rmdfiles")`.
+
 
 rmarkdown 2.26
 ================================================================================

--- a/R/util.R
+++ b/R/util.R
@@ -184,11 +184,7 @@ file_with_meta_ext <- function(file, meta_ext, ext = xfun::file_ext(file)) {
 }
 
 knitr_files_dir <- function(file) {
-  if (!is.null(getOption("rmarkdown.files.suffix"))) {
-    suffix <- getOption("rmarkdown.files.suffix")
-  } else {
-    suffix <- "_files"
-  }
+  suffix <- getOption("rmarkdown.files.suffix", "_files")
   paste(xfun::sans_ext(file), suffix, sep = "")
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -184,7 +184,12 @@ file_with_meta_ext <- function(file, meta_ext, ext = xfun::file_ext(file)) {
 }
 
 knitr_files_dir <- function(file) {
-  paste(xfun::sans_ext(file), "_files", sep = "")
+  if (!is.null(getOption("rmarkdown.files.suffix"))) {
+    suffix <- getOption("rmarkdown.files.suffix")
+  } else {
+    suffix <- "_files"
+  }
+  paste(xfun::sans_ext(file), suffix, sep = "")
 }
 
 knitr_root_cache_dir <- function(file) {


### PR DESCRIPTION
We are making this pull request because we have been experiencing an issue with OneDrive deleting html files shortly after knitting them. We have been in email contact with @yihui about updating the knitr_files_dir funtion to aviod this issue (28 Mar 2024, Subject: Rmarkdown: patch for knitr_files_dir).

We have experienced apparently random deletions of html files from OneDrive synced folders shortly after completing the knitting of corresponding Rmd scripts. It appears that this is related to a feature (not bug...) described on this page: 


[Managing the File System - Win32 apps | Microsoft Learn](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fwindows%2Fwin32%2Fshell%2Fmanage%3Fredirectedfrom%3DMSDN%23connected-files&data=05%7C02%7Cthijs.zweers%40certara.com%7C0c51552ea15d4a508ac008dc52ea4203%7C7287abd30220456e98514352bae208c9%7C1%7C0%7C638476413285887341%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=RgGn24MoT69xwfHNl6zGmTJ02FXARdk%2BN6XOskDrPWg%3D&reserved=0)

As such, the issue is a consequence of different components following their designs with an undesirable outcome. A solution to this could be to change the knitr_files_dir function in util.R so the temporary folder for knitr files is not created with a suffix of "_files" but almost anything else, such as "_knitrfiles".

With this update we have made the knitr temp directory suffix configurable via options(rmarkdown.files.suffix = "_knitrfiles") in the knitr_files_dir function.