### PR TITLE
Fix regression w/ image path processing from absolute to relative

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.26.1
+Version: 2.26.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,7 +83,8 @@ Suggests:
     tibble,
     vctrs,
     cleanrmd,
-    withr (>= 2.4.2)
+    withr (>= 2.4.2),
+    xml2
 VignetteBuilder: knitr
 Config/Needs/website: rstudio/quillt, pkgdown
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.27
 
 - Provide a global option `rmarkdown.files.suffix` to configure the suffix of the directory for auxiliary files (thanks, @certara-tzweers, #2550). By default, this suffix is `_files`, which can cause HTML output files to be deleted automatically on Microsoft OneDrive or Google Drive. If that is the case for you, you may set a different suffix in your `.Rprofile`, e.g., `options(rmarkdown.files.suffix = "_rmdfiles")`.
 
+- Fix a regression in 2.26 regarding image paths post-processing in `html_document_base()`. Now absolute paths to image in the output directory (`output_dir`) are correctly made relative to the output directory again.
+
 
 rmarkdown 2.26
 ================================================================================

--- a/R/base64.R
+++ b/R/base64.R
@@ -1,6 +1,7 @@
 # processes an HTML resource, given a regular expression that locates
 # instances of that resource
 process_html_res <- function(html, reg, processor) {
+  html <- one_string(html)
   m <- gregexpr(reg, html, perl = TRUE, ignore.case = TRUE)
   regmatches(html, m) <- lapply(regmatches(html, m), function(img_src) {
     src <- sub(reg, '\\1', img_src, ignore.case = TRUE)
@@ -10,7 +11,7 @@ process_html_res <- function(html, reg, processor) {
       character(1)
     )
   })
-  html
+  strsplit(html, "\n", fixed = TRUE)[[1]]
 }
 
 process_images <- function(html, processor) {

--- a/tests/testthat/test-html_document_base.R
+++ b/tests/testthat/test-html_document_base.R
@@ -1,0 +1,60 @@
+# TODO: to remove when switching the package to edition 3
+local_edition(3)
+
+test_that("Absolute path for image from output directory are made relative to output directory", {
+  skip_if_not_pandoc("2.0")
+  skip_if_not_installed("xml2")
+  skip_if_not_installed("withr")
+  rmd <- local_rmd_file(c(
+    "---",
+    "  title: test",
+    "---",
+    "",
+    "```{r}",
+    "#| label: veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongfilename",
+    "plot(mtcars)",
+    "```"
+  ))
+  # Forcing absolute path for input and output to trigger absolute path for images
+  out <- rmarkdown::render(rmd, "html_document", output_options = list(self_contained = FALSE), output_dir = dirname(rmd), quiet = TRUE)
+  html <- xml2::read_html(out)
+  img <- xml2::xml_find_first(html, ".//img")
+  # is the path correctly made relative to _files ?
+  expect_match(xml2::xml_attr(img, "src"), sprintf("^%s", knitr_files_dir(basename(rmd))))
+})
+
+
+test_that("Absolute path from output_dir from img tag created through pandoc are made relative to output_dir", {
+  skip_if_not_pandoc("2.0")
+  skip_if_not_installed("xml2")
+  skip_if_not_installed("withr")
+  # from https://github.com/r-lib/pkgdown/issues/2341
+  # Issue happens because
+  # - knitr::hook_plot_md_base() will use markdown syntax when no width and height are provided (+ other contextt). Pandoc will convert and add a linebreak
+  #   due to its wrapping config --wrap=auto from pandoc 2.17 which could break our processing
+  # - This won't be the case for .png file for example, as a out.width is computed by knitr internally which trigger <img src=> tag use
+  # - This is why we recreate using gif below
+  #   1. Take the gif from package
+  #   2. Copy it to the fig_path() which will be in output directory
+  #   3. Use include_graphics to include it in knitr, keeping absolute path
+  rmd <- local_rmd_file(c(
+    "---",
+    "  title: test",
+    "---",
+    "",
+    "```{r}",
+    "#| label: veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongfilename",
+    "gif <- system.file('rmd/h/rmarkdown/rmd_loader.gif', package = 'rmarkdown')",
+    "stopifnot(file.exists(gif))",
+    "file <- knitr::fig_path('.gif')",
+    "dir.create(dirname(file), showWarnings = FALSE, recursive = TRUE)",
+    "file.copy(gif, file)",
+    "knitr::include_graphics(file, rel_path = FALSE)",
+    "```"
+  ))
+  out <- rmarkdown::render(rmd, "html_document", output_options = list(self_contained = FALSE, keep_md = TRUE), output_dir = dirname(rmd), quiet = TRUE)
+  html <- xml2::read_html(out)
+  img <- xml2::xml_find_first(html, ".//img")
+  # # is the path correctly made relative to _files ?
+  expect_match(xml2::xml_attr(img, "src"), sprintf("^%s", knitr_files_dir(basename(rmd))))
+})


### PR DESCRIPTION
Processing of HTML needs to account for newlines because pandoc --wrap behavior can sometimes likes to split lines in the HTML like
```
<img>
src="..." </img>
```

Processing line by line would break a reg for img tag's src attribute

This breakage was found in pkgdown processing which uses absolute path for rendering leading to very long image source creating the split

It is also related to `knitr.graphics.rel_path = FALSE` being set fro

Related to 
- https://github.com/r-lib/pkgdown/issues/2496
- https://github.com/r-lib/pkgdown/issues/2341 (requires `knitr.graphics.rel_path = FALSE` due to https://github.com/yihui/knitr/issues/2171)
- https://github.com/r-lib/pkgdown/issues/2334 (requires `knitr.graphics.rel_path = FALSE` due to https://github.com/yihui/knitr/issues/2171) 

See discussion in 0951a2fea7e317f77d27969c25f3194ead38805e