### PR TITLE
Add support for `child=c("child.Rmd")` in find_external_resources()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 rmarkdown 2.29
 ================================================================================
 
+- `find_external_resources()` now correctly detects knitr child document provided with option like `child = c("child.Rmd")` (thanks, @rempsyc, #2574).
 
 rmarkdown 2.28
 ================================================================================

--- a/R/html_resources.R
+++ b/R/html_resources.R
@@ -316,7 +316,7 @@ discover_rmd_resources <- function(rmd_file, discover_single_resource) {
         rmd_content[idx], chunk_start,
         chunk_start + attr(chunk_line, "capture.length", exact = TRUE) - 2
       )
-      for (child_expr in c("\\bchild\\s*=\\s*'([^']+)'", "\\bchild\\s*=\\s*\"([^\"]+)\"")) {
+      for (child_expr in c("\\bchild\\s*=\\s*(?:c\\()?'([^']+)'\\)?", "\\bchild\\s*=\\s*(?:c\\()?\"([^\"]+)\"\\)?")) {
         child_match <- gregexpr(child_expr, chunk_text, perl = TRUE)[[1]]
         if (child_match > 0) {
           child_start <- attr(child_match, "capture.start", exact = TRUE)

--- a/tests/testthat/test-resources.R
+++ b/tests/testthat/test-resources.R
@@ -263,3 +263,24 @@ test_that("multiple resources in the includes option can be discovered", {
 
   expect_equal(resources, expected)
 })
+
+test_that("knitr child are correctly discovered as resources from chunk options", {
+  expect_child_resource_found <- function(child_opts, child) {
+    dir <- withr::local_tempdir("find-child")
+    withr::local_dir(dir)
+    rmd <- "test.Rmd"
+    xfun::write_utf8(
+      text = knitr::knit_expand(text = c("```{r,<<child_opts>>}", "```"), delim = c("<<", ">>")),
+      rmd
+    )
+    xfun::write_utf8(c("Content"), child)
+    expect_contains(find_external_resources(!!rmd)$path, !!child)
+  }
+  child <- "child.Rmd"
+  expect_child_resource_found('child="child.Rmd"', child)
+  expect_child_resource_found(' child = "child.Rmd"', child)
+  expect_child_resource_found('child=c("child.Rmd")', child)
+  expect_child_resource_found("child='child.Rmd'", child)
+  expect_child_resource_found(" child = 'child.Rmd'", child)
+  expect_child_resource_found("child=c('child.Rmd')", child)
+})


### PR DESCRIPTION
fix #2574 

