### PR TITLE
Require Pandoc >= 2.8 and drop Pandoc 1.x support

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,8 +32,10 @@ jobs:
           # testing R release with last shipped pandoc version in RStudio IDE and new pandoc
           - {os: windows-latest, pandoc: 'latest',  r: 'release'}
           - {os: macOS-latest,   pandoc: 'latest',  r: 'release'}
+          - {os: ubuntu-latest,  pandoc: 'latest',  r: 'release'}
           - {os: ubuntu-latest,  pandoc: 'nightly',    r: 'release'}
-          # testing older pandoc versions
+          # testing older pandoc versions (rmarkdown requires Pandoc >= 2.8)
+          - {os: ubuntu-latest,  pandoc: '3.8.3',    r: 'release'}
           - {os: ubuntu-latest,  pandoc: '3.1.11',   r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.19.2',   r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.18',     r: 'release'}
@@ -41,8 +43,7 @@ jobs:
           - {os: ubuntu-latest,  pandoc: '2.16.2',   r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.14.2',   r: 'release'}
           - {os: ubuntu-latest,  pandoc: '2.11.4',   r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.7.3',    r: 'release'}
-          - {os: ubuntu-latest,  pandoc: '2.5',      r: 'release'}
+          - {os: ubuntu-latest,  pandoc: '2.8',      r: 'release'}
           # testing other R versions
           - {os: ubuntu-latest,  pandoc: 'latest',   r: 'devel'}
           - {os: ubuntu-latest,  pandoc: 'latest',   r: 'oldrel-1'}
@@ -98,7 +99,7 @@ jobs:
       - uses: yihui/actions/check-r-package@HEAD
 
       - name: Test coverage
-        if: success() && runner.os == 'Linux' && matrix.config.r == 'release' && matrix.config.pandoc == '2.19.2'
+        if: success() && runner.os == 'Linux' && matrix.config.r == 'release' && matrix.config.pandoc == 'latest'
         run: |
           xfun::pkg_load2('covr')
           covr::codecov()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,4 +88,4 @@ VignetteBuilder: knitr
 Config/testthat/edition: 3
 Encoding: UTF-8
 RoxygenNote: 7.3.3
-SystemRequirements: pandoc (>= 1.14) - http://pandoc.org
+SystemRequirements: pandoc (>= 2.8) - http://pandoc.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.32
 ================================================================================
 
+- The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2622).
+
 - Relicensed this package to MIT (thanks, @karangattu, #2615).
 
 - Replaced the Pandoc argument `--extract-media` with a Lua filter to fix the `*_files/` cleanup regression (thanks, @bastistician, #2620).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.32
 ================================================================================
 
-- The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2622).
+- The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2623).
 
 - Relicensed this package to MIT (thanks, @karangattu, #2615).
 

--- a/R/beamer_presentation.R
+++ b/R/beamer_presentation.R
@@ -77,11 +77,9 @@ beamer_presentation <- function(toc = FALSE,
   # base pandoc options for all beamer output
   args <- c()
 
-  # template path and assets
-  if (!is.null(template)) {
-    if (identical(template, "default")) template <- patch_beamer_template()
-    if (!is.null(template))
-      args <- c(args, "--template", pandoc_path_arg(template))
+  # template path and assets ("default" uses Pandoc's built-in beamer template)
+  if (!is.null(template) && !identical(template, "default")) {
+    args <- c(args, "--template", pandoc_path_arg(template))
   }
 
   # table of contents
@@ -177,93 +175,4 @@ beamer_presentation <- function(toc = FALSE,
     keep_md = keep_md,
     df_print = df_print
   )
-}
-
-
-patch_beamer_template_pagenumber <- function(template) {
-
-  patch <- paste(
-    "% Comment these out if you don't want a slide with just the",
-    "% part/section/subsection/subsubsection title:", "\\AtBeginPart{",
-    "  \\let\\insertpartnumber\\relax", "  \\let\\partname\\relax",
-    "  \\frame{\\partpage}", "}", "\\AtBeginSection{",
-    "  \\let\\insertsectionnumber\\relax", "  \\let\\sectionname\\relax",
-    "  \\frame{\\sectionpage}", "}", "\\AtBeginSubsection{",
-    "  \\let\\insertsubsectionnumber\\relax", "  \\let\\subsectionname\\relax",
-    "  \\frame{\\subsectionpage}", "}",
-    sep = "\n"
-  )
-
-  pasted <- one_string(template)
-  patched <- sub(patch, "", pasted, fixed = TRUE)
-  strsplit(patched, "\n", fixed = TRUE)[[1]]
-}
-
-patch_beamer_template_paragraph_spacing <- function(template) {
-
-  patch <- c(
-    "\\setlength{\\parindent}{0pt}",
-    "\\setlength{\\parskip}{6pt plus 2pt minus 1pt}"
-  )
-
-  lines <- unlist(lapply(patch, function(line) {
-    index <- grep(line, template, fixed = TRUE)
-    if (length(index) == 1) index else -1
-  }))
-
-  # bail if we already have these lines in the document
-  if (all(lines >= 0) && lines[[1]] == lines[[2]] - 1)
-    return(template)
-
-  # find patch location -- we insert before this line
-  targetLine <- "\\setlength{\\emergencystretch}{3em}  % prevent overfull lines"
-  targetIdx <- grep(targetLine, template, fixed = TRUE)
-  if (!length(targetIdx))
-    return(template)
-
-  # insert patch
-  c(
-    utils::head(template, n = targetIdx - 1),
-    patch,
-    utils::tail(template, n = -(targetIdx - 1))
-  )
-}
-
-patch_beamer_template <- function() {
-  pandoc_available(error = TRUE)
-
-  # invoke pandoc to read default template
-  command <- paste(quoted(pandoc()), "-D beamer")
-  template <- with_pandoc_safe_environment({
-    tryCatch(
-      system(command, intern = TRUE),
-      error = function(e) NULL
-    )
-  })
-
-  # make failure to read template non-fatal
-  if (is.null(template))
-    return(NULL)
-
-  # trim whitespace
-  template <- gsub("^\\s+|\\s+$", "", template, perl = TRUE)
-
-  # apply patches (store original version of template so we can
-  # compare after applying patches)
-  original <- template
-  version <- pandoc_version()
-
-  if (version < "1.15.2")
-    template <- patch_beamer_template_pagenumber(template)
-
-  if (version > "1.15.2" && version < "1.17.3")
-    template <- patch_beamer_template_paragraph_spacing(template)
-
-  # if the template hasn't changed, return NULL (we don't need
-  # to apply a custom template)
-  if (identical(template, original))
-    return(NULL)
-
-  # write and return path to template
-  as_tmpfile(enc2utf8(template))
 }

--- a/R/github_document.R
+++ b/R/github_document.R
@@ -69,13 +69,8 @@ github_document <- function(toc = FALSE,
     pkg_file_arg("rmarkdown/templates/github_document/resources/default.md")
   )
 
-  pandoc2 <- pandoc2.0()
   # use md_document as base
-  if (pandoc2) {
-    variant <-  "gfm"
-  } else {
-    variant <- "markdown_github"
-  }
+  variant <- "gfm"
   if (!hard_line_breaks) variant <- paste0(variant, "-hard_line_breaks")
 
   # atx headers are the default in pandoc 2.11.2 and the flag has been deprecated
@@ -85,13 +80,12 @@ github_document <- function(toc = FALSE,
   )
 
   if ((toc || number_sections) &&
-      !isTRUE(grepl("gfm_auto_identifiers", md_extensions)) &&
-      pandoc2) {
+      !isTRUE(grepl("gfm_auto_identifiers", md_extensions))) {
     md_extensions <- c(md_extensions, "+gfm_auto_identifiers")
   }
 
   # math support
-  if (!is.null(math_method) && pandoc_available("2.0.4")) {
+  if (!is.null(math_method)) {
     math <- check_math_argument(math_method)
     preview_math <- NULL
     if (!math$engine %in% c("default", "webtex")) {
@@ -146,7 +140,7 @@ github_document <- function(toc = FALSE,
         "--template", pkg_file_arg(
           "rmarkdown/templates/github_document/resources/preview.html"),
         "--variable", paste0("github-markdown-css:", css),
-        if (pandoc2) c("--metadata", "pagetitle=PREVIEW"),  # HTML5 requirement
+        "--metadata", "pagetitle=PREVIEW",  # HTML5 requirement
         if (!is.null(preview_math)) preview_math$args
       )
 

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -910,10 +910,6 @@ add_anchor_sections <- function(anchor_sections, section_divs = FALSE) {
   if (identical(anchor_sections, FALSE)) {
     return(res)
   }
-  # Requires Pandoc 2.0 because using a Lua filter
-  if (!pandoc2.0()) {
-    stop("Using anchor_sections requires Pandoc 2.0+", call. = FALSE)
-  }
 
   allowed_args <- c("style", "depth")
   default_style <- "hash"

--- a/R/html_document_base.R
+++ b/R/html_document_base.R
@@ -296,11 +296,6 @@ add_math_support <- function(math, template, files_dir, output_dir) {
     stop2(sprintf("`math_method='%s'` is not supported.", math$engine))
   }
 
-  # support only mathjax for Pandoc before 2.0+
-  if (!pandoc2.0() && !identical(math$engine, "mathjax")) {
-    stop2("only `math_method = 'mathjax'` is supported with earlier version than Pandoc 2.0 ")
-  }
-
   # change default for url for webtex to use SVG
   # Pandoc still uses PNG
   if (identical(math$engine, "webtex")) {

--- a/R/ioslides_presentation.R
+++ b/R/ioslides_presentation.R
@@ -424,24 +424,6 @@ ioslides_presentation <- function(number_sections = FALSE,
     output_tmpfile <- tempfile("ioslides-output", fileext = ".html")
     on.exit(unlink(output_tmpfile), add = TRUE)
 
-    # on Windows, cache the current codepage and set it to 65001 (UTF-8) for the
-    # duration of the Pandoc command. Without this, Pandoc fails when attempting
-    # to hand UTF-8 encoded non-ASCII characters over to the custom Lua writer.
-    # See https://github.com/rstudio/rmarkdown/issues/134
-    if (is_windows() && !pandoc2.0()) {
-      # 'chcp' returns e.g., "Active code page: 437"; strip characters and parse
-      # the number
-      codepage <- as.numeric(gsub("\\D", "", system2("chcp", stdout = TRUE)))
-
-      if (!is.na(codepage)) {
-        # if we got a valid codepage, restore it on exit
-        on.exit(system2("chcp", args = codepage, stdout = TRUE), add = TRUE)
-
-        # change to the UTF-8 codepage
-        system2("chcp", args = 65001, stdout = TRUE)
-      }
-    }
-
     pandoc_convert(input = input_file,
                    to = relative_to(dirname(input_file), lua_writer),
                    from = from_rmarkdown(fig_caption),

--- a/R/md_document.R
+++ b/R/md_document.R
@@ -70,11 +70,6 @@ md_document <- function(variant = "markdown_strict",
   args <- c(args, pandoc_args)
 
   # Preprocess number_sections if variant is a markdown flavor +gfm_auto_identifiers
-  if (number_sections && !pandoc_available("2.1")) {
-    warning("`number_sections = TRUE` requires at least Pandoc 2.1. The feature will be deactivated",
-            call. = FALSE)
-    number_sections <- FALSE
-  }
   pre_processor <- if (
     number_sections
     && grepl("^(commonmark|gfm|markdown)", variant)

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -196,7 +196,7 @@ pandoc_citeproc_convert <- function(file, type = c("list", "json", "yaml")) {
 #' if (pandoc_available())
 #'   cat("pandoc", as.character(pandoc_version()), "is available!\n")
 #'
-#' if (pandoc_available("1.12.3"))
+#' if (pandoc_available("2.8"))
 #'   cat("required version of pandoc is available!\n")
 #' }
 #' @export
@@ -322,8 +322,7 @@ pandoc_highlight_args <- function(highlight, default = "tango") {
 #' @export
 pandoc_latex_engine_args <- function(latex_engine) {
 
-  c(if (pandoc2.0()) "--pdf-engine" else "--latex-engine",
-    find_latex_engine(latex_engine))
+  c("--pdf-engine", find_latex_engine(latex_engine))
 }
 
 # For macOS, use a full path to the latex engine since the stripping
@@ -458,13 +457,7 @@ pandoc_self_contained_html <- function(input, output) {
   # we still need to do this "conversion" to get the
   # base64 encoding)
 
-  # determine from (there are bugs in pandoc < 1.17 that
-  # cause markdown_strict to hang on very large script
-  # elements)
-  from <- if (pandoc_available("1.17"))
-            "markdown_strict"
-          else
-            "markdown"
+  from <- "markdown_strict"
 
   # do the conversion
   pandoc_convert(
@@ -564,7 +557,7 @@ pandoc_html_highlight_args <- function(template,
   # downlit engine
   if (highlight_downlit) {
     check_highlightjs(highlight, "downlit")
-    default <- if (pandoc2.0()) resolve_highlight("arrow") else "pygments"
+    default <- resolve_highlight("arrow")
     args <- c(
       pandoc_highlight_args(highlight, default = default),
       # variable used to insert some css in a Pandoc template
@@ -595,10 +588,6 @@ resolve_highlight <- function(highlight, supported = highlighters()) {
   if (i > 0L) return(supported[i])
 
   # Otherwise it could be a custom (built-in) .theme file
-  if (!pandoc2.0()) {
-    stop("Using a custom highlighting style requires Pandoc 2.0 and above",
-         call. = FALSE)
-  }
   custom <- list(
     # from distill
     # https://raw.githubusercontent.com/apreshill/distill/arrow/inst/rmarkdown/templates/distill_article/resources/arrow.theme
@@ -797,8 +786,7 @@ pandoc_citeproc <- function() {
 #'   will be transformed by \code{\link{pandoc_path_arg}}.
 #' @export
 pandoc_lua_filter_args <- function(lua_files) {
-  # Lua filters was introduced in pandoc 2.0
-  if (pandoc2.0()) c(rbind("--lua-filter", pandoc_path_arg(lua_files)))
+  c(rbind("--lua-filter", pandoc_path_arg(lua_files)))
 }
 
 # quote args if they need it
@@ -831,10 +819,6 @@ find_pandoc_theme_variable <- function(args) {
 .pandoc <- new.env()
 .pandoc$dir <- NULL
 .pandoc$version <- NULL
-
-pandoc2.0 <- function() {
-  pandoc_available("2.0")
-}
 
 # Pandoc 2.19 deprecated --self-contained
 self_contained_args <- function() {

--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -172,10 +172,6 @@ pdf_document <- function(toc = FALSE,
       # set the margin to 1 inch if no geometry options or document class specified
       if (default_geometry(names(metadata), pandoc_args))
         args <- c(args, "--variable", "geometry:margin=1in")
-      # support subtitle for Pandoc < 2.6
-      if (("subtitle" %in% names(metadata)) && !pandoc_available("2.6")) args <- c(
-        args, append_in_header(file = pkg_file("rmd/latex/subtitle.tex"))
-      )
     }
 
     if (length(extra_dependencies) || has_latex_dependencies(knit_meta)) {
@@ -269,16 +265,6 @@ patch_tex_output <- function(file) {
   write_utf8(x, file)
 }
 
-# patch output from Pandoc < 2.8: https://github.com/jgm/pandoc/issues/5801
-fix_horiz_rule <- function(file) {
-  if (pandoc_available('2.8')) return()
-  x <- read_utf8(file)
-  i <- x == '\\begin{center}\\rule{0.5\\linewidth}{\\linethickness}\\end{center}'
-  if (any(i)) {
-    x[i] <- '\\begin{center}\\rule{0.5\\linewidth}{0.5pt}\\end{center}'
-    write_utf8(x, file)
-  }
-}
 
 citation_package_arg <- function(value) {
   value <- value[1]

--- a/R/powerpoint_presentation.R
+++ b/R/powerpoint_presentation.R
@@ -23,9 +23,6 @@ powerpoint_presentation <- function(toc = FALSE,
                                     reference_doc = "default",
                                     pandoc_args = NULL) {
 
-  # PowerPoint has been supported since Pandoc 2.0.5
-  pandoc_available('2.0.5', error = TRUE)
-
   # knitr options and hooks
   knitr <- knitr_options(opts_chunk = list(
     dev = 'png', dpi = 96, fig.width = fig_width, fig.height = fig_height

--- a/R/render.R
+++ b/R/render.R
@@ -316,7 +316,7 @@ render <- function(input,
 
   # check for required version of pandoc if we are running pandoc
   if (run_pandoc) {
-    required_pandoc <- "1.12.3"
+    required_pandoc <- "2.8"
     pandoc_available(required_pandoc, error = TRUE)
   }
 
@@ -603,9 +603,8 @@ render <- function(input,
     on.exit(knitr::opts_template$restore(templates), add = TRUE)
 
     # specify that htmltools::htmlPreserve() should use the Pandoc raw attribute
-    # by default (e.g. ```{=html}) rather than preservation tokens when pandoc
-    # >= v2.0.
-    if (pandoc2.0() && is.null(prev <- getOption("htmltools.preserve.raw"))) {
+    # by default (e.g. ```{=html}) rather than preservation tokens
+    if (is.null(prev <- getOption("htmltools.preserve.raw"))) {
       options(htmltools.preserve.raw = TRUE)
       on.exit(options(htmltools.preserve.raw = prev), add = TRUE)
     }
@@ -1004,7 +1003,6 @@ render <- function(input,
       convert(texfile, run_citeproc && !need_bibtex)
       # patch the .tex output generated from the default Pandoc LaTeX template
       if (!("--template" %in% output_format$pandoc$args)) patch_tex_output(texfile)
-      fix_horiz_rule(texfile)
       # unless the output file has the extension .tex, we assume it is PDF
       if (!grepl('[.]tex$', output_file)) {
         latexmk(texfile, output_format$pandoc$latex_engine, '--biblatex' %in% output_format$pandoc$args)

--- a/R/word_document.R
+++ b/R/word_document.R
@@ -106,8 +106,6 @@ word_document <- function(toc = FALSE,
 
 reference_doc_args <- function(type, doc) {
   if (is.null(doc) || identical(doc, "default")) return()
-  c(paste0("--reference-", if (pandoc2.0()) "doc" else {
-    match.arg(type, c("docx", "odt", "doc"))
-  }), pandoc_path_arg(doc))
+  c("--reference-doc", pandoc_path_arg(doc))
 }
 

--- a/inst/rmarkdown/lua/latex-div.lua
+++ b/inst/rmarkdown/lua/latex-div.lua
@@ -7,15 +7,6 @@
 -- REQUIREMENTS: Load shared lua filter - see `shared.lua` for more details.
 dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
 
---[[
-  About the requirement:
-  * PANDOC_VERSION -> 2.1
-]]
-if (not pandocAvailable {2,1}) then
-    io.stderr:write("[WARNING] (latex-div.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
-    return {}
-end
-
 -- START OF THE FILTER'S FUNCTIONS --
 
 text = require 'text'

--- a/inst/rmarkdown/lua/number-sections.lua
+++ b/inst/rmarkdown/lua/number-sections.lua
@@ -21,15 +21,6 @@ https://github.com/atusy/lua-filters/blob/master/lua/number-sections.lua
 -- REQUIREMENTS: Load shared lua filter - see `shared.lua` for more details.
 dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
 
---[[
-  About the requirement:
-  * PANDOC_VERSION -> 2.1
-]]
-if (not pandocAvailable {2,1}) then
-  io.stderr:write("[WARNING] (number-sections.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
-  return {}
-end
-
 -- START OF THE FILTER'S FUNCTIONS --
 
 local section_number_table = {0, 0, 0, 0, 0, 0, 0, 0, 0}

--- a/inst/rmarkdown/lua/pagebreak.lua
+++ b/inst/rmarkdown/lua/pagebreak.lua
@@ -20,16 +20,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 -- REQUIREMENTS: Load shared lua filter - see `shared.lua` for more details.
 dofile(os.getenv 'RMARKDOWN_LUA_SHARED')
 
---[[
-  About the requirement:
-  * PANDOC_VERSION -> 2.1
-  * pandoc.utils -> 2.1
-]]
-if (not pandocAvailable {2,1}) then
-  io.stderr:write("[WARNING] (pagebreak.lua) requires at least Pandoc 2.1. Lua Filter skipped.\n")
-  return {}
-end
-
 -- START OF THE FILTER'S FUNCTIONS --
 
 local stringify_orig = (require 'pandoc.utils').stringify

--- a/inst/rmd/latex/subtitle.tex
+++ b/inst/rmd/latex/subtitle.tex
@@ -1,6 +1,0 @@
-\usepackage{etoolbox}
-\makeatletter
-\providecommand{\subtitle}[1]{% add subtitle to \maketitle
-  \apptocmd{\@title}{\par {\large #1 \par}}{}{}
-}
-\makeatother

--- a/man/pandoc_available.Rd
+++ b/man/pandoc_available.Rd
@@ -40,7 +40,7 @@ library(rmarkdown)
 if (pandoc_available())
   cat("pandoc", as.character(pandoc_version()), "is available!\n")
 
-if (pandoc_available("1.12.3"))
+if (pandoc_available("2.8"))
   cat("required version of pandoc is available!\n")
 }
 }

--- a/tests/testthat/test-lua-filters.R
+++ b/tests/testthat/test-lua-filters.R
@@ -47,7 +47,8 @@ test_that("number_sections Lua filter works", {
   expect_snapshot_output(result, variant = pandoc_versions)
 
   # +gfm_auto_identifiers
-  skip_if_not_pandoc("2.5") # gfm_auto_identifiers is not working the same before
+  # the markdown reader rejects gfm_auto_identifiers before Pandoc 2.11 (#6604)
+  skip_if_not_pandoc("2.11")
   result <- .generate_md_and_convert(
     rmd,
     md_document(number_sections = TRUE, md_extensions = "+gfm_auto_identifiers")

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -13,13 +13,9 @@ test_that("Detect if a theme file is providing in highlight", {
   expect_equal(
     resolve_highlight("textmate", html_highlighters()), "textmate"
   )
-  if (pandoc_available("2.0")) {
-    expect_equal(resolve_highlight("arrow"), pkg_file_highlight("arrow.theme"))
-    expect_equal(resolve_highlight("custom.theme"), "custom.theme")
-    expect_error(resolve_highlight("custom.json"), "a file with extension")
-  } else {
-    expect_error(resolve_highlight("arrow"), "requires Pandoc 2.0")
-  }
+  expect_equal(resolve_highlight("arrow"), pkg_file_highlight("arrow.theme"))
+  expect_equal(resolve_highlight("custom.theme"), "custom.theme")
+  expect_error(resolve_highlight("custom.json"), "a file with extension")
 })
 
 test_that("Correct HTML highlighting argument as requested", {
@@ -51,7 +47,6 @@ test_that("Correct HTML highlighting argument as requested", {
   expect_error(hl_args("textmate", "dummy.html", TRUE), "downlit engine")
   expect_error(hl_args("textmate", "default", TRUE), "downlit engine")
   # custom theme
-  skip_if_not(pandoc2.0())
   expect_equal(hl_args("default", "default", TRUE), c(arrow_theme, downlit))
   expect_equal(hl_args("default", "dummy.html", TRUE), c(arrow_theme, downlit))
   expect_equal(hl_args("arrow", "default", FALSE), c(arrow_theme))


### PR DESCRIPTION
## Motivation

Follow-up to #2622. In that PR, the new `extract-data-uri.lua` filter (which replaced `--extract-media`) was noted by @bastistician to be [more complex than necessary](https://github.com/rstudio/rmarkdown/pull/2622#issuecomment-4767802091) because it had to cope with old-Pandoc quirks.

@cderv [pointed out](https://github.com/rstudio/rmarkdown/pull/2623#issuecomment-4924717587) that jumping straight to Pandoc 3.0 is a big move for organizations that upgrade slowly, and suggested splitting the change: first drop only Pandoc 1.x and bump to the latest Pandoc 2.x minor that our version guards actually need, and require Pandoc 3.0 separately later.

This PR does the first half. It raises the minimum required Pandoc version from **1.14 to 2.8** and removes the version guards and dead code paths that only existed for Pandoc 1.x and early 2.x (`< 2.8`). A follow-up PR (#2628) requires Pandoc 3.0 on top of this.

## Changes

**R**
- Dropped `pandoc2.0()` and the `pandoc_available("1.x"/"2.0"/"2.0.4")` branches: `--latex-engine` (now always `--pdf-engine`), the `markdown_github` variant, the `markdown` fallback in `pandoc_self_contained_html()`, the "requires Pandoc 2.0" guards for custom highlight themes / `anchor_sections` / non-mathjax math, the conditional `--lua-filter` args, and the ioslides Windows codepage workaround.
- Removed the `subtitle.tex` patch (Pandoc < 2.6), `fix_horiz_rule()` (< 2.8), and the beamer template patches (< 1.17.3).
- `render()` now requires Pandoc 2.8.

**Lua filters**
- Dropped the Pandoc 2.1 version guards from `number-sections`, `latex-div`, and `pagebreak`.

**Kept** (guards for features added after 2.8, so Pandoc 2.8–2.18 keep working): `--citeproc`/csljson (2.11), `--embed-resources` (2.19), native gfm math (2.10.1), docx `--number-sections` (2.10.1), pptx `--incremental` (2.15), `yaml_metadata_block` for gfm/commonmark (2.13), `--atx-headers` deprecation (2.11.2), the `accessible-code-block` (2.7.3–2.9.2.1) and `header-attrs` (2.9) HTML dependencies, and `pandoc.system.make_directory` / `pandoc.utils.type` fallbacks in the shared Lua filter.

## Testing

Affected test files pass locally against Pandoc 3.6.3 (old-Pandoc branches are skipped on modern Pandoc as expected). The CI matrix now tests Pandoc 2.8 through the nightly build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
