### PR TITLE
feat(beamer): support latex_dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -87,6 +87,7 @@ Suggests:
     xml2
 VignetteBuilder: knitr
 Config/Needs/website: rstudio/quillt, pkgdown
+Config/testthat/edition: 3
 Encoding: UTF-8
 RoxygenNote: 7.3.1
 SystemRequirements: pandoc (>= 1.14) - http://pandoc.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.28
 ================================================================================
 
-
+- `beamer_presentation` support handling latex dependencies via the new `extra_dependencies` argument and declarations within chunks (e.g., `knitr::asis_output("", meta = list(rmarkdown::latex_dependency("longtable")))`) (thanks, @cderv, @atusy, #2478).
 
 rmarkdown 2.27
 ================================================================================

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -71,7 +71,8 @@ beamer_presentation <- function(toc = FALSE,
                                 self_contained = TRUE,
                                 includes = NULL,
                                 md_extensions = NULL,
-                                pandoc_args = NULL) {
+                                pandoc_args = NULL,
+                                extra_dependencies = NULL) {
 
   # base pandoc options for all beamer output
   args <- c()
@@ -143,6 +144,12 @@ beamer_presentation <- function(toc = FALSE,
     # Same in PDF for beamer
     # https://github.com/rstudio/rmarkdown/issues/2294
     args <- append_in_header(process_header_includes(metadata))
+
+    if (length(extra_dependencies) || has_latex_dependencies(knit_meta)) {
+      extra_dependencies <- latex_dependencies(extra_dependencies)
+      all_dependencies <- append(extra_dependencies, flatten_latex_dependencies(knit_meta))
+      args <- c(args, append_in_header(latex_dependencies_as_string(all_dependencies)))
+    }
 
     # no-op other than caching dir location
     args

--- a/man/beamer_presentation.Rd
+++ b/man/beamer_presentation.Rd
@@ -27,7 +27,8 @@ beamer_presentation(
   self_contained = TRUE,
   includes = NULL,
   md_extensions = NULL,
-  pandoc_args = NULL
+  pandoc_args = NULL,
+  extra_dependencies = NULL
 )
 }
 \arguments{
@@ -129,6 +130,13 @@ default definition of R Markdown. See the \code{\link{rmarkdown_format}} for
 additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
+
+\item{extra_dependencies}{A LaTeX dependency \code{latex_dependency()}, a
+list of LaTeX dependencies, a character vector of LaTeX package names (e.g.
+\code{c("framed", "hyperref")}), or a named list of LaTeX package options
+with the names being package names (e.g. \code{list(hyperef =
+c("unicode=true", "breaklinks=true"), lmodern = NULL)}). It can be used to
+add custom LaTeX packages to the .tex header.}
 }
 \value{
 R Markdown output format to pass to \code{\link[=render]{render()}}

--- a/tests/testthat/test-beamer_presentation.R
+++ b/tests/testthat/test-beamer_presentation.R
@@ -1,0 +1,32 @@
+test_that("beamer_presentation() incorporates latex dependencies", {
+  expected_dependencies <- c(
+    "\\usepackage{longtable}", # from extra_dependencies
+    "\\usepackage{hyperref}" # from knit_meta
+  )
+
+  extra_dependencies <- list(
+    # do not include non-latex dependencies
+    # as pre processor does not care the kind of extra dependencies
+    latex_dependency("longtable")
+  )
+  knit_meta <- list(
+    latex_dependency("hyperref"),
+    html_dependency_jquery() # pre_processor should remove html dependencies
+  )
+
+  fmt <- beamer_presentation(extra_dependencies = extra_dependencies)
+
+  pandoc_args <- fmt$pre_processor(
+    list(),
+    tempfile(),
+    "static",
+    knit_meta,
+    tempdir(),
+    tempdir()
+  )
+
+  included <- pandoc_args[which(pandoc_args == "--include-in-header") + 1L]
+  expect_length(included, 1L)
+  expect_true(file.exists(included))
+  expect_identical(readLines(included), expected_dependencies)
+})

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("formats successfully produce a document", {
 
   testFormat <- function(output_format, df_print = NULL) {

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("toc has correct identifier", {
   skip_on_cran() # avoid pandoc issue on CRAN
   skip_if_not_pandoc("2.10.1") # changes in gfm writer break this test for earlier versions

--- a/tests/testthat/test-html_dependencies.R
+++ b/tests/testthat/test-html_dependencies.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("Correct anchor_sections style is used", {
   deps <- html_dependency_anchor_sections
   expect_s3_class(deps(), "html_dependency")

--- a/tests/testthat/test-html_document.R
+++ b/tests/testthat/test-html_document.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("anchor_sections() adds correct component", {
   skip_if_not_pandoc("2.0")
   res <- list(args = NULL, lua_filters = NULL, extra_dependencies = NULL)

--- a/tests/testthat/test-html_document_base.R
+++ b/tests/testthat/test-html_document_base.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("Absolute path for image from output directory are made relative to output directory", {
   skip_if_not_pandoc("2.0")
   skip_if_not_installed("xml2")

--- a/tests/testthat/test-ioslides_presentation.R
+++ b/tests/testthat/test-ioslides_presentation.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("Only mathjax is supported", {
   expect_error(ioslides_presentation(math_method = "katex"))
 })

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 .generate_md_and_convert <- function(content, output_format) {
   input_file <- local_rmd_file(c("---\ntitle: Test\n---\n", content))
   res <- .render_and_read(input_file, output_format = output_format)

--- a/tests/testthat/test-math.R
+++ b/tests/testthat/test-math.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("check_math_argument()", {
   # valid value
   expect_null(check_math_argument(NULL))

--- a/tests/testthat/test-md_document.R
+++ b/tests/testthat/test-md_document.R
@@ -1,5 +1,3 @@
-local_edition(3)
-
 test_that("adapt_md_variant() adds extensions to markdown variants", {
   expect_identical(adapt_md_variant("markdown"), "markdown-yaml_metadata_block-pandoc_title_block")
   expect_identical(adapt_md_variant("markdown_phpextra"), "markdown_phpextra-yaml_metadata_block")

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("build highlight args for pandoc correctly", {
   hl_style <- function(name) c("--highlight-style", name)
   expect_equal(pandoc_highlight_args(NULL), "--no-highlight")

--- a/tests/testthat/test-pdf_document.R
+++ b/tests/testthat/test-pdf_document.R
@@ -1,0 +1,32 @@
+test_that("pdf_document() incorporates latex dependencies", {
+  expected_dependencies <- c(
+    "\\usepackage{longtable}", # from extra_dependencies
+    "\\usepackage{hyperref}" # from knit_meta
+  )
+
+  extra_dependencies <- list(
+    # do not include non-latex dependencies
+    # as pre processor does not care the kind of extra dependencies
+    latex_dependency("longtable")
+  )
+  knit_meta <- list(
+    latex_dependency("hyperref"),
+    html_dependency_jquery() # pre_processor should remove html dependencies
+  )
+
+  fmt <- pdf_document(extra_dependencies = extra_dependencies)
+
+  pandoc_args <- fmt$pre_processor(
+    list(),
+    tempfile(),
+    "static",
+    knit_meta,
+    tempdir(),
+    tempdir()
+  )
+
+  included <- pandoc_args[which(pandoc_args == "--include-in-header") + 1L]
+  expect_length(included, 1L)
+  expect_true(file.exists(included))
+  expect_identical(readLines(included), expected_dependencies)
+})

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,6 +1,3 @@
-# TODO: to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("Metadata is available before pre_knit", {
   message_pre_knit = 'pre_knit handles metadata'
   fmt <- md_document()

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -1,6 +1,3 @@
-# TODO: added for new tests - to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("file.path.ci returns correctly no matter the case", {
   tmp_dir <- withr::local_tempdir()
   expect_equal(file.path.ci(tmp_dir, "global.R"), file.path(tmp_dir, "global.R"))

--- a/tests/testthat/test-shiny_prerendered.R
+++ b/tests/testthat/test-shiny_prerendered.R
@@ -1,6 +1,3 @@
-# TODO: added for new tests - to remove when switching the package to edition 3
-local_edition(3)
-
 test_that("HTML template contains special comment when in shiny prerendered", {
   skip_if_not_pandoc()
   special_comment <- "<!-- HEAD_CONTENT -->"

--- a/tests/testthat/test-site.R
+++ b/tests/testthat/test-site.R
@@ -1,5 +1,3 @@
-local_edition(3)
-
 # copy part of our demo site to a tempdir
 local_create_site <- function(files, env = parent.frame()) {
   site_dir <- tempfile()


### PR DESCRIPTION
closes #2478

Confirmed it works by the following script.

```r
writeLines(
  c(
    '```{r}',
    'knitr::asis_output("", meta = list(rmarkdown::latex_dependency("longtable")))',
    '```',
    '\\begin{longtable}{r|r} \\hline speed & dist\\\\ \\hline 4 & 2\\\\ \\end{longtable}'
  ),
  "example.Rmd"
)

render("example.Rmd", beamer_presentation())
```