### PR TITLE
Fix PDF render() failure when intermediates_dir is set (#2183)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rmarkdown
 Title: Dynamic Documents for R
-Version: 2.31.5
+Version: 2.31.6
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut"),
     person("Yihui", "Xie", , "xie@yihui.name", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rmarkdown 2.32
 
 - LaTeX auxiliary files (`.aux`, `.log`, etc.) generated while producing PDF output are now written to the output directory instead of the input directory. Previously `latexmk()` ran in the input file's directory, so PDF rendering failed when the input directory was read-only (e.g. in production or Shiny deployments) even when `output_dir` pointed to a writable location (thanks, @cderv #1975, @siddharthab #1615).
 
+- Fixed a `cannot open file '<name>.tex'` error when rendering to PDF with the `intermediates_dir` argument set. Pandoc wrote the intermediate `.tex` into `intermediates_dir`, but `rmarkdown` looked for it in the input directory. The `.tex` is now resolved to its actual location, and with `keep_tex: true` the retained `.tex` is moved next to the output instead of being left behind in `intermediates_dir` (thanks, @beerda, #2183).
+
 - HTML output no longer errors when `lib_dir` points outside the output directory (e.g. `lib_dir = "../lib"`), so documents in sibling subdirectories can share a single library directory. Such dependencies are now referenced with an up-tree relative path instead of failing with "The path <file> does not appear to be a descendant of <dir>" (thanks, @gaborcsardi #146, @jonathan-g #1859 #2199).
 
 - The minimum required version of Pandoc is now 2.8 (previously 1.14). Dropping support for Pandoc 1.x and early 2.x allowed a simplification of internal version guards (#2623).

--- a/R/render.R
+++ b/R/render.R
@@ -997,6 +997,12 @@ render <- function(input,
       status
     }
     texfile <- file_with_ext(output_file, "tex")
+    # when pandoc is given a bare output filename, it writes the .tex next to
+    # its input (the knitted .md); if that input lives in an intermediates
+    # directory, resolve texfile to that actual location so that
+    # patch_tex_output() and latexmk() below can find it (#2183)
+    if (basename(texfile) == texfile)
+      texfile <- file.path(dirname(input), texfile)
     # determine whether we need to run citeproc (based on whether we have
     # references in the input)
     run_citeproc <- citeproc_required(front_matter, input_lines)
@@ -1023,6 +1029,14 @@ render <- function(input,
         if (!output_format$pandoc$keep_tex) {
           texfile <- normalize_path(texfile)
           on.exit(unlink(texfile), add = TRUE)
+        } else {
+          # if we kept the .tex but it was written to the intermediates
+          # directory, move it next to the output so it is not left behind in
+          # (or cleaned away with) the intermediates directory (#2183)
+          wanted_tex <- file_with_ext(output_file, "tex")
+          if (!same_path(texfile, wanted_tex, must_work = FALSE) &&
+              file.exists(texfile))
+            file.rename(texfile, wanted_tex)
         }
       }
     } else {

--- a/tests/testthat/test-pdf_document.R
+++ b/tests/testthat/test-pdf_document.R
@@ -52,3 +52,42 @@ test_that("LaTeX aux files are written next to the output, not the input dir (#1
   expect_false(file.exists(file.path(input_dir, "demo.log")))
   expect_false(file.exists(file.path(input_dir, "demo.aux")))
 })
+
+test_that("render() to PDF works with intermediates_dir set (#2183)", {
+  skip_if_not_latex()
+
+  input_dir <- withr::local_tempdir()
+  input <- file.path(input_dir, "demo.Rmd")
+  xfun::write_utf8(c("---", "output: pdf_document", "---", "", "Hello."), input)
+
+  # intermediates_dir made pandoc write the .tex into that directory while
+  # patch_tex_output()/latexmk() looked for it in the working directory,
+  # causing a "cannot open file 'demo.tex'" error (#2183)
+  int_dir <- file.path(input_dir, "tmp")
+  out <- render(input, intermediates_dir = int_dir, quiet = TRUE)
+  on.exit(unlink(out), add = TRUE)
+
+  expect_true(file.exists(out))
+  expect_identical(xfun::file_ext(out), "pdf")
+  # the intermediate .tex should not be left behind next to the output
+  expect_false(file.exists(file.path(input_dir, "demo.tex")))
+})
+
+test_that("keep_tex + intermediates_dir leaves the .tex next to the output (#2183)", {
+  skip_if_not_latex()
+
+  input_dir <- withr::local_tempdir()
+  input <- file.path(input_dir, "demo.Rmd")
+  xfun::write_utf8(c("---", "output:", "  pdf_document:", "    keep_tex: true",
+                     "---", "", "Hello."), input)
+
+  int_dir <- file.path(input_dir, "tmp")
+  out <- render(input, intermediates_dir = int_dir, quiet = TRUE)
+  tex <- file.path(input_dir, "demo.tex")
+  on.exit(unlink(c(out, tex)), add = TRUE)
+
+  expect_true(file.exists(out))
+  # the kept .tex must sit next to the output, not be stranded in int_dir
+  expect_true(file.exists(tex))
+  expect_false(file.exists(file.path(int_dir, "demo.tex")))
+})


### PR DESCRIPTION
## Problem

Rendering to PDF with `intermediates_dir` set fails:

```r
rmarkdown::render("test.Rmd", intermediates_dir = "./tmp")
#> Error in readLines(con, warn = FALSE) : cannot open the connection
#> ... cannot open file 'test.tex': No such file or directory
```

Reproduces on `main`.

## Root cause

When `intermediates_dir` is set, the knitted `.md` lives in that directory. Pandoc is called with a **bare** output filename, so it writes the `.tex` next to its input — i.e. into `intermediates_dir`. But `texfile` was `file_with_ext(output_file, "tex")`, a bare name resolved against the working directory (the input directory). `patch_tex_output(texfile)` and `latexmk()` therefore looked in the wrong place and the file was not found.

This matches the diagnosis @cderv posted in #2183. The `output_dir` case worked only incidentally, because `output_file` is absolute there.

## Fix

- Resolve `texfile` to `dirname(input)` when it is a bare filename, so it points at where pandoc actually wrote it.
- With `keep_tex: true`, move the retained `.tex` next to the output instead of leaving it stranded in (or cleaned away with) `intermediates_dir` — matching behavior without `intermediates_dir`.

## Tests

Added two regression tests (`test-pdf_document.R`):
- PDF render with `intermediates_dir` set succeeds and leaves no stray `.tex` in the input dir.
- `keep_tex` + `intermediates_dir` leaves the `.tex` next to the output, not in the intermediate dir.

Both fail on `main` (`FAIL 2`) and pass with the fix (`PASS 13`). Verified across combinations: plain, `intermediates_dir`, `output_dir` + `intermediates_dir`, and `keep_tex` variants.

Fixes #2183

🤖 Generated with [Claude Code](https://claude.com/claude-code)