### PR TITLE
Fix documentation mistake

### DIFF
--- a/man/html_document.Rd
+++ b/man/html_document.Rd
@@ -349,7 +349,7 @@ be included at the top of the document.
 
 The "_navbar.yml" file includes \code{title}, \code{type}, \code{left}, and
 \code{right} fields (to define menu items for the left and right of the navbar
-respectively). Menu items include \code{title} and \code{href} fields. For example:
+respectively). Menu items include \code{text} and \code{href} fields. For example:
 
 \preformatted{title: "My Website"
 type: default


### PR DESCRIPTION
The description contains "title" but it should be "text" as in the example below.