### PR TITLE
Fix typo in env var name in shared.lua comment

### DIFF
--- a/inst/rmarkdown/lua/shared.lua
+++ b/inst/rmarkdown/lua/shared.lua
@@ -3,7 +3,7 @@
     This filter contains utility functions that are useful in several filters.
 
   USAGE
-    This script is loaded in other script by an RMARKDOW_LUA_SHARED environment variable
+    This script is loaded in other script by an RMARKDOWN_LUA_SHARED environment variable
     set inside rmarkdown R package by `render()`.
 
     Use this line in other script to use this function


### PR DESCRIPTION
Fixing small typo in env var name in `shared.lua` file