### PR TITLE
Use literal YAML for vignette metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rmarkdown 2.32
 
 - Fixed the bug that the `intermediates_dir` argument may delete external input files during `rmarkdown::render()` (thanks, @BerndGit, #2619).
 
+- The `html_vignette` template now uses a literal YAML block for vignette metadata, preserving the required line breaks between directives (thanks, @t-kalinowski, #2624).
+
 
 rmarkdown 2.31
 ================================================================================

--- a/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/html_vignette/skeleton/skeleton.Rmd
@@ -3,7 +3,7 @@ title: "Vignette Title"
 author: "Vignette Author"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
-vignette: >
+vignette: |
   %\VignetteIndexEntry{Vignette Title}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}

--- a/tests/testthat/test-draft.R
+++ b/tests/testthat/test-draft.R
@@ -16,6 +16,20 @@ test_that("draft() correctly creates template from a package", {
   expect_match(xfun::read_utf8(rmd), "github_document", all = FALSE)
 })
 
+test_that("html vignette template preserves directive line breaks", {
+  rmd <- withr::local_tempfile(fileext = ".Rmd")
+  draft(rmd, "html_vignette", "rmarkdown", edit = FALSE)
+
+  expect_identical(
+    strsplit(yaml_front_matter(rmd)$vignette, "\n", fixed = TRUE)[[1]],
+    c(
+      "%\\VignetteIndexEntry{Vignette Title}",
+      "%\\VignetteEngine{knitr::rmarkdown}",
+      "%\\VignetteEncoding{UTF-8}"
+    )
+  )
+})
+
 test_that("draft() correctly creates template from a path", {
   # No template
   template_dir <- withr::local_tempdir("template")


### PR DESCRIPTION
## Summary

Preserve the three R vignette directives as separate lines in newly drafted `html_vignette` files.

## Thanks to maintainers

Thanks to @t-kalinowski for the precise report, and to the rmarkdown maintainers for reviewing the change.

## Issue or motivation

Closes #2624. R scans vignette directives as physical source lines, so their line boundaries need to survive YAML parsing and formatting.

## Root cause

The template used the YAML folded block scalar (`>`). A YAML formatter may therefore combine adjacent directive lines without changing the parsed scalar, leaving R to misread the vignette encoding during package checks.

## Change

Use a literal block scalar (`|`) in the `html_vignette` skeleton. A regression test drafts the real template and verifies that the parsed metadata contains three distinct directives. The NEWS entry records the fix.

## Tests

- `testthat::test_file("tests/testthat/test-draft.R")`: 17 passed
- `R CMD build`: passed
- `R CMD check --no-manual`: Status: OK (R 4.6.1, macOS)

## Scope

Only the `html_vignette` template, its draft regression test, and NEWS are changed. Other templates, YAML parsing, and rendering behavior are intentionally unchanged.