### PR TITLE
Support new Pandoc 3.4 behavior with GFM math

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.28.1
+Version: 2.28.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -102,8 +102,8 @@ github_document <- function(toc = FALSE,
         # don't activate math in Pandoc and pass it as is
         # https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/
         math <- NULL
-        # TODO: Check for version - should be the default in Pandoc 2.19+
-        variant <- paste0(variant, "+tex_math_dollars")
+        # Pandoc 3.4 uses +tex_math_gfm by default to write special gfm syntax. We choose to keep $$ and $ which are still supported by Github
+        variant <- if (pandoc_available("3.4")) paste0(variant, "-tex_math_gfm") else paste0(variant, "+tex_math_dollars")
         preview_math <- check_math_argument("mathjax")
       } else {
         # fallback to webtex

--- a/tests/testthat/test-github_document.R
+++ b/tests/testthat/test-github_document.R
@@ -13,7 +13,7 @@ test_that("toc has correct identifier", {
   } else {
     "before-pandoc-2.18"
   }
-  res <- render(tmp_file, github_document(toc = TRUE, html_preview = FALSE))
+  res <- render(tmp_file, github_document(toc = TRUE, html_preview = FALSE), quiet = TRUE)
   expect_snapshot_file(res, "github-toc.md", compare = compare_file_text, variant = pandoc_version)
 })
 
@@ -32,7 +32,7 @@ test_that("toc has correct identifier also when sections are numbered ", {
   } else {
     "before-pandoc-2.18"
   }
-  res <- render(tmp_file, github_document(toc = TRUE, number_sections = TRUE, html_preview = FALSE))
+  res <- render(tmp_file, github_document(toc = TRUE, number_sections = TRUE, html_preview = FALSE), quiet = TRUE)
   expect_snapshot_file(res, "github-toc-numbered.md", compare = compare_file_text, variant = pandoc_version)
 })
 
@@ -41,7 +41,7 @@ test_that("github_document produces atx-header", {
   skip_on_cran() # avoid pandoc issue on CRAN
   h <- paste0(Reduce(paste0, rep("#", 5), accumulate = TRUE), " title ", 1:5, "\n\n")
   tmp_file <- local_rmd_file(h)
-  res <- render(tmp_file, github_document(html_preview = FALSE))
+  res <- render(tmp_file, github_document(html_preview = FALSE), quiet = TRUE)
   expect_snapshot_file(res, "github-atx.md", compare = compare_file_text)
 })
 


### PR DESCRIPTION
closes #2572

As explained in this issue, Pandoc does by default uses the alternative GFM syntax for math. 

In `github_document()`, we choose to keep writing the dollars syntax `$$` and `$` to avoid any future breakage. 

In the future, we may add an option to activate the writing of `` ```math `` and `` $` `` if necessary. It seems they were added by Github to handle specific characters
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
> You can either surround the expression with dollar symbols ($), or start the expression with $` and end it with `$. The latter syntax is useful when the expression you are writing contains characters that overlap with markdown syntax.