### PR TITLE
Allow lib_dir outside the output directory for HTML output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.31.3
+Version: 2.31.4
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.32
 ================================================================================
 
+- HTML output no longer errors when `lib_dir` points outside the output directory (e.g. `lib_dir = "../lib"`), so documents in sibling subdirectories can share a single library directory. Such dependencies are now referenced with an up-tree relative path instead of failing with "The path <file> does not appear to be a descendant of <dir>" (#146, #1859, #2199).
+
 - The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2623).
 
 - Relicensed this package to MIT (thanks, @karangattu, #2615).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rmarkdown 2.32
 ================================================================================
 
-- HTML output no longer errors when `lib_dir` points outside the output directory (e.g. `lib_dir = "../lib"`), so documents in sibling subdirectories can share a single library directory. Such dependencies are now referenced with an up-tree relative path instead of failing with "The path <file> does not appear to be a descendant of <dir>" (#146, #1859, #2199).
+- HTML output no longer errors when `lib_dir` points outside the output directory (e.g. `lib_dir = "../lib"`), so documents in sibling subdirectories can share a single library directory. Such dependencies are now referenced with an up-tree relative path instead of failing with "The path <file> does not appear to be a descendant of <dir>" (thanks, @gaborcsardi #146, @jonathan-g #1859 #2199).
 
 - The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2623).
 

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -306,15 +306,17 @@ html_dependency_resolver <- function(all_dependencies) {
 html_reference_path <- function(path, lib_dir, output_dir) {
   # write the full OS-specific path if no library
   if (is.null(lib_dir))
-    pandoc_path_arg(path)
-  else if (xfun::is_abs_path(path))
-    # An absolute path reaches here only when makeDependencyRelative() could not
-    # relativize the dependency, i.e. lib_dir is not under output_dir (e.g.
-    # lib_dir = "../lib"). Unlike relative_to(), xfun::relative_path() can emit
-    # paths that step up the tree, so the reference still resolves.
-    xfun::relative_path(path, output_dir)
-  else
+    return(pandoc_path_arg(path))
+  # `path` may be a vector (a dependency with several files), so decide
+  # per-element. An absolute path reaches here only when makeDependencyRelative()
+  # could not relativize the dependency, i.e. lib_dir is not under output_dir
+  # (e.g. lib_dir = "../lib"). Unlike relative_to(), xfun::relative_path() can
+  # emit paths that step up the tree, so such references still resolve.
+  ifelse(
+    xfun::is_abs_path(path),
+    xfun::relative_path(path, output_dir),
     relative_to(output_dir, path)
+  )
 }
 
 # return the html dependencies as an HTML string suitable for inclusion

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -307,6 +307,12 @@ html_reference_path <- function(path, lib_dir, output_dir) {
   # write the full OS-specific path if no library
   if (is.null(lib_dir))
     pandoc_path_arg(path)
+  else if (xfun::is_abs_path(path))
+    # An absolute path reaches here only when makeDependencyRelative() could not
+    # relativize the dependency, i.e. lib_dir is not under output_dir (e.g.
+    # lib_dir = "../lib"). Unlike relative_to(), xfun::relative_path() can emit
+    # paths that step up the tree, so the reference still resolves.
+    xfun::relative_path(path, output_dir)
   else
     relative_to(output_dir, path)
 }
@@ -319,8 +325,14 @@ html_dependencies_as_string <- function(dependencies, lib_dir, output_dir) {
     # return untouched, keeping the order of all deps.
     dependencies <- lapply(dependencies, copyDependencyToDir,
                            outputDir = lib_dir, mustWork = FALSE)
-    dependencies <- lapply(dependencies, makeDependencyRelative,
-                           basepath = output_dir, mustWork = FALSE)
+    # Relativize only when lib_dir sits under output_dir. Otherwise
+    # makeDependencyRelative() would error ("does not appear to be a descendant
+    # of"), so we leave the dependencies' absolute src paths in place and turn
+    # them into up-tree references later, in html_reference_path().
+    if (!xfun::is_abs_path(normalized_relative_to(output_dir, lib_dir))) {
+      dependencies <- lapply(dependencies, makeDependencyRelative,
+                             basepath = output_dir, mustWork = FALSE)
+    }
   }
 
   # Dependencies are iterated on as file based dependencies needs to be

--- a/tests/testthat/test-html_dependencies.R
+++ b/tests/testthat/test-html_dependencies.R
@@ -229,17 +229,23 @@ test_that("a lib_dir outside the output dir yields an up-tree reference", {
   dir.create(src_dir, recursive = TRUE)
   dir.create(output_dir, recursive = TRUE)
   writeLines("p { color: red; }", file.path(src_dir, "styles.css"))
+  # a dependency with more than one file, so the path vector passed to
+  # html_reference_path() has length > 1
+  writeLines("var x = 1;", file.path(src_dir, "script.js"))
 
   dep <- htmltools::htmlDependency(
-    "uptree", "1.0", src = src_dir, stylesheet = "styles.css"
+    "uptree", "1.0", src = src_dir,
+    stylesheet = "styles.css", script = "script.js"
   )
 
   html <- html_dependencies_as_string(list(dep), lib_dir, output_dir)
 
-  # The stylesheet was copied into lib_dir...
+  # The files were copied into lib_dir...
   expect_true(file.exists(file.path(lib_dir, "uptree-1.0", "styles.css")))
-  # ...and the emitted href steps up out of output_dir into the shared lib.
+  expect_true(file.exists(file.path(lib_dir, "uptree-1.0", "script.js")))
+  # ...and each emitted reference steps up out of output_dir into the shared lib.
   expect_match(as.character(html), "\\.\\./lib/uptree-1\\.0/styles\\.css")
+  expect_match(as.character(html), "\\.\\./lib/uptree-1\\.0/script\\.js")
 })
 
 test_that("a lib_dir under the output dir still yields a plain relative ref", {

--- a/tests/testthat/test-html_dependencies.R
+++ b/tests/testthat/test-html_dependencies.R
@@ -217,3 +217,44 @@ test_that('needs_saas', {
     c(TRUE, TRUE, FALSE)
   )
 })
+
+test_that("a lib_dir outside the output dir yields an up-tree reference", {
+  # Fake site: out/lib is a sibling of the output dir out/node, so the copied
+  # dependency lives up-tree relative to the document being rendered. This used
+  # to abort with "does not appear to be a descendant of".
+  root <- withr::local_tempdir()
+  src_dir <- file.path(root, "src")
+  lib_dir <- file.path(root, "out", "lib")
+  output_dir <- file.path(root, "out", "node")
+  dir.create(src_dir, recursive = TRUE)
+  dir.create(output_dir, recursive = TRUE)
+  writeLines("p { color: red; }", file.path(src_dir, "styles.css"))
+
+  dep <- htmltools::htmlDependency(
+    "uptree", "1.0", src = src_dir, stylesheet = "styles.css"
+  )
+
+  html <- html_dependencies_as_string(list(dep), lib_dir, output_dir)
+
+  # The stylesheet was copied into lib_dir...
+  expect_true(file.exists(file.path(lib_dir, "uptree-1.0", "styles.css")))
+  # ...and the emitted href steps up out of output_dir into the shared lib.
+  expect_match(as.character(html), "\\.\\./lib/uptree-1\\.0/styles\\.css")
+})
+
+test_that("a lib_dir under the output dir still yields a plain relative ref", {
+  root <- withr::local_tempdir()
+  src_dir <- file.path(root, "src")
+  output_dir <- file.path(root, "out")
+  lib_dir <- file.path(output_dir, "lib")
+  dir.create(src_dir, recursive = TRUE)
+  dir.create(output_dir, recursive = TRUE)
+  writeLines("p { color: red; }", file.path(src_dir, "styles.css"))
+
+  dep <- htmltools::htmlDependency(
+    "descend", "1.0", src = src_dir, stylesheet = "styles.css"
+  )
+
+  html <- html_dependencies_as_string(list(dep), lib_dir, output_dir)
+  expect_match(as.character(html), "\"lib/descend-1\\.0/styles\\.css\"")
+})


### PR DESCRIPTION
## Summary

Lets `lib_dir` point outside the output directory (e.g. `lib_dir: "../lib"`) so that documents in sibling subdirectories can share a single HTML dependency library at a common root. Previously this aborted `render()` with:

> The path &lt;file&gt; does not appear to be a descendant of &lt;dir&gt;

This is a minimal, flagless alternative to #2199, addressing the same requests (#146, #1859).

## How it works

When `lib_dir` is **not** under `output_dir`, `makeDependencyRelative()` — the call that raised the error — is skipped. The dependency's absolute `src` path is instead turned into an up-tree relative reference (`../lib/...`) in `html_reference_path()` via `xfun::relative_path()`, which (unlike the internal `relative_to()`) can emit paths that step up the tree.

The check reuses existing helpers (`normalized_relative_to()` + `xfun::is_abs_path()`); no new function, no coupling to htmltools' error message.

## Why no new argument

The uptree `lib_dir` case only ever **errored**, so no currently-successful render can regress. The descendant case is left byte-for-byte unchanged (the pre-check is false, deps are relativized exactly as before, references stay plainly relative). Auto-detecting is therefore strictly a superset of today's successful behavior, and users get the intuitive result from just `lib_dir: "../lib"` without opting in.

Works for any format built on `html_document_base()` (`html_document`, `ioslides_presentation`, `slidy_presentation`), since they all flow through the same code path.

## Comparison to #2199

#2199 (435 lines) gates the behavior behind a new `allow_uptree_lib_dir` argument threaded through 5 functions, forks `htmltools::copyDependencyToDir` (~100 lines), and bundles two unrelated changes (dependency-override-by-name, copy-if-changed). This PR is 16 lines of core logic, no new API, no forked code.

## Tests

Added unit tests in `test-html_dependencies.R` covering both the uptree case (dependency copied into the shared lib; emitted href steps up out of the output dir) and the descendant case (reference stays plainly relative). Existing `test-html_document`, `test-html_document_base`, and `test-site` suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)