### PR TITLE
Skip Netlify deploy for fork PRs in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,6 +11,11 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
@@ -19,6 +24,9 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # Deploy previews and commit statuses need repo secrets and a
+      # writable token, neither of which is available to PRs from forks.
+      CAN_DEPLOY: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v6
 
@@ -38,6 +46,7 @@ jobs:
 
       - name: Deploy to Netlify
         id: netlify-deploy
+        if: env.CAN_DEPLOY == 'true'
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             DEPLOY_OUTPUT=$(npx --yes netlify-cli deploy \
@@ -58,7 +67,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Set commit status
-        if: always()
+        if: always() && env.CAN_DEPLOY == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -75,7 +84,7 @@ jobs:
             });
 
       - name: Comment deploy URL on PR
-        if: github.event_name == 'pull_request' && steps.netlify-deploy.outcome == 'success'
+        if: github.event_name == 'pull_request' && env.CAN_DEPLOY == 'true' && steps.netlify-deploy.outcome == 'success'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Summary

Fork PRs (e.g. #2629 from `LeonidasZhak/rmarkdown`) failed the `pkgdown` check. Same-repo branch PRs (e.g. #2622) were unaffected and keep deploying previews as before.

## Root cause

GitHub does not expose repo secrets to `pull_request` runs from forks, and the `GITHUB_TOKEN` is read-only. So for fork PRs:

1. `netlify-cli deploy` had no `NETLIFY_AUTH_TOKEN` → deploy failed.
2. The follow-up `createCommitStatus` call hit `403 Resource not accessible by integration`, failing the whole job.

The pkgdown site itself built fine — only deployment was impossible. This never worked for fork PRs; it only ever worked for same-repo PRs.

## Change

- Add a `CAN_DEPLOY` env flag: `true` for pushes, same-repo PRs, releases, and manual dispatch; `false` only for fork PRs.
- Gate the Deploy / Set commit status / Comment steps on `CAN_DEPLOY`.
- Declare explicit least-privilege `permissions`.

Fork PRs now build the site as a check without attempting to deploy. Same-repo PRs (like #2622) are unchanged — deploy preview + PR comment still work.

## Follow-up (not in this PR)

Deploy previews for *fork* PRs would need the two-workflow `workflow_run` pattern (build on `pull_request` without secrets → deploy in trusted context). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)