### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,7 +57,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/check-pandoc-daily.yaml
+++ b/.github/workflows/check-pandoc-daily.yaml
@@ -26,7 +26,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
I was looking at your workflow files for an unrelated reason and noticed all your `actions/checkout` are at old versions.

Merging this will get rid of these GHA warnings you are getting (screenshot below).

![CleanShot 2024-08-28 at 10 36 14@2x](https://github.com/user-attachments/assets/96bc1557-4da2-4ab5-8946-365519994d59)

Also your `nwtgck/actions-netlify` is at an old version (current is `v3` for that) <https://github.com/nwtgck/actions-netlify>.
