### PR TITLE
fix(pandoc): Throw error when pandoc isn't available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.29.1
+Version: 2.29.2
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.30
 ================================================================================
 
+- `pandoc_convert()` will throw an error if Pandoc is not available (thanks, @brianperdomo, #2600).
+
 
 rmarkdown 2.29
 ================================================================================

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -46,6 +46,10 @@ pandoc_convert <- function(input,
                            verbose = FALSE,
                            wd = NULL) {
 
+  # ensure pandoc is available
+  if (!pandoc_available()) 
+    stop2("pandoc not found, ensure pandoc is installed")
+  
   # ensure we've scanned for pandoc
   find_pandoc()
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -47,11 +47,7 @@ pandoc_convert <- function(input,
                            wd = NULL) {
 
   # ensure pandoc is available
-  if (!pandoc_available()) 
-    stop2("pandoc not found, ensure pandoc is installed")
-  
-  # ensure we've scanned for pandoc
-  find_pandoc()
+  pandoc_available(error = TRUE)
 
   # evaluate path arguments before changing working directory
   force(output)


### PR DESCRIPTION
I discovered an issue with the pandoc_convert function while attempting to use the btw package in Github Copilot in VS Code on a machine that did not have Rstudio installed.

If you attempt to use pandoc_convert on a machine without pandoc installed, it throws the following error:

`pandoc document conversion failed with error 127`

.... but there is not a pandoc error 127.

I see that pandoc_convert runs find_pandoc at the beginning, but this doesn't catch the issue. All it does is set .pandoc$version to 0 and .pandoc$dir to NULL.

I have added a call to pandoc_available to catch this issue and provide a more informative error message to the user.