### PR TITLE
Fix parallel render() temp file deletion (#1632)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.32
 
 - Relicensed this package to MIT (thanks, @karangattu, #2615).
 
+- Fixed a `pandoc: ... openBinaryFile: does not exist` error when calling `render()` in parallel via a fork cluster. Temp files created by `render()` are now tracked per process and cleaned up individually, instead of deleting all files matching the `rmarkdown-str*.html` pattern in the shared `tempdir()`, which could remove sibling renders' files while Pandoc still needed them (#1632).
+
 - Replaced the Pandoc argument `--extract-media` with a Lua filter to fix the `*_files/` cleanup regression (thanks, @bastistician, #2620).
 
 - Fixed the bug that the `intermediates_dir` argument may delete external input files during `rmarkdown::render()` (thanks, @BerndGit, #2619).

--- a/R/render.R
+++ b/R/render.R
@@ -1216,6 +1216,7 @@ resolve_df_print <- function(df_print) {
 .globals <- new.env(parent = emptyenv())
 .globals$evaluated_global_chunks <- character()
 .globals$level <- 0L
+.globals$tmpfiles <- NULL
 
 
 #' The output metadata object

--- a/R/util.R
+++ b/R/util.R
@@ -156,16 +156,20 @@ as_tmpfile <- function(str) {
   if (length(str) == 0) return()
   f <- tempfile(tmpfile_pattern, fileext = ".html")
   write_utf8(str, f)
+  # register this file so clean_tmpfiles() can remove exactly the files created
+  # by this process, instead of globbing the whole tempdir() (#1632): parallel
+  # renders (e.g. via a fork cluster) share tempdir(), so globbing would delete
+  # sibling renders' files while pandoc still needs them
+  .globals$tmpfiles <- c(.globals$tmpfiles, f)
   f
 }
 
 # temp files created by as_tmpfile() cannot be immediately removed because they
 # are needed later by the pandoc conversion; we have to clean up the temp files
-# that have the pattern specified in `tmpfile_pattern` when render() exits
+# registered in `.globals$tmpfiles` when render() exits
 clean_tmpfiles <- function() {
-  unlink(list.files(
-    tempdir(), sprintf("^%s[0-9a-f]+[.]html$", tmpfile_pattern), full.names = TRUE
-  ))
+  unlink(.globals$tmpfiles)
+  .globals$tmpfiles <- NULL
 }
 
 # test if all paths in x are directories

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,3 +11,21 @@ test_that('default_geometry() decides whether to pass a default geometry variabl
   expect_false(default_geometry('fontsize', c('--variable', 'documentclass:book')))
   expect_true(default_geometry('fontsize', c('--variable', 'graphics:true')))
 })
+
+test_that('clean_tmpfiles() only removes files created by as_tmpfile() in this process (#1632)', {
+  # a stray file matching the old glob pattern, e.g. left by a parallel render
+  # sharing the same tempdir(); it must survive clean_tmpfiles()
+  stray <- file.path(tempdir(), paste0(tmpfile_pattern, "deadbeef.html"))
+  file.create(stray)
+  on.exit(unlink(stray), add = TRUE)
+
+  .globals$tmpfiles <- NULL
+  f <- as_tmpfile("<div></div>")
+  expect_true(file.exists(f))
+  expect_true(f %in% .globals$tmpfiles)
+
+  clean_tmpfiles()
+  expect_false(file.exists(f))       # our own file is cleaned
+  expect_true(file.exists(stray))    # sibling's file is left intact
+  expect_null(.globals$tmpfiles)     # registry reset
+})


### PR DESCRIPTION
## Problem

`render()` in parallel via a **fork cluster** (`makeForkCluster`, `registerDoParallel(cores>1)`, `foreach %dopar%`, `BiocParallel::MulticoreParam`) intermittently fails with:

```
pandoc: /tmp/.../rmarkdown-str<hex>.html: openBinaryFile: does not exist (No such file or directory)
Error: pandoc document conversion failed with error 1
```

`makePSOCKcluster` never hit this — the tell.

## Root cause

`as_tmpfile()` writes `rmarkdown-str*.html` files that Pandoc reads later during conversion (navbar, `in_header`/`before_body`/`after_body` includes). On `render()` exit, `clean_tmpfiles()` deleted **every** file matching that pattern in `tempdir()`:

```r
clean_tmpfiles <- function() {
  unlink(list.files(
    tempdir(), sprintf("^%s[0-9a-f]+[.]html$", tmpfile_pattern), full.names = TRUE
  ))
}
```

Forked workers **share the parent's `tempdir()`**, so one worker's cleanup deleted sibling workers' files while Pandoc was still using them. PSOCK workers get a separate `tempdir()` per process, hence no failure.

Diagnosed by @gorgitko in #1632 back in 2019; the long-standing workaround was stubbing out `clean_tmpfiles` via `assignInNamespace()`.

## Fix

Track files created by `as_tmpfile()` in `.globals$tmpfiles` and unlink only those. Each process cleans up exactly what it created; siblings are untouched. `tempfile()` already generates per-process unique names (verified: 3200 names across 16 forks, 0 collisions), so no cross-process name collision remains.

## Test

Added a regression test in `test-utils.R`: a stray file matching the old glob pattern survives `clean_tmpfiles()`, while the process's own registered file is removed.

## Scope

Fixes the parallel-render cause. The parallel-render reports in #1268 share this root cause; the **network/UNC-drive** cause in #1268 is separate and remains open.