### PR TITLE
Credit @gorgitko in NEWS for the #1632 fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ rmarkdown 2.32
 
 - Relicensed this package to MIT (thanks, @karangattu, #2615).
 
-- Fixed a `pandoc: ... openBinaryFile: does not exist` error when calling `render()` in parallel via a fork cluster. Temp files created by `render()` are now tracked per process and cleaned up individually, instead of deleting all files matching the `rmarkdown-str*.html` pattern in the shared `tempdir()`, which could remove sibling renders' files while Pandoc still needed them (#1632).
+- Fixed a `pandoc: ... openBinaryFile: does not exist` error when calling `render()` in parallel via a fork cluster. Temp files created by `render()` are now tracked per process and cleaned up individually, instead of deleting all files matching the `rmarkdown-str*.html` pattern in the shared `tempdir()`, which could remove sibling renders' files while Pandoc still needed them (thanks, @gorgitko, #1632).
 
 - Replaced the Pandoc argument `--extract-media` with a Lua filter to fix the `*_files/` cleanup regression (thanks, @bastistician, #2620).
 


### PR DESCRIPTION
Follow-up to #2631. The NEWS entry for the parallel-render temp-file fix omitted the reporter credit; @gorgitko diagnosed the root cause in the #1632 thread back in 2019.