### PR TITLE
Write LaTeX aux files to the output dir, not the input dir (#1975, #1615)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.31.4
+Version: 2.31.5
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 rmarkdown 2.32
 ================================================================================
 
+- LaTeX auxiliary files (`.aux`, `.log`, etc.) generated while producing PDF output are now written to the output directory instead of the input directory. Previously `latexmk()` ran in the input file's directory, so PDF rendering failed when the input directory was read-only (e.g. in production or Shiny deployments) even when `output_dir` pointed to a writable location (thanks, @cderv #1975, @siddharthab #1615).
+
 - HTML output no longer errors when `lib_dir` points outside the output directory (e.g. `lib_dir = "../lib"`), so documents in sibling subdirectories can share a single library directory. Such dependencies are now referenced with an up-tree relative path instead of failing with "The path <file> does not appear to be a descendant of <dir>" (thanks, @gaborcsardi #146, @jonathan-g #1859 #2199).
 
 - The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2623).

--- a/R/render.R
+++ b/R/render.R
@@ -1010,7 +1010,17 @@ render <- function(input,
       if (!("--template" %in% output_format$pandoc$args)) patch_tex_output(texfile)
       # unless the output file has the extension .tex, we assume it is PDF
       if (!grepl('[.]tex$', output_file)) {
-        latexmk(texfile, output_format$pandoc$latex_engine, '--biblatex' %in% output_format$pandoc$args)
+        # run latexmk in the directory of the .tex file (i.e. the output
+        # directory) so that LaTeX aux files (.aux, .log, ...) are written there
+        # instead of the working directory (the input directory), which may be
+        # read-only, e.g. in production/Shiny settings (#1975, #1615)
+        xfun::in_dir(
+          dirname(texfile),
+          latexmk(
+            basename(texfile), output_format$pandoc$latex_engine,
+            '--biblatex' %in% output_format$pandoc$args
+          )
+        )
         file.rename(file_with_ext(texfile, "pdf"), output_file)
         # clean up the tex file if necessary
         if (!output_format$pandoc$keep_tex) {

--- a/R/render.R
+++ b/R/render.R
@@ -1014,13 +1014,10 @@ render <- function(input,
         # directory) so that LaTeX aux files (.aux, .log, ...) are written there
         # instead of the working directory (the input directory), which may be
         # read-only, e.g. in production/Shiny settings (#1975, #1615)
-        xfun::in_dir(
-          dirname(texfile),
-          latexmk(
-            basename(texfile), output_format$pandoc$latex_engine,
-            '--biblatex' %in% output_format$pandoc$args
-          )
-        )
+        xfun::in_dir(dirname(texfile), latexmk(
+          basename(texfile), output_format$pandoc$latex_engine,
+          '--biblatex' %in% output_format$pandoc$args
+        ))
         file.rename(file_with_ext(texfile, "pdf"), output_file)
         # clean up the tex file if necessary
         if (!output_format$pandoc$keep_tex) {

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -34,6 +34,15 @@ skip_if_not_pandoc <- function(ver = NULL) {
   }
 }
 
+# Skip unless a LaTeX toolchain is available to actually compile PDFs
+skip_if_not_latex <- function() {
+  skip_if_not_pandoc()
+  skip_on_cran()
+  if (!nzchar(Sys.which("pdflatex")) && !tinytex::is_tinytex()) {
+    skip("No LaTeX installation available")
+  }
+}
+
 # Use to test version greater than
 skip_if_pandoc <- function(ver = NULL) {
   if (pandoc_available(ver)) {

--- a/tests/testthat/test-pdf_document.R
+++ b/tests/testthat/test-pdf_document.R
@@ -30,3 +30,25 @@ test_that("pdf_document() incorporates latex dependencies", {
   expect_true(file.exists(included))
   expect_identical(readLines(included), expected_dependencies)
 })
+
+test_that("LaTeX aux files are written next to the output, not the input dir (#1975, #1615)", {
+  skip_if_not_latex()
+
+  # separate, writable input and output directories
+  input_dir <- withr::local_tempdir()
+  output_dir <- withr::local_tempdir()
+  input <- file.path(input_dir, "demo.Rmd")
+  xfun::write_utf8(c("---", "output: pdf_document", "---", "", "Hello."), input)
+
+  # keep aux files so we can observe where they land
+  withr::local_options(tinytex.clean = FALSE)
+  out <- render(input, output_dir = output_dir, quiet = TRUE)
+  on.exit(unlink(out), add = TRUE)
+
+  expect_true(file.exists(out))
+  # the aux/log files must be created in the output dir ...
+  expect_true(file.exists(file.path(output_dir, "demo.log")))
+  # ... and NOT in the input dir, which may be read-only in production
+  expect_false(file.exists(file.path(input_dir, "demo.log")))
+  expect_false(file.exists(file.path(input_dir, "demo.aux")))
+})


### PR DESCRIPTION
## Problem

When rendering to PDF, `render()` fails if the **input directory is read-only** — even when `output_dir` points to a writable location. Reported by production/Shiny users (#1975) and with a minimal read-only-dir repro in #1615.

## Root cause

`render()` extracts the `.tex` into the **output** directory (`R/render.R` — `texfile <- file_with_ext(output_file, "tex")`), but `latexmk()` runs in the **working directory**, which is the **input** file's directory (`setwd(dirname(abs_path(input)))`). LaTeX writes its auxiliary files (`.aux`, `.log`, `.out`, ...) to the current working directory, so they land next to the input, not the output.

Demonstrated (with `tinytex.clean = FALSE` to keep aux files): rendering `src/demo.Rmd` with `output_dir = "out/"` leaves `demo.aux` and `demo.log` in `src/`, only `demo.pdf` in `out/`. If `src/` is read-only, the render errors.

## Fix

Run `latexmk()` inside the `.tex` file's directory (the output directory) via `xfun::in_dir()`, so aux files are written there. Figures are already generated into the output directory's `_files/` folder, so relative resource paths in the `.tex` still resolve (verified with an embedded plot).

## Test

Added a regression test in `test-pdf_document.R` (guarded by a new `skip_if_not_latex()` helper): renders with separate input/output dirs and asserts the `.log` lands in the output dir and no `.aux`/`.log` appears in the input dir. Confirmed it **fails without** the fix and **passes with** it.

## Notes

- A fully read-only input dir also needs `intermediates_dir` (the knit step writes `*.knit.md` to the cwd); that path already worked and still does. This PR removes the aux-file obstacle that affected even the writable-input + separate-`output_dir` case.
- Closes #1615 as well (same root cause).