### PR TITLE
Fix ioslides figures with Pandoc 3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ rmarkdown 2.32
 
 - Bumped the minimum version of **knitr** to 1.50 to avoid an incompatible combination of **knitr** (< 1.50) and **xfun** (>= 0.56), which fails to load because `xfun::attr()` was removed in xfun 0.56 (thanks, @jsinnett, #2627).
 
+- Fixed captioned figures disappearing from `ioslides_presentation()` output with Pandoc 3, which represents standalone captioned images as `Figure` elements not handled by the custom writer (thanks, @LeonidasZhak, #2607).
+
 
 rmarkdown 2.31
 ================================================================================

--- a/inst/rmd/ioslides/ioslides_presentation.lua
+++ b/inst/rmd/ioslides/ioslides_presentation.lua
@@ -236,6 +236,14 @@ function Plain(s)
   return s
 end
 
+function Figure(s, content, attr)
+  if fig_caption and string.len(s) > 0 then
+    return content .. "<p class='caption'>" .. s .. "</p>"
+  else
+    return content
+  end
+end
+
 function Para(s)
   return "<p>" .. s .. "</p>"
 end

--- a/tests/testthat/test-ioslides-figures.R
+++ b/tests/testthat/test-ioslides-figures.R
@@ -28,5 +28,5 @@ test_that("ioslides renders figures with Pandoc 3", {
   expect_false(any(grepl("Undefined function 'Figure'", messages, fixed = TRUE)))
   rendered <- paste(readLines(output), collapse = "\n")
   expect_match(rendered, "image.jpg", fixed = TRUE)
-  expect_match(rendered, "caption", fixed = TRUE)
+  expect_match(rendered, "<p class='caption'>caption</p>", fixed = TRUE)
 })

--- a/tests/testthat/test-ioslides-figures.R
+++ b/tests/testthat/test-ioslides-figures.R
@@ -1,0 +1,32 @@
+test_that("ioslides renders figures with Pandoc 3", {
+  skip_if_not(rmarkdown::pandoc_available("3.0"))
+
+  input <- tempfile(fileext = ".md")
+  output <- tempfile(fileext = ".html")
+  source_writer <- system.file(
+    "rmd/ioslides/ioslides_presentation.lua",
+    package = "rmarkdown"
+  )
+  writer <- tempfile(fileext = ".lua")
+  writeLines(c(
+    "local fig_caption = true",
+    "local incremental = false",
+    "local smaller = false",
+    "local smart = true",
+    "local slide_level = 2",
+    readLines(source_writer)
+  ), writer)
+  writeLines(c("# Slide", "", "![caption](image.jpg)"), input)
+
+  messages <- system2(
+    rmarkdown::pandoc_exec(),
+    c("--from=markdown", "--to", writer, "--output", output, input),
+    stdout = TRUE,
+    stderr = TRUE
+  )
+
+  expect_false(any(grepl("Undefined function 'Figure'", messages, fixed = TRUE)))
+  rendered <- paste(readLines(output), collapse = "\n")
+  expect_match(rendered, "image.jpg", fixed = TRUE)
+  expect_match(rendered, "caption", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

Pandoc 3 represents standalone images with captions as `Figure` elements. The ioslides custom writer did not define that writer function, so the figure content was dropped.

## Thanks to maintainers

Thanks for maintaining rmarkdown and its Pandoc compatibility layer.

## Issue or motivation

Fixes #2607. With Pandoc 3, captioned images in ioslides produced `WARNING: Undefined function 'Figure'` and disappeared from the rendered slide.

## Root cause

The classic writer handled `Image` and `CaptionedImage`, but not the `Figure` element introduced in the Pandoc 3 AST.

## Change

Add a `Figure` handler that preserves the existing ioslides caption markup while returning the rendered figure content. Add a regression test for the Pandoc 3 custom writer.

## Tests

- Focused ioslides figure test: 3/3 expectations passed.
- `R CMD build --no-manual`: passed.
- `R CMD check --as-cran --no-manual`: `Status: OK` on the patched rmarkdown 2.31 source tree, with the remote CRAN incoming lookup disabled because it hung locally.

## Scope

This only changes the ioslides custom writer and adds a regression test. It does not change other output formats, figure sizing, or caption text handling.
